### PR TITLE
[cap006] Translate Windows bind-mount paths to WSL2 format

### DIFF
--- a/cutip/backends/podman/backend.py
+++ b/cutip/backends/podman/backend.py
@@ -29,6 +29,23 @@ from cutip.models.cards.network import NetworkCard
 from cutip.utils.exceptions import CutipError
 
 
+def _win_to_wsl(path: str) -> str:
+    """Translate a Windows-style path to its WSL2 bind-mount equivalent.
+
+    Podman on Windows runs inside a Linux VM; the daemon has no knowledge of
+    Windows drive letters.  Paths like ``C:/Users/foo`` or ``C:Users/foo``
+    must become ``/mnt/c/Users/foo`` before being sent to the API.
+
+    Non-Windows paths are returned unchanged.
+    """
+    path = path.replace("\\", "/")
+    if len(path) >= 2 and path[1] == ":" and path[0].isalpha():
+        drive = path[0].lower()
+        rest = path[2:].lstrip("/")
+        return f"/mnt/{drive}/{rest}"
+    return path
+
+
 class PodmanBackend(CutipBackend):
     """Podman backend — communicates via PodmanClient (SSH tunnel or local socket)."""
 
@@ -231,12 +248,17 @@ class PodmanBackend(CutipBackend):
             kwargs["restart_policy"] = {"Name": card.spec.restart_policy}
         if card.spec.mounts:
             # Filter out CUTIP-specific fields (create_host_path) that
-            # podman-py does not accept.
+            # podman-py does not accept.  Also translate Windows-style host
+            # paths (C:/…) to their WSL2 equivalents (/mnt/c/…) so the
+            # Podman daemon running inside the Linux VM can resolve them.
             _PODMAN_MOUNT_KEYS = {"type", "source", "target", "read_only"}
-            kwargs["mounts"] = [
-                {k: v for k, v in m.model_dump().items() if k in _PODMAN_MOUNT_KEYS}
-                for m in card.spec.mounts
-            ]
+            mounts = []
+            for m in card.spec.mounts:
+                d = {k: v for k, v in m.model_dump().items() if k in _PODMAN_MOUNT_KEYS}
+                if d.get("type") == "bind" and "source" in d:
+                    d["source"] = _win_to_wsl(d["source"])
+                mounts.append(d)
+            kwargs["mounts"] = mounts
         if card.spec.volumes:
             kwargs["volumes"] = {
                 vol: {"bind": path, "mode": "rw"}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -13,6 +13,7 @@ commit messages, and PR titles.
 | cap003 | Remove non-existent [podman] extra from CI             | bug  | merged | bug/cap003-fix-podman-extra         | #8  | 2026-02-28 |
 | cap004 | Add MIT license                                        | feat | merged | feat/cap004-mit-license             | #9  | 2026-02-28 |
 | cap005 | Remove deprecated --backend flag from e2e steps        | bug  | merged | bug/cap005-fix-e2e-backend-flag     | #10 | 2026-02-28 |
+| cap006 | Translate Windows bind-mount paths to WSL2 format      | bug  | open   | bug/cap006-win-path-wsl-translation | —   | 2026-03-02 |
 
 ## ID Assignment
 

--- a/tests/test_win_path.py
+++ b/tests/test_win_path.py
@@ -1,0 +1,25 @@
+"""Tests for Windows-to-WSL2 path translation in the Podman backend."""
+
+import pytest
+
+from cutip.backends.podman.backend import _win_to_wsl
+
+
+@pytest.mark.parametrize("inp, expected", [
+    # Canonical Windows forward-slash paths
+    ("C:/Users/foo/bar",         "/mnt/c/Users/foo/bar"),
+    ("D:/some/path",             "/mnt/d/some/path"),
+    # Missing slash after colon (as seen in the wild)
+    ("C:Users/foo/.ssh/key",     "/mnt/c/Users/foo/.ssh/key"),
+    # Backslash paths
+    ("C:\\Users\\foo\\bar",      "/mnt/c/Users/foo/bar"),
+    # Drive letter casing is normalised to lowercase
+    ("c:/Users/foo",             "/mnt/c/Users/foo"),
+    ("Z:/data",                  "/mnt/z/data"),
+    # Non-Windows paths are returned unchanged
+    ("/home/user/.ssh/key",      "/home/user/.ssh/key"),
+    ("/mnt/c/already/wsl",       "/mnt/c/already/wsl"),
+    ("relative/path",            "relative/path"),
+])
+def test_win_to_wsl(inp, expected):
+    assert _win_to_wsl(inp) == expected


### PR DESCRIPTION
Forward staging → integration. Fixes #22.