### PR TITLE
gh: preserve release/* and gh-pages in prune-branches workflow

### DIFF
--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -23,8 +23,9 @@ jobs:
           git fetch --prune origin
 
           # Branches fully merged into integration, excluding permanent branches
+          # release/* branches are kept permanently as historical references
           MERGED=$(git branch -r --merged origin/integration \
-            | grep -vE 'origin/(integration|staging|HEAD)' \
+            | grep -vE 'origin/(integration|staging|HEAD|release/.+|gh-pages)' \
             | sed 's|^\s*origin/||' \
             | xargs)
 


### PR DESCRIPTION
## Summary

The `prune-branches.yml` workflow was deleting `release/*` branches after they fast-forwarded into `integration`, and would also delete `gh-pages` (managed by mkdocs). Added both to the exclusion pattern so they persist permanently.

## Test plan
- [ ] CI passes
- [ ] After merge, `release/v0.1.0` branch is recreated and will not be pruned on subsequent integration pushes