### PR TITLE
docs: update installation instructions for PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,10 @@ Every artifact is a versioned YAML file. Every ref is validated before any backe
 
 ```shell
 pip install cutip
-```
-
-Or install from source with [uv](https://github.com/astral-sh/uv):
-
-```shell
-git clone https://github.com/joshuajerome/cutip && cd cutip
-uv pip install -e .
 cutip --help
 ```
+
+> **Contributing?** Clone the repo and use `uv pip install -e .` for an editable install — see the [installation guide](https://joshuajerome.github.io/cutip/getting-started/installation/).
 
 > [!NOTE]
 > `cutip init`, `cutip tree`, `cutip validate`, `cutip show`, and `cutip plan` run without any container runtime installed. Only `cutip run` requires Podman.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,18 +14,6 @@
 
 ```shell
 pip install cutip
-```
-
-Or install from source:
-
-```shell
-git clone https://github.com/joshuajerome/cutip && cd cutip
-uv pip install -e .
-```
-
-Verify the CLI is available:
-
-```shell
 cutip --help
 ```
 
@@ -44,7 +32,9 @@ Summary:
 
 ---
 
-## Development Install (with test dependencies)
+## Contributing to CUTIP
+
+To work on CUTIP itself, clone the repo and install in editable mode with test dependencies:
 
 ```shell
 git clone https://github.com/joshuajerome/cutip && cd cutip

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,15 +36,10 @@ Every artifact is a versioned YAML file. Every ref is validated before any backe
 
 ```shell
 pip install cutip
-```
-
-Or install from source:
-
-```shell
-git clone https://github.com/joshuajerome/cutip && cd cutip
-uv pip install -e .
 cutip --help
 ```
+
+> **Contributing?** Clone the repo and use `uv pip install -e .` for an editable install — see [Installation](getting-started/installation.md).
 
 > [!NOTE]
 > `cutip init`, `cutip tree`, `cutip validate`, `cutip show`, and `cutip plan` run without any container runtime installed. Only `cutip run` requires Podman.


### PR DESCRIPTION
Forward `staging → integration`: update installation docs for PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)