### PR TITLE
[cap-pypi] Add PyPI metadata and bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,25 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cutip"
-version = "0.1.1"
+version = "0.1.2"
 description = "Container Unit Templates in Python — a deterministic framework for building container workloads"
+readme = "README.md"
 license = { text = "MIT" }
+authors = [
+    { name = "Joshua Jerome" },
+]
+keywords = ["containers", "podman", "devops", "workflow", "infrastructure"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: System :: Software Distribution",
+    "Operating System :: OS Independent",
+]
 requires-python = ">=3.11"
 dependencies = [
     "typer>=0.12",
@@ -16,6 +32,12 @@ dependencies = [
     "rich>=13.0",
     "podman>=4.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/joshuajerome/cutip"
+Documentation = "https://joshuajerome.github.io/cutip"
+Repository = "https://github.com/joshuajerome/cutip"
+"Bug Tracker" = "https://github.com/joshuajerome/cutip/issues"
 
 [project.scripts]
 cutip = "cutip.cli.main:app"


### PR DESCRIPTION
## Summary

- Forward `staging → integration`: PyPI metadata enrichment + version bump `0.1.1 → 0.1.2`
- Adds `readme`, `authors`, `keywords`, `classifiers`, `[project.urls]` to `pyproject.toml`

## Test plan

- [ ] All PR checks pass on staging
- [ ] `uv publish` triggered by `release/v0.1.2` push

🤖 Generated with [Claude Code](https://claude.com/claude-code)