### PR TITLE
bump: version 0.1.2 → 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cutip"
-version = "0.1.2"
+version = "0.1.3"
 description = "Container Unit Templates in Python — a deterministic framework for building container workloads"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Version bump for the v0.1.3 release (includes cap006 Windows path fix).