### PR TITLE
[cap003] fix: remove non-existent [podman] extra from CI install steps

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,10 +63,10 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install cutip with Podman extra
+      - name: Install cutip
         run: |
           uv venv .venv
-          uv pip install -e ".[podman]"
+          uv pip install -e .
 
       - name: Install & start Podman (Ubuntu)
         run: |
@@ -99,10 +99,10 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install cutip with Podman extra
+      - name: Install cutip
         run: |
           uv venv .venv
-          uv pip install -e ".[podman]"
+          uv pip install -e .
 
       - name: Install Podman (Windows)
         shell: pwsh

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -81,7 +81,7 @@ jobs:
         run: uv run cutip validate --path tests/e2e/hello-world
 
       - name: Run E2E group (Podman · Ubuntu)
-        run: uv run cutip run hello --path tests/e2e/hello-world --backend podman --local
+        run: uv run cutip run hello --path tests/e2e/hello-world --local
 
   e2e-podman-windows:
     name: E2E Podman · Windows
@@ -128,7 +128,7 @@ jobs:
         run: uv run cutip validate --path tests/e2e/hello-world
 
       - name: Run E2E group (Podman · Windows)
-        run: uv run cutip run hello --path tests/e2e/hello-world --backend podman
+        run: uv run cutip run hello --path tests/e2e/hello-world
 
   docs-build:
     name: Docs Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         run: uv run cutip validate --path tests/e2e/hello-world
 
       - name: Run E2E group (Podman · Ubuntu)
-        run: uv run cutip run hello --path tests/e2e/hello-world --backend podman --local
+        run: uv run cutip run hello --path tests/e2e/hello-world --local
 
   build-and-release:
     name: Build & GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,10 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install cutip with Podman extra
+      - name: Install cutip
         run: |
           uv venv .venv
-          uv pip install -e ".[podman]"
+          uv pip install -e .
 
       - name: Install & start Podman (Ubuntu)
         run: |


### PR DESCRIPTION
Closes #6

## Root Cause

When docker support was dropped, `podman>=4.0` was promoted from an optional `[podman]` extra to a core dependency in `pyproject.toml`. The extra itself was removed, but `pr-checks.yml` and `release.yml` still referenced `.[podman]` in their install steps:

```yaml
uv pip install -e ".[podman]"
```

pip/uv behaviour with an undefined extra is non-deterministic across versions (silent skip vs. error), making CI unreliable.

## Consumer project note (issue #6)

The `setuptools.backends.legacy: BuildBackend` error in the install logs is a **consumer project** issue, not a CUTIP issue. `snf-gui-dev` has its own `pyproject.toml` with an old setuptools build backend. The fix on the consumer side is one of:
- Upgrade setuptools: `pip install "setuptools>=68"`
- Switch build backend to hatchling: `build-backend = "hatchling.build"`

Using `uv run --project ~/dev/cutip cutip <cmd>` (as documented in CLAUDE.md) avoids this entirely — uv resolves against the cutip project, never attempting to install the consumer project as a wheel.

## Changes

- `pr-checks.yml`: `uv pip install -e ".[podman]"` → `uv pip install -e .` (×2, ubuntu and windows jobs)
- `release.yml`: same fix (×1, e2e-podman-ubuntu job)

## Test plan

- [ ] `pr-checks` CI gates pass on this PR (specifically the e2e-podman jobs now install cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)