### PR TITLE
claude: add /resolve-issues and /cut-release skills

### DIFF
--- a/.claude/skills/cut-release.md
+++ b/.claude/skills/cut-release.md
@@ -1,0 +1,160 @@
+# cut-release
+
+Bump the version, update docs, merge to integration, push the release branch, clean up the GitHub Release page, and update the capabilities registry.
+
+---
+
+## Workflow
+
+### Step 1 — Determine the new version
+
+Ask the user: "What version? (current: X.Y.Z)"
+
+If the user doesn't specify, suggest the next patch version (`X.Y.Z+1`).
+
+### Step 2 — Ensure staging and integration are clean
+
+```bash
+git checkout staging && git pull
+git checkout integration && git pull
+git diff integration..staging --name-only
+```
+
+If there are unmerged commits on staging, warn the user and ask whether to proceed or merge staging first.
+
+### Step 3 — Bump version in pyproject.toml
+
+```bash
+git checkout staging && git pull
+git checkout -b feat/bump-vX.Y.Z
+```
+
+Edit `pyproject.toml`:
+```toml
+version = "X.Y.Z"
+```
+
+Commit:
+```bash
+git add pyproject.toml
+git commit -m "bump: version A.B.C → X.Y.Z"
+git push -u origin feat/bump-vX.Y.Z
+```
+
+Open PR:
+```bash
+gh pr create --base staging \
+  --title "bump: version A.B.C → X.Y.Z" \
+  --body "Version bump for the X.Y.Z release." \
+  --label "enhancement" \
+  --assignee joshuajerome
+```
+
+Wait for all CI checks to pass:
+```bash
+gh pr checks <PR_NUMBER> --watch
+```
+
+Merge:
+```bash
+gh pr merge <PR_NUMBER> --merge --delete-branch
+```
+
+### Step 4 — Update docs/patch-notes.md
+
+On the same branch (before merging) or a separate `docs/` branch, add a release section to `docs/patch-notes.md`:
+
+```markdown
+## vX.Y.Z (YYYY-MM-DD)
+
+### cap{N} — <title> (YYYY-MM-DD)
+- <bullet describing what changed from a user perspective>
+```
+
+Only include cap IDs that shipped since the last release. Describe changes in terms users care about — not internal refactors or CI fixes.
+
+### Step 5 — Update docs/capabilities.md
+
+Ensure all cap IDs that shipped in this release are registered in `docs/capabilities.md` with `status: merged`.
+
+### Step 6 — Forward staging → integration
+
+```bash
+git checkout integration && git pull
+git merge origin/staging --no-edit
+git push
+```
+
+### Step 7 — Cut the release branch
+
+```bash
+git checkout -b release/vX.Y.Z integration
+git push -u origin release/vX.Y.Z
+```
+
+The `release.yml` workflow will fire automatically. Watch it:
+
+```bash
+gh run watch $(gh run list --branch release/vX.Y.Z --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+### Step 8 — Clean up the GitHub Release page
+
+After `release.yml` completes:
+
+**Remove non-wheel assets** (keep only the `.whl`):
+```bash
+gh api repos/{owner}/{repo}/releases/tags/vX.Y.Z \
+  --jq '.assets[] | select(.name | test("whl") | not) | .id' \
+  | while read id; do
+      gh api repos/{owner}/{repo}/releases/assets/$id --method DELETE
+    done
+```
+
+**Update release notes** — replace the auto-generated "What's Changed" with user-facing bullet points:
+```bash
+gh release edit vX.Y.Z --notes "..."
+```
+
+Notes format:
+```markdown
+Container Unit Templates in Python — deterministic framework for building and orchestrating Podman container workloads.
+
+## What's Changed
+
+- <user-facing bullet for cap{N}>
+- <user-facing bullet for cap{M}>
+
+**Full Changelog**: https://github.com/{owner}/{repo}/compare/vA.B.C...vX.Y.Z
+```
+
+Focus on what users care about: new commands, behavior changes, bug fixes that caused visible errors. Omit CI fixes, doc cleanups, and internal refactors.
+
+### Step 9 — Clean up local branches
+
+```bash
+git checkout integration
+git branch -d release/vX.Y.Z feat/bump-vX.Y.Z 2>/dev/null || true
+```
+
+### Step 10 — Report
+
+Print a summary:
+
+```
+✓ Version bumped: A.B.C → X.Y.Z
+✓ release/vX.Y.Z pushed → release.yml passed
+✓ GitHub Release: https://github.com/{owner}/{repo}/releases/tag/vX.Y.Z
+✓ Assets: cutip-X.Y.Z-py3-none-any.whl (only)
+✓ Docs: patch-notes.md and capabilities.md updated
+```
+
+---
+
+## Rules
+
+- Never push directly to `integration` for the version bump — always go through a PR on staging
+- The release branch is created from `integration` (not staging)
+- `release/*` branches are permanent — never delete them
+- Do not tag manually — the `release.yml` workflow creates the git tag automatically via `softprops/action-gh-release`
+- If `release.yml` fails, investigate the logs before retrying

--- a/.claude/skills/resolve-issues.md
+++ b/.claude/skills/resolve-issues.md
@@ -1,0 +1,116 @@
+# resolve-issues
+
+Fetch all open GitHub issues, group them by root cause, fix each group on a dedicated branch, open PRs, and comment on every issue with the resolution and a downloadable wheel.
+
+---
+
+## Workflow
+
+### Step 1 — Fetch and parse open issues
+
+```bash
+gh issue list --state open --json number,title,body,labels --limit 100
+```
+
+Read each issue body carefully. Look at attached logs, stack traces, and reproduction steps.
+
+### Step 2 — Group by root cause
+
+Group issues where a single code change will resolve multiple issues (shared root cause, related components, same error path). List ungrouped issues individually.
+
+Print a summary:
+
+```
+Group A (issues #3, #7): Empty generated vars silently map to project root
+Group B (issue #5): Missing required var not caught until container start
+Standalone (issue #9): Tab completion broken on zsh
+```
+
+Then immediately begin fixing all groups without waiting for approval.
+
+### Step 3 — Assign cap IDs
+
+For each group or standalone issue:
+1. Read `docs/capabilities.md` to find the next unused ID
+2. State: "Assigning **cap{N}**: {title}. Branch: `bug/cap{N}-<short-desc>`."
+3. Do this for all groups before branching — assign IDs sequentially
+
+### Step 4 — Branch, fix, and commit (per group)
+
+For each cap ID:
+
+```bash
+git checkout staging && git pull
+git checkout -b bug/cap{N}-<short-desc>
+```
+
+- Read the relevant source files before making any change
+- Fix the root cause — do not patch symptoms or add workarounds
+- Commit with prefix: `[cap{N}] fix: <description>`
+- Push the branch
+
+### Step 5 — Build a wheel for this fix
+
+```bash
+uv build --wheel
+```
+
+This produces `dist/cutip-X.Y.Z-py3-none-any.whl`. Note the path — it will be attached to the PR and referenced in issue comments.
+
+### Step 6 — Open a PR
+
+```bash
+gh pr create --base staging \
+  --title "[cap{N}] fix: <description>" \
+  --body "..." \
+  --label "bug" \
+  --assignee joshuajerome
+```
+
+PR body must include:
+- **Root cause**: one sentence explaining what was wrong
+- **Fix**: what changed and why
+- **Issues resolved**: `Closes #N, Closes #M`
+- **Test plan**: checklist
+
+### Step 7 — Upload wheel and comment on every resolved issue
+
+For each issue resolved by this group:
+
+```bash
+gh issue comment {number} --body "..."
+```
+
+Comment body:
+```
+**Resolved in PR #<N> — [cap{X}]**
+
+**Root cause:** <one sentence>
+
+**Fix:** <what changed>
+
+**Wheel with fix:** download `cutip-X.Y.Z-py3-none-any.whl` from the PR's wheel-build artifact, or wait for it to ship in the next release.
+
+This issue will be closed automatically when the PR merges to staging.
+```
+
+### Step 8 — Repeat for all groups
+
+Work through all groups and standalone issues. After all PRs are open, print a summary table:
+
+```
+| Cap ID | Branch                        | PR  | Issues Closed |
+|--------|-------------------------------|-----|---------------|
+| cap007 | bug/cap007-empty-generated-var | #17 | #3, #7        |
+| cap008 | bug/cap008-zsh-completion      | #18 | #9            |
+```
+
+---
+
+## Rules
+
+- Never auto-commit. Only commit when a fix is complete and tested locally (`uv run pytest tests/ --ignore=tests/e2e`)
+- One branch per cap ID — never mix fixes
+- Always read source files before editing
+- Do not close issues manually — they close via `Closes #N` in the PR body when merged
+- If a fix requires more investigation, open a draft PR and note what is unclear in the issue comment


### PR DESCRIPTION
## Summary

Adds two new Claude Code skills to `.claude/skills/`:

**`/resolve-issues`**
- Fetches all open GitHub issues and groups them by root cause
- Assigns cap IDs sequentially from `docs/capabilities.md`
- For each group: branches off staging, fixes root cause, builds wheel, opens PR with `Closes #N` references
- Comments on every resolved issue with root cause explanation, fix summary, and wheel download link

**`/cut-release`**
- Prompts for version, bumps `pyproject.toml` via PR to staging
- Updates `docs/patch-notes.md` and `docs/capabilities.md`
- Merges staging → integration, pushes `release/vX.Y.Z` branch
- Watches `release.yml`, then cleans up GitHub Release page (wheel-only, user-facing notes)
- Reports final summary with release URL

Both skills are also installed at `~/.claude/skills/` for user-level access.