### PR TITLE
Add issue-driven Claude diagnosis and fix workflow

### DIFF
--- a/.github/scripts/diagnose-issue.py
+++ b/.github/scripts/diagnose-issue.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Diagnose a GitHub issue using the Claude API.
+
+Called by issue-diagnose.yml when the claude-review label is applied to an issue.
+Outputs a structured markdown diagnosis to stdout, which the workflow posts as a comment.
+
+Environment variables (set by the workflow):
+  ANTHROPIC_API_KEY  - Anthropic API key (from repo secret)
+  ISSUE_NUMBER       - GitHub issue number
+  ISSUE_TITLE        - Issue title
+  ISSUE_BODY         - Issue body (markdown)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import anthropic
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Source files included as context for diagnosis (most issue-relevant paths first)
+CONTEXT_FILES = [
+    "cutip/backends/podman/backend.py",
+    "cutip/cli/commands/run.py",
+    "cutip/cli/main.py",
+    "cutip/models/cards/container.py",
+    "cutip/models/cards/image.py",
+    "cutip/models/cards/network.py",
+    "cutip/models/unit.py",
+    "cutip/models/group.py",
+    "cutip/context/workflow.py",
+    "cutip/context/startup.py",
+    "cutip/resolver/refs.py",
+    "cutip/validation/graph.py",
+    "cutip/utils/exceptions.py",
+    "cutip/workspace/discovery.py",
+    "cutip/workspace/registry.py",
+]
+
+
+def _env(key: str) -> str:
+    val = os.environ.get(key, "").strip()
+    if not val:
+        print(f"ERROR: environment variable {key!r} is not set", file=sys.stderr)
+        sys.exit(1)
+    return val
+
+
+def _build_source_context() -> str:
+    parts = []
+    for rel_path in CONTEXT_FILES:
+        path = REPO_ROOT / rel_path
+        if not path.exists():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+            parts.append(f"### {rel_path}\n```python\n{content}\n```")
+        except Exception as exc:
+            print(f"WARNING: could not read {rel_path}: {exc}", file=sys.stderr)
+    return "\n\n".join(parts)
+
+
+def diagnose(
+    issue_number: str,
+    issue_title: str,
+    issue_body: str,
+    source_context: str,
+) -> str:
+    client = anthropic.Anthropic()
+
+    prompt = f"""You are a senior engineer maintaining CUTIP (Container Unit Templates in Python) — \
+a deterministic framework for defining and orchestrating container environments using Podman.
+
+A user has filed a GitHub issue. Diagnose the root cause and describe a concise fix approach.
+
+## Issue #{issue_number}: {issue_title}
+
+{issue_body or "_No description provided._"}
+
+## Relevant Source Code
+
+{source_context}
+
+---
+
+Respond with a structured diagnosis in **exactly** this format (use the exact headings):
+
+## Claude Diagnosis
+
+**Root Cause:** (one sentence describing the fundamental problem)
+
+**Affected Location:** `path/to/file.py:line_number` (one or more locations)
+
+**What's Happening:** (2–4 sentences explaining the bug mechanically — what code path leads to the failure)
+
+**Proposed Fix:** (2–5 sentences describing the minimal code change that will resolve it)
+
+**Confidence:** High / Medium / Low — (one sentence explaining confidence level and any uncertainty)
+"""
+
+    message = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=2048,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return message.content[0].text
+
+
+def main() -> None:
+    issue_number = _env("ISSUE_NUMBER")
+    issue_title = _env("ISSUE_TITLE")
+    issue_body = os.environ.get("ISSUE_BODY", "").strip()
+
+    print(f"Diagnosing issue #{issue_number}: {issue_title}", file=sys.stderr)
+
+    source_context = _build_source_context()
+    print(
+        f"Loaded context from {source_context.count('###')} source files.",
+        file=sys.stderr,
+    )
+
+    diagnosis = diagnose(
+        issue_number=issue_number,
+        issue_title=issue_title,
+        issue_body=issue_body,
+        source_context=source_context,
+    )
+
+    print(diagnosis)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/fix-issue.py
+++ b/.github/scripts/fix-issue.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Generate an automated code fix for a GitHub issue using the Claude API.
+
+Called by issue-resolve.yml after a /approve comment is received.
+Reads relevant source files, generates a minimal fix, writes changed files to disk,
+and outputs a markdown summary to stdout (posted as an issue comment by the workflow).
+
+Environment variables (set by the workflow):
+  ANTHROPIC_API_KEY  - Anthropic API key (from repo secret)
+  ISSUE_NUMBER       - GitHub issue number
+  ISSUE_TITLE        - Issue title
+  ISSUE_BODY         - Issue body (markdown)
+  DIAGNOSIS_FILE     - Path to file containing Claude's prior diagnosis
+  CAP_ID             - Capability ID for this fix (e.g., cap007)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import anthropic
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# All source files that could potentially need a change
+ALL_SOURCE_FILES = [
+    "cutip/backends/podman/backend.py",
+    "cutip/cli/commands/run.py",
+    "cutip/cli/commands/validate.py",
+    "cutip/cli/commands/ls.py",
+    "cutip/cli/commands/show.py",
+    "cutip/cli/commands/plan.py",
+    "cutip/cli/commands/init.py",
+    "cutip/cli/main.py",
+    "cutip/models/cards/container.py",
+    "cutip/models/cards/image.py",
+    "cutip/models/cards/network.py",
+    "cutip/models/unit.py",
+    "cutip/models/group.py",
+    "cutip/context/workflow.py",
+    "cutip/context/startup.py",
+    "cutip/resolver/refs.py",
+    "cutip/validation/graph.py",
+    "cutip/utils/exceptions.py",
+    "cutip/utils/logging.py",
+    "cutip/workspace/discovery.py",
+    "cutip/workspace/registry.py",
+    "cutip/workspace/scaffold.py",
+]
+
+
+def _env(key: str) -> str:
+    val = os.environ.get(key, "").strip()
+    if not val:
+        print(f"ERROR: environment variable {key!r} is not set", file=sys.stderr)
+        sys.exit(1)
+    return val
+
+
+def _build_source_context() -> str:
+    parts = []
+    for rel_path in ALL_SOURCE_FILES:
+        path = REPO_ROOT / rel_path
+        if not path.exists():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+            parts.append(f"### {rel_path}\n```python\n{content}\n```")
+        except Exception as exc:
+            print(f"WARNING: could not read {rel_path}: {exc}", file=sys.stderr)
+    return "\n\n".join(parts)
+
+
+def generate_fix(
+    issue_number: str,
+    issue_title: str,
+    issue_body: str,
+    diagnosis: str,
+    cap_id: str,
+    source_context: str,
+) -> tuple[dict[str, str], str]:
+    """
+    Call Claude to generate a minimal code fix.
+
+    Returns:
+        file_changes: dict mapping relative file path → complete new file content
+        summary: markdown summary of changes (for the issue comment)
+    """
+    client = anthropic.Anthropic()
+
+    prompt = f"""You are a senior engineer maintaining CUTIP (Container Unit Templates in Python) — \
+a deterministic framework for defining and orchestrating container environments using Podman.
+
+A user filed issue #{issue_number} and you previously diagnosed the root cause. \
+Now generate a minimal, correct code fix.
+
+## Issue #{issue_number}: {issue_title}
+
+{issue_body or "_No description provided._"}
+
+## Prior Diagnosis
+
+{diagnosis}
+
+## Current Source Code
+
+{source_context}
+
+---
+
+Generate the minimal fix. Respond in exactly two parts separated by `---SUMMARY---` on its own line:
+
+**Part 1:** A JSON object where:
+- Keys are relative file paths (e.g., `"cutip/cli/commands/run.py"`)
+- Values are the **complete** new file contents (not diffs, not excerpts — full file text)
+- Only include files that actually need to change
+
+Wrap the JSON in a ```json code block.
+
+**Part 2:** A concise markdown summary (3–8 bullet points) of:
+- What changed and in which file(s)
+- Why the change fixes the issue
+- Any caveats or limitations of the automated fix
+
+Example response structure:
+
+```json
+{{
+  "cutip/some/file.py": "#!/usr/bin/env python3\\n..."
+}}
+```
+---SUMMARY---
+- Fixed null-check in `cutip/some/file.py:42` to handle missing key
+- Added `KeyError` guard in the `_validate_vars` path
+"""
+
+    message = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=8192,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    response_text = message.content[0].text
+
+    # Split on ---SUMMARY---
+    parts = response_text.split("---SUMMARY---", 1)
+    json_part = parts[0].strip()
+    summary = parts[1].strip() if len(parts) > 1 else "_No summary provided._"
+
+    # Strip code fences from the JSON part
+    if "```json" in json_part:
+        json_part = json_part.split("```json", 1)[1]
+        if "```" in json_part:
+            json_part = json_part.rsplit("```", 1)[0]
+    elif "```" in json_part:
+        json_part = json_part.split("```", 1)[1]
+        if "```" in json_part:
+            json_part = json_part.rsplit("```", 1)[0]
+
+    try:
+        file_changes: dict[str, str] = json.loads(json_part.strip())
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: Could not parse Claude's response as JSON: {exc}", file=sys.stderr)
+        print(f"--- Raw response ---\n{response_text}\n---", file=sys.stderr)
+        sys.exit(1)
+
+    return file_changes, summary
+
+
+def apply_fix(file_changes: dict[str, str]) -> list[str]:
+    """Write changed files to disk. Returns list of relative paths written."""
+    written = []
+    for rel_path, content in file_changes.items():
+        path = REPO_ROOT / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        written.append(rel_path)
+        print(f"  Wrote {rel_path}", file=sys.stderr)
+    return written
+
+
+def main() -> None:
+    issue_number = _env("ISSUE_NUMBER")
+    issue_title = _env("ISSUE_TITLE")
+    issue_body = os.environ.get("ISSUE_BODY", "").strip()
+    diagnosis_file = _env("DIAGNOSIS_FILE")
+    cap_id = _env("CAP_ID")
+
+    diagnosis_path = Path(diagnosis_file)
+    if not diagnosis_path.exists():
+        print(f"ERROR: diagnosis file not found: {diagnosis_file}", file=sys.stderr)
+        sys.exit(1)
+    diagnosis = diagnosis_path.read_text(encoding="utf-8").strip()
+    if not diagnosis:
+        print("ERROR: diagnosis file is empty", file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        f"Generating fix for issue #{issue_number} ({cap_id}): {issue_title}",
+        file=sys.stderr,
+    )
+
+    source_context = _build_source_context()
+    print(
+        f"Loaded context from {source_context.count('###')} source files.",
+        file=sys.stderr,
+    )
+
+    file_changes, summary = generate_fix(
+        issue_number=issue_number,
+        issue_title=issue_title,
+        issue_body=issue_body,
+        diagnosis=diagnosis,
+        cap_id=cap_id,
+        source_context=source_context,
+    )
+
+    if not file_changes:
+        print("ERROR: Claude returned no file changes.", file=sys.stderr)
+        sys.exit(1)
+
+    written = apply_fix(file_changes)
+    print(f"Applied fix to {len(written)} file(s).", file=sys.stderr)
+
+    # Stdout output is captured by the workflow and posted as a GitHub comment
+    print(summary)
+    print()
+    print("**Files changed:**")
+    for path in written:
+        print(f"- `{path}`")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/issue-diagnose.yml
+++ b/.github/workflows/issue-diagnose.yml
@@ -1,0 +1,101 @@
+name: Issue Diagnose
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  diagnose:
+    name: Diagnose issue with Claude
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'claude-review'
+
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Ensure required labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "claude-review"      --color "0075ca" --description "Needs Claude diagnosis"  --force --repo ${{ github.repository }}
+          gh label create "claude-diagnosing"  --color "e4e669" --description "Claude is diagnosing"    --force --repo ${{ github.repository }}
+          gh label create "claude-diagnosed"   --color "cfd3d7" --description "Claude diagnosis posted"  --force --repo ${{ github.repository }}
+          gh label create "claude-fixing"      --color "e4e669" --description "Claude is generating fix" --force --repo ${{ github.repository }}
+          gh label create "claude-fixed"       --color "0e8a16" --description "Claude fix ready"         --force --repo ${{ github.repository }}
+          gh label create "claude-staging"     --color "1d76db" --description "Fix PR opened to staging" --force --repo ${{ github.repository }}
+
+      - name: Apply claude-diagnosing label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-diagnosing"
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-review" 2>/dev/null || true
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install script dependencies
+        run: |
+          uv venv .venv
+          uv pip install anthropic
+
+      - name: Run Claude diagnosis
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          uv run python .github/scripts/diagnose-issue.py > /tmp/diagnosis.md
+
+      - name: Post diagnosis comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body-file /tmp/diagnosis.md
+
+      - name: Update labels to claude-diagnosed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-diagnosed"
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-diagnosing" 2>/dev/null || true
+
+      - name: Post follow-up prompt comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Reply \`/approve\` to proceed with the automated fix, or add more detail and re-apply \`claude-review\` for a fresh diagnosis."
+
+      - name: Revert labels on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-review" 2>/dev/null || true
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-diagnosing" 2>/dev/null || true
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Diagnosis failed (check [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details). Re-applying \`claude-review\` to retry."

--- a/.github/workflows/issue-resolve.yml
+++ b/.github/workflows/issue-resolve.yml
@@ -1,0 +1,332 @@
+name: Issue Resolve
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  # ──────────────────────────────────────────────────────────
+  # /approve  →  generate fix, build wheel, post results
+  # ──────────────────────────────────────────────────────────
+  handle-approve:
+    name: Handle /approve
+    runs-on: ubuntu-latest
+    if: |
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/approve')
+
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check claude-diagnosed label
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json labels --jq '.labels[].name' | tr '\n' ' ')
+          echo "Issue labels: $LABELS"
+          if echo "$LABELS" | grep -qw "claude-diagnosed"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "Issue does not have claude-diagnosed label — ignoring."
+          fi
+
+      - name: Apply claude-fixing label
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-fixing"
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-diagnosed" 2>/dev/null || true
+
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.valid == 'true'
+
+      - name: Determine next cap ID and branch name
+        if: steps.check.outputs.valid == 'true'
+        id: cap
+        run: |
+          LAST_ID=$(grep -oP 'cap\d+' docs/capabilities.md | sort -V | tail -1)
+          LAST_NUM=$(echo "$LAST_ID" | grep -oP '\d+')
+          NEXT_NUM=$((10#$LAST_NUM + 1))
+          NEXT_ID=$(printf "cap%03d" "$NEXT_NUM")
+          echo "cap_id=$NEXT_ID" >> "$GITHUB_OUTPUT"
+
+          SLUG=$(echo "${{ github.event.issue.title }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9]/-/g' \
+            | sed 's/-\+/-/g' \
+            | cut -c1-30 \
+            | sed 's/-$//')
+          BRANCH="bug/${NEXT_ID}-issue-${{ github.event.issue.number }}-${SLUG}"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Cap ID: $NEXT_ID  Branch: $BRANCH"
+
+      - name: Fetch Claude diagnosis from issue comments
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json comments \
+            --jq '.comments | map(select(.author.login == "github-actions[bot]")) | if length > 0 then first.body else "" end' \
+            > /tmp/diagnosis.md
+          echo "Diagnosis fetched: $(wc -c < /tmp/diagnosis.md) bytes"
+
+      - name: Install uv
+        if: steps.check.outputs.valid == 'true'
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install script dependencies
+        if: steps.check.outputs.valid == 'true'
+        run: |
+          uv venv .venv
+          uv pip install anthropic
+
+      - name: Generate fix via Claude
+        if: steps.check.outputs.valid == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          DIAGNOSIS_FILE: /tmp/diagnosis.md
+          CAP_ID: ${{ steps.cap.outputs.cap_id }}
+        run: |
+          uv run python .github/scripts/fix-issue.py > /tmp/fix-summary.md
+
+      - name: Commit and push fix branch
+        if: steps.check.outputs.valid == 'true'
+        env:
+          CAP_ID: ${{ steps.cap.outputs.cap_id }}
+          BRANCH: ${{ steps.cap.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add cutip/
+          if git diff --staged --quiet; then
+            echo "ERROR: No staged changes after running fix script." >&2
+            exit 1
+          fi
+          git commit -m "[${CAP_ID}] fix: automated fix for issue #${{ github.event.issue.number }}"
+          git push origin "$BRANCH"
+
+      - name: Build wheel
+        if: steps.check.outputs.valid == 'true'
+        run: uv build --wheel
+
+      - name: Upload wheel artifact
+        if: steps.check.outputs.valid == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: "cutip-fix-${{ steps.cap.outputs.cap_id }}"
+          path: dist/*.whl
+          retention-days: 14
+
+      - name: Apply claude-fixed label
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-fixed"
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-fixing" 2>/dev/null || true
+
+      - name: Post fix comment
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CAP_ID: ${{ steps.cap.outputs.cap_id }}
+          BRANCH: ${{ steps.cap.outputs.branch }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "## Claude Fix — ${CAP_ID}"
+            echo ""
+            cat /tmp/fix-summary.md
+            echo ""
+            echo "---"
+            echo ""
+            echo "**Branch:** \`${BRANCH}\`"
+            echo ""
+            echo "**Download wheel:** [Workflow run artifacts](${RUN_URL})"
+            echo ""
+            echo "**Install the patched wheel:**"
+            echo '```bash'
+            echo "pip install cutip-*.whl"
+            echo '```'
+            echo ""
+            echo "Reply \`/acknowledge\` to open a PR from \`${BRANCH}\` to \`staging\` for release."
+          } > /tmp/fix-comment.md
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body-file /tmp/fix-comment.md
+
+      - name: Revert labels on failure
+        if: failure() && steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-diagnosed" 2>/dev/null || true
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-fixing" 2>/dev/null || true
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Fix generation failed. Issue reset to \`claude-diagnosed\`. Check [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. Reply \`/approve\` to retry."
+
+  # ──────────────────────────────────────────────────────────
+  # /reject  →  ask for more detail, keep claude-diagnosed
+  # ──────────────────────────────────────────────────────────
+  handle-reject:
+    name: Handle /reject
+    runs-on: ubuntu-latest
+    if: |
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/reject')
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Check claude-diagnosed label
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json labels --jq '.labels[].name' | tr '\n' ' ')
+          if echo "$LABELS" | grep -qw "claude-diagnosed"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post rejection comment
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Diagnosis rejected. Please add more detail to the issue description, then re-apply the \`claude-review\` label to trigger a fresh diagnosis."
+
+  # ──────────────────────────────────────────────────────────
+  # /acknowledge  →  open PR from fix branch to staging
+  # ──────────────────────────────────────────────────────────
+  handle-acknowledge:
+    name: Handle /acknowledge
+    runs-on: ubuntu-latest
+    if: |
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/acknowledge')
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Check claude-fixed label
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json labels --jq '.labels[].name' | tr '\n' ' ')
+          if echo "$LABELS" | grep -qw "claude-fixed"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "Issue does not have claude-fixed label — ignoring."
+          fi
+
+      - name: Apply claude-staging label
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-staging"
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-fixed" 2>/dev/null || true
+
+      - name: Find fix branch for this issue
+        if: steps.check.outputs.valid == 'true'
+        id: find-branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUM="${{ github.event.issue.number }}"
+          BRANCH=$(gh api "repos/${{ github.repository }}/git/refs/heads" \
+            --jq '.[].ref' \
+            | grep -oP "(?<=refs/heads/)bug/cap\d+-issue-${ISSUE_NUM}-\S+" \
+            | head -1 || true)
+
+          if [ -z "$BRANCH" ]; then
+            echo "ERROR: No bug/cap* branch found for issue #${ISSUE_NUM}" >&2
+            exit 1
+          fi
+
+          CAP_ID=$(echo "$BRANCH" | grep -oP 'cap\d+')
+          echo "branch=$BRANCH"   >> "$GITHUB_OUTPUT"
+          echo "cap_id=$CAP_ID"   >> "$GITHUB_OUTPUT"
+          echo "Found branch: $BRANCH"
+
+      - name: Open PR to staging
+        if: steps.check.outputs.valid == 'true'
+        id: open-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.find-branch.outputs.branch }}
+          CAP_ID: ${{ steps.find-branch.outputs.cap_id }}
+        run: |
+          {
+            echo "Automated fix for issue #${{ github.event.issue.number }}, acknowledged by @${{ github.event.comment.user.login }}."
+            echo ""
+            echo "## Summary"
+            echo "- Branch: \`${BRANCH}\`"
+            echo "- Triggered by: \`/acknowledge\` comment on issue #${{ github.event.issue.number }}"
+            echo ""
+            echo "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+          } > /tmp/pr-body.md
+          PR_URL=$(gh pr create \
+            --repo ${{ github.repository }} \
+            --base staging \
+            --head "$BRANCH" \
+            --title "[${CAP_ID}] Automated fix for issue #${{ github.event.issue.number }}" \
+            --body-file /tmp/pr-body.md)
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "PR opened: $PR_URL"
+
+      - name: Post acknowledgement comment
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.open-pr.outputs.pr_url }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "PR opened to staging: ${PR_URL}. The fix will be released in the next version once the PR is reviewed and merged."


### PR DESCRIPTION
## Summary

- Adds `issue-diagnose.yml`: triggers on `claude-review` label, calls Claude API to diagnose the issue, posts a structured comment, and manages a label state machine (`claude-diagnosing` → `claude-diagnosed`)
- Adds `issue-resolve.yml`: handles three comment commands on issues:
  - `/approve` — generates a code fix via Claude, builds a wheel, uploads as artifact, posts download link
  - `/reject` — posts "add more detail" prompt, labels unchanged
  - `/acknowledge` — opens a PR from the fix branch to `staging`
- Adds `diagnose-issue.py`: reads 15 key source files for context, calls `claude-sonnet-4-6`, outputs structured markdown diagnosis
- Adds `fix-issue.py`: reads all 22 source files + prior diagnosis, calls Claude to generate a JSON `{file: content}` fix, writes changed files to disk, outputs markdown summary

## Prerequisites

- [x] `ANTHROPIC_API_KEY` secret — confirmed present
- [x] `PYPI_TOKEN` secret — confirmed present

## Test plan

- [ ] Create a test issue with a known bug description
- [ ] Apply `claude-review` label → confirm `issue-diagnose.yml` runs and diagnosis comment appears
- [ ] Reply `/approve` → confirm fix branch created, wheel built, comment with artifact link posted
- [ ] Reply `/acknowledge` → confirm PR opened to staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)