### PR TITLE
[cap005] fix: remove deprecated --backend flag from e2e workflow steps

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -81,7 +81,7 @@ jobs:
         run: uv run cutip validate --path tests/e2e/hello-world
 
       - name: Run E2E group (Podman · Ubuntu)
-        run: uv run cutip run hello --path tests/e2e/hello-world --backend podman --local
+        run: uv run cutip run hello --path tests/e2e/hello-world --local
 
   e2e-podman-windows:
     name: E2E Podman · Windows
@@ -128,7 +128,7 @@ jobs:
         run: uv run cutip validate --path tests/e2e/hello-world
 
       - name: Run E2E group (Podman · Windows)
-        run: uv run cutip run hello --path tests/e2e/hello-world --backend podman
+        run: uv run cutip run hello --path tests/e2e/hello-world
 
   docs-build:
     name: Docs Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         run: uv run cutip validate --path tests/e2e/hello-world
 
       - name: Run E2E group (Podman · Ubuntu)
-        run: uv run cutip run hello --path tests/e2e/hello-world --backend podman --local
+        run: uv run cutip run hello --path tests/e2e/hello-world --local
 
   build-and-release:
     name: Build & GitHub Release


### PR DESCRIPTION
## Summary

- Remove `--backend podman` from e2e `cutip run` steps in `pr-checks.yml` (×2) and `release.yml` (×1)

## Root Cause

`--backend` was a CLI flag used when both Docker and Podman were supported. When Docker support was dropped and Podman became the sole backend, the flag was removed from `cutip run`. The CI workflow steps were not updated, causing all e2e jobs to fail with an unrecognised option error.

## Test plan

- [ ] `e2e-podman-ubuntu` passes without `--backend podman`
- [ ] `e2e-podman-windows` passes without `--backend podman`

🤖 Generated with [Claude Code](https://claude.com/claude-code)