### PR TITLE
Add e2e workflow playbooks, PR/release templates, and deliverables mandate

### DIFF
--- a/.claude/templates/github-release-notes.md
+++ b/.claude/templates/github-release-notes.md
@@ -1,0 +1,63 @@
+# GitHub Release Notes Template
+
+Use this when running `gh release edit vX.Y.Z --notes "..."`.
+
+Fill every `{placeholder}`. Write only user-facing changes.
+Omit: CI fixes, doc cleanups, internal refactors, test changes.
+
+---
+
+## GitHub Release page body
+
+```
+Container Unit Templates in Python — deterministic framework for building
+and orchestrating Podman container workloads.
+
+## What's Changed
+
+- **{cap{N}} — {title}**: {one sentence — what the user can now do or what error is fixed}
+- **{cap{M}} — {title}**: {one sentence — what the user can now do or what error is fixed}
+
+## Installation
+
+```bash
+pip install cutip=={X.Y.Z}
+```
+
+Or install the wheel directly from this release:
+
+```bash
+pip install cutip-{X.Y.Z}-py3-none-any.whl
+```
+
+**Full Changelog**: https://github.com/joshuajerome/cutip/compare/v{A.B.C}...v{X.Y.Z}
+```
+
+---
+
+## docs/patch-notes.md entry
+
+Prepend this block after the `# Patch Notes` heading in `docs/patch-notes.md`:
+
+```markdown
+## v{X.Y.Z} ({YYYY-MM-DD})
+
+### cap{N} — {title}
+
+- {what changed from a user perspective}
+- {behavioral impact — what was broken, what now works}
+
+### cap{M} — {title}
+
+- {what changed from a user perspective}
+```
+
+---
+
+## Checklist before saving
+
+- [ ] Every shipped cap ID appears exactly once
+- [ ] No mention of CI, docs, or internal-only changes
+- [ ] Installation commands use the correct version number
+- [ ] Full Changelog URL uses the previous tag as the base (`v{A.B.C}`)
+- [ ] patch-notes.md entry is prepended (not appended)

--- a/.claude/templates/pr-body.md
+++ b/.claude/templates/pr-body.md
@@ -1,0 +1,134 @@
+# PR Body Templates
+
+Copy the section matching your branch type. Fill every `{placeholder}`.
+Write the filled body to `/tmp/pr-body.md` and pass `--body-file /tmp/pr-body.md` to `gh pr create`.
+
+---
+
+## feat/cap{N} — New Feature
+
+```markdown
+## Summary
+
+- {one sentence: what new capability this adds}
+- {implementation approach in 1–2 sentences}
+- {any trade-offs or known limitations}
+
+## Changes
+
+- `{file}`: {what changed and why}
+- `{file}`: {what changed and why}
+
+## Test plan
+
+- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes
+- [ ] {feature-specific manual test step}
+- [ ] Smoke test: `cutip {relevant command}`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## bug/cap{N} — Bug Fix
+
+```markdown
+## Summary
+
+**Root cause:** {one sentence — what code path caused the failure}
+
+**Fix:** {what changed and why it resolves the root cause}
+
+Closes #{issue-number}
+
+## Changes
+
+- `{file}:{line}`: {what changed}
+- `{file}:{line}`: {what changed}
+
+## Test plan
+
+- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes
+- [ ] Reproduction steps from the issue no longer reproduce
+- [ ] {any regression test added}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## docs/cap{N} — Auto-generated Documentation
+
+```markdown
+## Summary
+
+Auto-generated patch notes and capability registry entry for `{source-branch}`.
+
+## Changes
+
+- `docs/capabilities.md`: added `{cap{N}}` entry
+- `docs/patch-notes.md`: added patch note for `{cap{N}}`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## gh/* — GitHub Actions Change
+
+```markdown
+## Summary
+
+- {what the workflow or script change does}
+- {why it was needed / what problem it solves}
+
+## Changes
+
+- `.github/workflows/{file}`: {what changed}
+- `.github/scripts/{file}`: {what changed}
+
+## Test plan
+
+- [ ] Workflow YAML has no syntax errors
+- [ ] Trigger condition is correct for intended events
+- [ ] Secrets and permissions are correctly scoped
+- [ ] {manual trigger test if applicable}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## claude/* — Claude Config / Skills / Memory
+
+```markdown
+## Summary
+
+- {what changed in `.claude/`, skills, workflows, or memory}
+- {why — what inconsistency or gap this addresses}
+
+## Changes
+
+- `.claude/{file}`: {what changed}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## bump: version — Release Version Bump
+
+```markdown
+## Summary
+
+Version bump for the {X.Y.Z} release.
+
+- `pyproject.toml`: `{A.B.C}` → `{X.Y.Z}`
+- `docs/patch-notes.md`: added v{X.Y.Z} release section
+
+## Caps shipping in this release
+
+{List cap IDs and titles from docs/capabilities.md that are shipping}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/.claude/workflows/feature-fix.md
+++ b/.claude/workflows/feature-fix.md
@@ -1,0 +1,151 @@
+# Feature or Bug Fix — End-to-End Playbook
+
+Follow this playbook **completely** for every `feat/cap{N}` or `bug/cap{N}` deliverable.
+Do not stop at PR creation. Do not stop at push. Finish when all completion criteria are met.
+
+---
+
+## Completion Criteria
+
+All of the following must be true before reporting done:
+
+- [ ] Tests pass locally
+- [ ] Branch pushed, PR opened with correct body (from `.claude/templates/pr-body.md`)
+- [ ] All CI checks green (`gh pr checks --watch`)
+- [ ] PR merged to staging (`gh pr merge --merge --delete-branch`)
+- [ ] `docs-generate.yml` run confirmed (or reported as queued)
+- [ ] Final summary printed to user
+
+---
+
+## Step 1 — Assign a Cap ID
+
+1. Read `docs/capabilities.md`
+2. Find the highest existing `cap{N}` ID and increment by 1
+3. Announce: **"Assigning cap{N}: {title}. Branch: `{feat|bug}/cap{N}-{slug}`."**
+
+Never reuse a cap ID. Never skip this step. Announce before branching.
+
+---
+
+## Step 2 — Branch from staging
+
+```bash
+git checkout staging && git pull origin staging
+git checkout -b {feat|bug}/cap{N}-{slug}
+```
+
+- `feat/` for new capabilities
+- `bug/` for fixes
+
+---
+
+## Step 3 — Read before editing
+
+Before touching any file:
+
+- Read every file you will modify
+- Read any file whose logic you need to understand (callers, tests, models)
+
+**Never edit a file you haven't read in this session.**
+
+---
+
+## Step 4 — Implement
+
+- Fix the root cause — not the symptom
+- Keep the diff minimal — no comments, refactors, or docstrings beyond what the task requires
+- Do not add error handling for impossible cases
+
+---
+
+## Step 5 — Run tests
+
+```bash
+cd ~/dev/cutip && uv run pytest tests/ -v --ignore=tests/e2e
+```
+
+All tests must pass before committing. If a test fails, fix it first.
+
+---
+
+## Step 6 — Commit and push
+
+```bash
+git add <specific files — never git add -A or git add .>
+git commit -m "[cap{N}] {feat|fix}: {short imperative description}"
+git push -u origin {feat|bug}/cap{N}-{slug}
+```
+
+Commit message format: `[cap007] fix: handle missing key in _validate_vars`
+
+---
+
+## Step 7 — Open PR
+
+Fill out the PR body using `.claude/templates/pr-body.md` (feat or bug section).
+Write the filled body to `/tmp/pr-body.md`, then:
+
+```bash
+gh pr create \
+  --base staging \
+  --head {feat|bug}/cap{N}-{slug} \
+  --title "[cap{N}] {description}" \
+  --body-file /tmp/pr-body.md \
+  --label "{feat|bug}" \
+  --assignee joshuajerome
+```
+
+---
+
+## Step 8 — Watch CI
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+```
+
+Wait for **all checks to pass**. If a check fails:
+
+1. Read the failure: `gh run view <run-id> --log-failed`
+2. Fix locally, push — CI reruns automatically
+3. Never merge a PR with failing checks
+
+---
+
+## Step 9 — Merge
+
+```bash
+gh pr merge <PR_NUMBER> --merge --delete-branch
+```
+
+---
+
+## Step 10 — Confirm docs-generate fired
+
+```bash
+gh run list --workflow docs-generate.yml --limit 3
+```
+
+A run should appear within ~30 seconds of the merge. If a `docs/cap{N}-*` PR was opened, note its URL.
+
+---
+
+## Step 11 — Final report
+
+```
+✓ cap{N} — {title}
+✓ Branch: {feat|bug}/cap{N}-{slug}
+✓ PR #{N} merged to staging
+✓ docs-generate: {run URL or "queued — run ID {N}"}
+  docs PR: {URL or "not yet opened"}
+```
+
+---
+
+## Rules
+
+- Never merge with failing CI
+- One cap ID per PR — never mix changes
+- Always use `[cap{N}]` prefix on commits and PR titles
+- Stage specific files — never `git add -A`
+- Never skip Step 3 (read before editing)

--- a/.claude/workflows/release.md
+++ b/.claude/workflows/release.md
@@ -1,0 +1,176 @@
+# Release — End-to-End Playbook
+
+Follow this playbook **completely** when cutting a release.
+Do not stop until the GitHub Release page is edited, assets are cleaned, and the final report is printed.
+
+---
+
+## Completion Criteria
+
+- [ ] Version bumped in `pyproject.toml`, PR merged to staging
+- [ ] `docs/patch-notes.md` updated with release section
+- [ ] `docs/capabilities.md` — all shipped caps marked `merged`
+- [ ] staging forwarded to integration (`git merge`)
+- [ ] `release/vX.Y.Z` branch pushed, `release.yml` passed
+- [ ] GitHub Release notes edited (using `.claude/templates/github-release-notes.md`)
+- [ ] Non-wheel assets removed from GitHub Release
+- [ ] Local release branch cleaned up
+- [ ] Final report printed
+
+---
+
+## Step 1 — Determine version
+
+Read current version from `pyproject.toml`.
+Ask: "What version? (current: {X.Y.Z})"
+If not specified, suggest next patch: `X.Y.{Z+1}`.
+
+---
+
+## Step 2 — Identify what's shipping
+
+Read `docs/capabilities.md`. List every cap with `status: open` or merged since the last `release/*` tag.
+These are the changes that will appear in the release notes.
+
+```bash
+git log $(git describe --tags --abbrev=0)..HEAD --oneline
+```
+
+---
+
+## Step 3 — Draft release notes
+
+Fill the template at `.claude/templates/github-release-notes.md`.
+Save the GitHub Release section to `/tmp/release-notes.md`.
+Save the patch-notes section to `/tmp/patch-note-entry.md`.
+
+Write only user-facing changes. Omit CI fixes, doc cleanups, internal refactors.
+
+---
+
+## Step 4 — Version bump PR
+
+```bash
+git checkout staging && git pull origin staging
+git checkout -b feat/bump-v{X.Y.Z}
+```
+
+Edit `pyproject.toml`:
+```toml
+version = "{X.Y.Z}"
+```
+
+Prepend `/tmp/patch-note-entry.md` content into `docs/patch-notes.md` (after the `# Patch Notes` heading).
+
+```bash
+git add pyproject.toml docs/patch-notes.md
+git commit -m "bump: version {A.B.C} → {X.Y.Z}"
+git push -u origin feat/bump-v{X.Y.Z}
+
+gh pr create \
+  --base staging \
+  --title "bump: version {A.B.C} → {X.Y.Z}" \
+  --body "Version bump for the {X.Y.Z} release." \
+  --assignee joshuajerome
+```
+
+Watch CI, then merge:
+```bash
+gh pr checks <PR_NUMBER> --watch
+gh pr merge <PR_NUMBER> --merge --delete-branch
+```
+
+---
+
+## Step 5 — Update capabilities.md
+
+Ensure all shipped caps have `status: merged` and the correct PR number.
+If any are still `open`, update them now on a `docs/*` branch or inline with the bump commit.
+
+---
+
+## Step 6 — Forward staging → integration
+
+```bash
+git checkout integration && git pull origin integration
+git merge origin/staging --no-edit
+git push origin integration
+```
+
+---
+
+## Step 7 — Cut the release branch
+
+```bash
+git checkout -b release/v{X.Y.Z} origin/integration
+git push -u origin release/v{X.Y.Z}
+```
+
+Watch the release workflow until it completes:
+```bash
+gh run watch $(gh run list --branch release/v{X.Y.Z} --workflow release.yml \
+  --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+If `release.yml` fails, read the logs before retrying:
+```bash
+gh run view <run-id> --log-failed
+```
+
+---
+
+## Step 8 — Edit the GitHub Release page
+
+After `release.yml` completes, update the release notes:
+```bash
+gh release edit v{X.Y.Z} --notes "$(cat /tmp/release-notes.md)"
+```
+
+Remove non-wheel assets (keep only `.whl`):
+```bash
+gh api repos/joshuajerome/cutip/releases/tags/v{X.Y.Z} \
+  --jq '.assets[] | select(.name | test("whl") | not) | .id' \
+  | while read id; do
+      gh api repos/joshuajerome/cutip/releases/assets/$id --method DELETE
+    done
+```
+
+Verify the release page looks correct:
+```bash
+gh release view v{X.Y.Z}
+```
+
+---
+
+## Step 9 — Clean up local branches
+
+```bash
+git checkout integration
+git branch -d feat/bump-v{X.Y.Z} 2>/dev/null || true
+```
+
+`release/*` branches are **permanent** — never delete them locally or remotely.
+
+---
+
+## Step 10 — Final report
+
+```
+✓ Version bumped: {A.B.C} → {X.Y.Z}
+✓ docs/patch-notes.md updated
+✓ docs/capabilities.md — all shipped caps marked merged
+✓ staging → integration forwarded
+✓ release/v{X.Y.Z} pushed — release.yml passed
+✓ GitHub Release: https://github.com/joshuajerome/cutip/releases/tag/v{X.Y.Z}
+✓ Assets: cutip-{X.Y.Z}-py3-none-any.whl (only)
+```
+
+---
+
+## Rules
+
+- Never push directly to `integration` — always merge staging in
+- The release branch is created from `integration`, not staging
+- `release/*` branches are permanent — never delete them
+- Do not tag manually — `release.yml` creates the git tag via `softprops/action-gh-release`
+- If `release.yml` fails, investigate logs before retrying

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,24 @@
 
 **Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments with structured YAML artifacts and Python workflows. **Podman is the only supported backend** (docker support was removed).
 
+## Deliverables — End-to-End Mandate
+
+When asked to implement a feature, fix a bug, or cut a release, **complete the full workflow**.
+Do not stop at writing code. Do not stop at opening a PR. Finish when every completion criterion is met.
+
+| Task type | Playbook | Template |
+|-----------|----------|----------|
+| Feature / bug fix | `.claude/workflows/feature-fix.md` | `.claude/templates/pr-body.md` |
+| Release | `.claude/workflows/release.md` | `.claude/templates/github-release-notes.md` |
+| Resolve issues | `.claude/skills/resolve-issues.md` | `.claude/templates/pr-body.md` |
+
+**Always read the playbook before starting. Always use the template for PRs and release notes.**
+
+The only valid stopping points before completion are:
+- A test is failing and the fix is not clear — report and ask
+- A required manual action (GitHub web UI, auth) — report exactly what the user must do, then continue everything else
+- The user explicitly asks you to stop
+
 ## Key Conventions
 
 - **Never auto-commit.** Only commit when explicitly asked.


### PR DESCRIPTION
## Summary

- Adds `.claude/workflows/feature-fix.md` — complete step-by-step playbook Claude follows for every `feat/bug` deliverable, with explicit completion criteria (branch → read before edit → test → commit → open PR with template → watch CI → merge → confirm docs-generate)
- Adds `.claude/workflows/release.md` — complete release playbook (version bump PR → patch-notes → staging→integration forward → release branch → watch `release.yml` → edit GitHub Release notes → clean assets → final report)
- Adds `.claude/templates/pr-body.md` — fill-in templates for feat, bug, docs, gh, claude, and version-bump PR types; Claude must use these for every PR
- Adds `.claude/templates/github-release-notes.md` — template for the GitHub Release page body and `docs/patch-notes.md` entry with a pre-submit checklist
- Updates `CLAUDE.md` with a **Deliverables — End-to-End Mandate** section at the top: lookup table maps each task type to the correct playbook and template; defines the only valid stopping points

## Test plan

- [ ] Open a new conversation and ask Claude to implement a feature — verify it reads `feature-fix.md` and completes through PR merge
- [ ] Ask Claude to cut a release — verify it reads `release.md` and completes through GitHub Release edit
- [ ] Verify PR bodies match the templates in `pr-body.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
