### PR TITLE
Enforce PR assignee/label and capability-focused release notes

### DIFF
--- a/.claude/templates/github-release-notes.md
+++ b/.claude/templates/github-release-notes.md
@@ -5,6 +5,11 @@ Use this when running `gh release edit vX.Y.Z --notes "..."`.
 Fill every `{placeholder}`. Write only user-facing changes.
 Omit: CI fixes, doc cleanups, internal refactors, test changes.
 
+**Format rules:**
+- List capabilities added/fixed — one bullet per cap ID
+- Do not list individual PRs, authors, or "What's Changed" auto-generated content
+- Replace any GitHub-generated release notes entirely with this template
+
 ---
 
 ## GitHub Release page body

--- a/.claude/templates/pr-body.md
+++ b/.claude/templates/pr-body.md
@@ -3,6 +3,10 @@
 Copy the section matching your branch type. Fill every `{placeholder}`.
 Write the filled body to `/tmp/pr-body.md` and pass `--body-file /tmp/pr-body.md` to `gh pr create`.
 
+**Every PR must include:**
+- `--assignee joshuajerome` — always
+- `--label {feat|bug|docs|gh|claude}` — always, matching the branch type
+
 ---
 
 ## feat/cap{N} — New Feature

--- a/.claude/workflows/feature-fix.md
+++ b/.claude/workflows/feature-fix.md
@@ -96,6 +96,8 @@ gh pr create \
   --assignee joshuajerome
 ```
 
+`--assignee` and `--label` are **required on every PR** — never omit them.
+
 ---
 
 ## Step 8 — Watch CI

--- a/.claude/workflows/release.md
+++ b/.claude/workflows/release.md
@@ -121,7 +121,11 @@ gh run view <run-id> --log-failed
 
 ## Step 8 — Edit the GitHub Release page
 
-After `release.yml` completes, update the release notes:
+After `release.yml` completes, update the release notes using the template at
+`.claude/templates/github-release-notes.md`. The release description must list
+capabilities added/fixed — do not list individual PRs, authors, or retain the
+GitHub-generated "What's Changed" content.
+
 ```bash
 gh release edit v{X.Y.Z} --notes "$(cat /tmp/release-notes.md)"
 ```


### PR DESCRIPTION
## Summary

- PRs must always include \`--assignee\` and \`--label\` — noted in \`pr-body.md\` and \`feature-fix.md\`
- Release descriptions list capabilities added/fixed only — no individual PRs, authors, or GitHub-generated content — noted in \`github-release-notes.md\` and \`release.md\`

## Changes

- \`.claude/templates/pr-body.md\`: added mandatory assignee/label rule at top
- \`.claude/workflows/feature-fix.md\`: reinforced assignee/label on \`gh pr create\`
- \`.claude/templates/github-release-notes.md\`: added format rules block
- \`.claude/workflows/release.md\`: added release notes format note at Step 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)