### PR TITLE
gh: update README and fix docs GitHub Pages deploy trigger

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "docs/**"
+      - "integration"
   pull_request:
     branches:
       - staging

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-3776ab)](https://www.python.org/downloads/)
 [![Pydantic v2](https://img.shields.io/badge/pydantic-v2-e92063)](https://docs.pydantic.dev/latest/)
 [![uv](https://img.shields.io/badge/uv-package_manager-6e44ff)](https://github.com/astral-sh/uv)
-[![Runtime](https://img.shields.io/badge/runtime-podman%20%7C%20docker-e44c11)](https://podman.io/)
-[![CI](https://github.com/your-org/cutip/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/cutip/actions/workflows/ci.yml)
+[![Runtime](https://img.shields.io/badge/runtime-podman-892ca0)](https://podman.io/)
+[![CI](https://github.com/joshuajerome/cutip/actions/workflows/pr-checks.yml/badge.svg)](https://github.com/joshuajerome/cutip/actions/workflows/pr-checks.yml)
+[![Docs](https://img.shields.io/badge/docs-github%20pages-0969da)](https://joshuajerome.github.io/cutip)
 
 **Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments using structured YAML artifacts and Python workflows.
 
@@ -36,18 +37,19 @@ Every artifact is a versioned YAML file. Every ref is validated before any backe
 ## Install
 
 ```shell
-git clone <repo-url> cutip && cd cutip
-uv venv && uv pip install -e .
+pip install cutip
+```
 
-# Runtime backend (choose one or both)
-uv pip install -e ".[podman]"
-uv pip install -e ".[docker]"
+Or install from source with [uv](https://github.com/astral-sh/uv):
 
+```shell
+git clone https://github.com/joshuajerome/cutip && cd cutip
+uv pip install -e .
 cutip --help
 ```
 
 > [!NOTE]
-> `cutip init`, `cutip tree`, `cutip validate`, `cutip show`, and `cutip plan` run without any container runtime installed. Only `cutip run` requires a backend.
+> `cutip init`, `cutip tree`, `cutip validate`, `cutip show`, and `cutip plan` run without any container runtime installed. Only `cutip run` requires Podman.
 
 ---
 
@@ -61,8 +63,8 @@ metadata:
   name: app
 spec:
   source: build
-  context: containers/dockerfiles
-  dockerfile: app.dockerfile
+  context: resources/buildtime
+  dockerfile: resources/dockerfiles/app.dockerfile
   tag: latest
 ```
 
@@ -85,20 +87,13 @@ spec:
 ```python
 # cutip/groups/dev/workflow.py
 def main(ctx):
-    img  = ctx.resolved_cards["images/app"]
-    cc   = ctx.resolved_cards["containers/app"]
-    net  = ctx.resolved_cards["networks/dev"]
-
-    ctx.runtime.build_image(img, project_root=ctx.project_root)
-    ctx.runtime.ensure_network(net)
-    ctx.runtime.create_container(cc, image_name=f"{img.name}:{img.spec.tag}")
-    ctx.runtime.start_container(cc.name)
+    ctx.container("app").start()
 ```
 
 ```shell
 cutip validate
 cutip plan dev
-cutip run dev --backend podman
+cutip run dev
 ```
 
 ---
@@ -114,32 +109,41 @@ cutip run dev --backend podman
 | `cutip show unit <name>` | Show a unit's resolved card graph |
 | `cutip show group <name>` | Show a group's units and workflow status |
 | `cutip plan <group> [--path]` | Dry-run: print execution table, start nothing |
-| `cutip run <group> [--backend podman\|docker] [--local]` | Validate → connect → execute workflow |
+| `cutip run <group> [--local] [--path]` | Validate → connect → execute workflow |
+| `cutip group ls` | List all groups in the workspace |
+| `cutip unit ls` | List all units in the workspace |
+| `cutip card ls` | List all cards in the workspace |
 
-Full flag reference: [`docs/reference/cli.md`](docs/reference/cli.md)
+`cutip run` connects to the Podman socket over SSH by default. Pass `--local` to use the local socket directly (useful in CI or rootless setups).
+
+---
+
+## vars.yaml
+
+Workspace variables are declared in `cutip/vars.yaml` with two sections:
+
+```yaml
+required:
+  ssh_private_key: ""   # must be filled in — cutip fails fast if empty
+
+generated:
+  data_dir: ".my-data"  # cutip creates this directory automatically
+```
+
+CUTIP validates all `{{ vars.key }}` references in cards before any container backend is contacted — missing or empty required values surface as a clear error, not a runtime failure.
 
 ---
 
 ## Documentation
 
+Full documentation at **[joshuajerome.github.io/cutip](https://joshuajerome.github.io/cutip)**
+
 | Section | Contents |
 |---|---|
-| [Getting Started](docs/getting-started/installation.md) | Installation, quickstart, workspace layout |
-| [Concepts](docs/concepts/overview.md) | The 4-layer model, cards, units, groups, graph resolution |
-| [Reference](docs/reference/cli.md) | CLI flags, card schemas, workflow contract, exceptions |
-| [Guides — Runtimes](docs/guides/runtimes/podman.md) | Podman (SSH tunnel + local), Docker, per-platform setup |
-| [Guides — Workflows](docs/guides/workflows/writing-workflows.md) | Patterns, runtime injection, plan-safe guards |
-| [Guides — CI/CD](docs/guides/ci-cd/github-actions.md) | GitHub Actions (build, Podman E2E, Docker E2E) |
-| [Architecture](docs/architecture/design-decisions.md) | Design decisions, backend interface, registry internals |
-
----
-
-## Project Status
-
-| Backend | Status |
-|---|---|
-| Podman | ✅ Fully implemented (SSH tunnel + local socket) |
-| Docker | ✅ Implemented (local daemon via docker-py) |
+| [Getting Started](https://joshuajerome.github.io/cutip/getting-started/installation/) | Installation, quickstart, workspace layout |
+| [Concepts](https://joshuajerome.github.io/cutip/concepts/overview/) | The 4-layer model, cards, units, groups, graph resolution |
+| [Reference](https://joshuajerome.github.io/cutip/reference/cli/) | CLI flags, card schemas, workflow contract, exceptions |
+| [Guides](https://joshuajerome.github.io/cutip/guides/runtimes/podman/) | Podman setup, writing workflows, CI/CD |
 
 ---
 


### PR DESCRIPTION
## Summary

- **README**: removed Docker references, corrected install instructions (no extras needed), updated workflow ctx API example, fixed resource paths (`resources/dockerfiles`), added `vars.yaml` section, added `ls` commands to CLI table, linked to GitHub Pages docs site
- **docs-check.yml**: added `integration` to push triggers — the deploy step checked `github.ref == refs/heads/integration` but the trigger only listened to `docs/**` branches, so the deploy could never fire

## Test plan
- [ ] All pr-checks pass
- [ ] MkDocs build passes
- [ ] After merge to integration, docs deploy fires and GitHub Pages site is live at joshuajerome.github.io/cutip