### PR TITLE
add Jenkins pipelines, e2e playbook expansion, and release terminology

### DIFF
--- a/.claude/templates/github-release-notes.md
+++ b/.claude/templates/github-release-notes.md
@@ -18,10 +18,15 @@ Omit: CI fixes, doc cleanups, internal refactors, test changes.
 Container Unit Templates in Python — deterministic framework for building
 and orchestrating Podman container workloads.
 
-## What's Changed
+## Features
 
-- **{cap{N}} — {title}**: {one sentence — what the user can now do or what error is fixed}
-- **{cap{M}} — {title}**: {one sentence — what the user can now do or what error is fixed}
+- **cap{N} — {title}**: {one sentence — what the user can now do}
+- **cap{M} — {title}**: {one sentence — what the user can now do}
+
+## Patch Notes
+
+- **cap{P} — {title}**: {one sentence — what error is fixed}
+- **cap{Q} — {title}**: {one sentence — what error is fixed}
 
 ## Installation
 
@@ -38,6 +43,9 @@ pip install cutip-{X.Y.Z}-py3-none-any.whl
 **Full Changelog**: https://github.com/joshuajerome/cutip/compare/v{A.B.C}...v{X.Y.Z}
 ```
 
+Omit `## Features` entirely if no `feat/*` caps shipped in this release.
+Omit `## Patch Notes` entirely if no `bug/*` caps shipped in this release.
+
 ---
 
 ## docs/patch-notes.md entry
@@ -47,22 +55,28 @@ Prepend this block after the `# Patch Notes` heading in `docs/patch-notes.md`:
 ```markdown
 ## v{X.Y.Z} ({YYYY-MM-DD})
 
-### cap{N} — {title}
+### Features
 
-- {what changed from a user perspective}
-- {behavioral impact — what was broken, what now works}
+- **cap{N}** — {title}: {what changed from a user perspective}
+- **cap{M}** — {title}: {what the user can now do}
 
-### cap{M} — {title}
+### Patch Notes
 
-- {what changed from a user perspective}
+- **cap{P}** — {title}: {what was broken, what now works}
+- **cap{Q}** — {title}: {behavioral impact}
 ```
+
+Omit `### Features` if no feat caps. Omit `### Patch Notes` if no bug caps.
 
 ---
 
 ## Checklist before saving
 
 - [ ] Every shipped cap ID appears exactly once
+- [ ] feat/* caps are in `## Features`; bug/* caps are in `## Patch Notes`
+- [ ] Sections with no caps are omitted entirely
 - [ ] No mention of CI, docs, or internal-only changes
+- [ ] No PR numbers, authors, or GitHub-generated content
 - [ ] Installation commands use the correct version number
 - [ ] Full Changelog URL uses the previous tag as the base (`v{A.B.C}`)
 - [ ] patch-notes.md entry is prepended (not appended)

--- a/.claude/workflows/feature-fix.md
+++ b/.claude/workflows/feature-fix.md
@@ -10,11 +10,14 @@ Do not stop at PR creation. Do not stop at push. Finish when all completion crit
 All of the following must be true before reporting done:
 
 - [ ] Tests pass locally
-- [ ] Branch pushed, PR opened with correct body (from `.claude/templates/pr-body.md`)
-- [ ] All CI checks green (`gh pr checks --watch`)
-- [ ] PR merged to staging (`gh pr merge --merge --delete-branch`)
-- [ ] `docs-generate.yml` run confirmed (or reported as queued)
-- [ ] Final summary printed to user
+- [ ] PR opened with correct body, assignee, and label
+- [ ] All CI checks green
+- [ ] PR merged to staging
+- [ ] docs-generate fired (confirmed or N/A for non-feat/bug branches)
+- [ ] docs PR merged (if one was created)
+- [ ] staging forwarded to integration
+- [ ] Merged branch pruned locally
+- [ ] Final summary printed
 
 ---
 
@@ -122,24 +125,53 @@ gh pr merge <PR_NUMBER> --merge --delete-branch
 
 ---
 
-## Step 10 — Confirm docs-generate fired
+## Step 10 — Wait for docs-generate and merge docs PR
 
 ```bash
+# Wait for docs-generate run (fires within ~30s of merge for feat/* and bug/*)
 gh run list --workflow docs-generate.yml --limit 3
 ```
 
-A run should appear within ~30 seconds of the merge. If a `docs/cap{N}-*` PR was opened, note its URL.
+If a `docs/cap{N}-*` PR was opened, watch its CI and merge it:
+
+```bash
+gh pr checks <DOCS_PR_NUMBER> --watch
+gh pr merge <DOCS_PR_NUMBER> --merge --delete-branch
+```
+
+Note: docs-generate only fires for `feat/*` and `bug/*` merges. If no docs PR is created, mark this step N/A.
 
 ---
 
-## Step 11 — Final report
+## Step 11 — Forward staging → integration
+
+```bash
+git checkout integration && git pull origin integration
+git merge origin/staging --no-edit
+git push origin integration
+```
+
+---
+
+## Step 12 — Prune merged branches
+
+```bash
+git fetch --prune
+git branch -d {feat|bug}/cap{N}-{slug} 2>/dev/null || true
+```
+
+---
+
+## Step 13 — Final report
 
 ```
 ✓ cap{N} — {title}
 ✓ Branch: {feat|bug}/cap{N}-{slug}
 ✓ PR #{N} merged to staging
-✓ docs-generate: {run URL or "queued — run ID {N}"}
-  docs PR: {URL or "not yet opened"}
+✓ docs-generate: {run URL or "N/A"}
+  docs PR: {URL and merged, or "N/A"}
+✓ staging forwarded to integration
+✓ Branch pruned locally
 ```
 
 ---
@@ -151,3 +183,4 @@ A run should appear within ~30 seconds of the merge. If a `docs/cap{N}-*` PR was
 - Always use `[cap{N}]` prefix on commits and PR titles
 - Stage specific files — never `git add -A`
 - Never skip Step 3 (read before editing)
+- When asked to raise a PR, complete the entire e2e: PR → GHA → staging → integration → branch prune

--- a/jenkins/build.Jenkinsfile
+++ b/jenkins/build.Jenkinsfile
@@ -1,0 +1,94 @@
+// build.Jenkinsfile
+// Triggered on push to feat/** or bug/** branches (or PR targeting staging).
+// Mirrors GHA pr-checks.yml + wheel-build.yml.
+
+pipeline {
+    agent any
+
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        buildDiscarder(logRotator(numToKeepStr: '20'))
+    }
+
+    triggers {
+        // Trigger on push to feat/** or bug/** via SCM webhook
+        // Configure branch filter in Jenkins SCM plugin or Multibranch Pipeline
+        pollSCM('')
+    }
+
+    environment {
+        PYTHONUTF8 = '1'
+        CUTIP_BACKEND_NAME = 'podman'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Install Dependencies') {
+            steps {
+                sh 'uv sync'
+            }
+        }
+
+        stage('Unit Tests') {
+            steps {
+                sh 'uv run pytest tests/ -v --ignore=tests/e2e --tb=short'
+            }
+            post {
+                always {
+                    // Archive JUnit XML if pytest-junit is configured
+                    junit allowEmptyResults: true, testResults: 'test-results.xml'
+                }
+            }
+        }
+
+        stage('Smoke Test') {
+            steps {
+                sh '''
+                    uv build --wheel
+                    uv venv .wheel-test
+                    uv pip install --python .wheel-test/bin/python dist/cutip-*.whl
+                    .wheel-test/bin/python -c "import cutip; print('cutip import OK')"
+                    .wheel-test/bin/cutip --help
+                '''
+            }
+        }
+
+        stage('E2E (Ubuntu / Podman)') {
+            steps {
+                sh '''
+                    uv venv .venv
+                    uv pip install -e .
+                    uv run cutip validate --path tests/e2e/hello-world
+                    uv run cutip run hello --path tests/e2e/hello-world --local
+                '''
+            }
+        }
+
+        stage('Build Wheel') {
+            steps {
+                sh 'uv build --wheel'
+                sh 'ls -lh dist/'
+            }
+            post {
+                success {
+                    archiveArtifacts artifacts: 'dist/*.whl', fingerprint: true
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // Clean up ephemeral venvs
+            sh 'rm -rf .wheel-test .venv dist/ 2>/dev/null || true'
+        }
+        failure {
+            echo "Build failed — check console output above for details."
+        }
+    }
+}

--- a/jenkins/docs.Jenkinsfile
+++ b/jenkins/docs.Jenkinsfile
@@ -1,0 +1,99 @@
+// docs.Jenkinsfile
+// Triggered on push to staging (after feat/bug merge) or push to docs/**.
+// Full documentation verification and deployment pipeline.
+// Agent must have git configured with push access to the repo.
+
+pipeline {
+    agent any
+
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        buildDiscarder(logRotator(numToKeepStr: '20'))
+    }
+
+    environment {
+        PYTHONUTF8 = '1'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+                // Full history required for mkdocs gh-deploy
+                sh 'git fetch --unshallow 2>/dev/null || true'
+            }
+        }
+
+        stage('Install Dependencies') {
+            steps {
+                sh '''
+                    uv venv .venv
+                    uv pip install -e ".[docs]"
+                '''
+            }
+        }
+
+        stage('Analyze Code Changes') {
+            steps {
+                sh '''
+                    git diff HEAD~1 --name-only -- "*.py" > /tmp/changed_files.txt
+                    echo "Changed Python files:"
+                    cat /tmp/changed_files.txt
+                    python3 jenkins/scripts/analyze-doc-coverage.py
+                '''
+            }
+        }
+
+        stage('Scan Documentation for Outdated Content') {
+            steps {
+                sh 'python3 jenkins/scripts/scan-outdated-docs.py'
+            }
+        }
+
+        stage('Scan for Vulnerabilities in Documentation') {
+            steps {
+                sh 'python3 jenkins/scripts/scan-doc-vulnerabilities.py'
+            }
+        }
+
+        stage('Update README.md if Needed') {
+            steps {
+                sh 'python3 jenkins/scripts/update-readme.py'
+            }
+        }
+
+        stage('Update GitHub Pages') {
+            steps {
+                sh 'uv run mkdocs gh-deploy --force'
+            }
+        }
+
+        stage('Build with MkDocs & Verify') {
+            steps {
+                sh 'uv run mkdocs build --strict'
+                sh '''
+                    python3 -m http.server 8000 --directory site &
+                    SERVER_PID=$!
+                    sleep 2
+                    curl -f http://localhost:8000/ > /dev/null
+                    curl -f http://localhost:8000/getting-started/installation/ > /dev/null
+                    kill $SERVER_PID 2>/dev/null || true
+                '''
+            }
+            post {
+                always {
+                    sh 'pkill -f "http.server 8000" 2>/dev/null || true'
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            sh 'rm -rf .venv site/ 2>/dev/null || true'
+        }
+        failure {
+            echo "Docs pipeline failed — check console output above for details."
+        }
+    }
+}

--- a/jenkins/scripts/analyze-doc-coverage.py
+++ b/jenkins/scripts/analyze-doc-coverage.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+analyze-doc-coverage.py
+
+Cross-reference changed Python source files (from /tmp/changed_files.txt)
+against docs/ to identify undocumented modules.
+
+Exit 0 — report printed; pipeline continues regardless (informational stage).
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+CHANGED_FILES_PATH = "/tmp/changed_files.txt"
+DOCS_DIR = Path("docs")
+REPO_ROOT = Path(".")
+
+
+def load_changed_files() -> list[str]:
+    if not os.path.exists(CHANGED_FILES_PATH):
+        print("[analyze-doc-coverage] No changed files list found — skipping.")
+        return []
+    with open(CHANGED_FILES_PATH) as f:
+        return [line.strip() for line in f if line.strip().endswith(".py")]
+
+
+def load_docs_content() -> str:
+    """Return concatenated text of all markdown files under docs/."""
+    if not DOCS_DIR.exists():
+        return ""
+    parts = []
+    for md_file in DOCS_DIR.rglob("*.md"):
+        parts.append(md_file.read_text(errors="replace"))
+    return "\n".join(parts)
+
+
+def module_name_from_path(py_path: str) -> str:
+    """Convert a file path like cutip/models/group.py → cutip.models.group."""
+    return py_path.replace("/", ".").removesuffix(".py")
+
+
+def main() -> None:
+    changed = load_changed_files()
+    if not changed:
+        print("[analyze-doc-coverage] No Python files changed — nothing to check.")
+        return
+
+    docs_text = load_docs_content()
+    gaps: list[str] = []
+
+    for py_file in changed:
+        module = module_name_from_path(py_file)
+        # Check for any mention of the module path or leaf name in docs
+        leaf = py_file.split("/")[-1].removesuffix(".py")
+        mentioned = (
+            py_file in docs_text
+            or module in docs_text
+            or leaf in docs_text
+        )
+        if not mentioned:
+            gaps.append(py_file)
+
+    print(f"\n[analyze-doc-coverage] Changed Python files: {len(changed)}")
+    print(f"[analyze-doc-coverage] Undocumented in docs/: {len(gaps)}")
+
+    if gaps:
+        print("\nThe following changed modules have no reference in docs/:")
+        for g in gaps:
+            print(f"  - {g}")
+        print(
+            "\nAction: Consider adding or updating documentation for these modules."
+        )
+    else:
+        print("All changed modules are referenced in docs/. No gaps found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/scan-doc-vulnerabilities.py
+++ b/jenkins/scripts/scan-doc-vulnerabilities.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+scan-doc-vulnerabilities.py
+
+Scan docs/ for:
+  - Accidental credential / token patterns (HIGH)
+  - Internal / private path leakage (MEDIUM)
+  - Broken external links (LOW — HTTP GET with timeout)
+
+Exit 0 — low/medium findings only (printed as warnings).
+Exit 1 — any HIGH-severity finding detected.
+"""
+
+import re
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+DOCS_DIR = Path("docs")
+LINK_TIMEOUT_SECONDS = 5
+
+# Credential patterns: (regex, label)
+CREDENTIAL_PATTERNS: list[tuple[str, str]] = [
+    (r"password\s*[:=]\s*\S+", "password assignment"),
+    (r"secret\s*[:=]\s*\S+", "secret assignment"),
+    (r"api[_-]?key\s*[:=]\s*\S+", "API key"),
+    (r"token\s*[:=]\s*\S+", "token assignment"),
+    (r"ssh-rsa\s+[A-Za-z0-9+/]{20,}", "SSH public key literal"),
+    (r"-----BEGIN [A-Z ]+PRIVATE KEY-----", "private key block"),
+    (r"ghp_[A-Za-z0-9]{36,}", "GitHub PAT"),
+    (r"sk-[A-Za-z0-9]{32,}", "OpenAI / Anthropic API key"),
+]
+
+# Private path patterns: (regex, label)
+PRIVATE_PATH_PATTERNS: list[tuple[str, str]] = [
+    (r"/Users/[a-zA-Z0-9._-]+/", "macOS user home path"),
+    (r"/home/[a-zA-Z0-9._-]+/", "Linux user home path"),
+    (r"C:\\Users\\[a-zA-Z0-9._-]+\\", "Windows user home path"),
+    (r"192\.168\.\d+\.\d+", "private IP address (192.168.x.x)"),
+    (r"10\.\d+\.\d+\.\d+", "private IP address (10.x.x.x)"),
+]
+
+EXTERNAL_LINK_RE = re.compile(r"https?://[^\s\)\]\"']+")
+
+# Domains to skip for link checking (known slow or auth-gated)
+SKIP_LINK_DOMAINS = {"localhost", "127.0.0.1", "example.com"}
+
+
+def extract_links(text: str) -> list[str]:
+    return EXTERNAL_LINK_RE.findall(text)
+
+
+def check_link(url: str) -> bool:
+    """Return True if URL responds with HTTP 2xx/3xx, False otherwise."""
+    for domain in SKIP_LINK_DOMAINS:
+        if domain in url:
+            return True
+    try:
+        req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "cutip-docs-scanner/1.0"})
+        with urllib.request.urlopen(req, timeout=LINK_TIMEOUT_SECONDS) as resp:
+            return resp.status < 400
+    except Exception:
+        return False
+
+
+def scan_file(md_file: Path, check_links: bool) -> dict:
+    text = md_file.read_text(errors="replace")
+    lines = text.splitlines()
+    hits: dict[str, list] = {"HIGH": [], "MEDIUM": [], "LOW": []}
+
+    for lineno, line in enumerate(lines, start=1):
+        # Credential patterns
+        for pattern, label in CREDENTIAL_PATTERNS:
+            if re.search(pattern, line, re.IGNORECASE):
+                # Skip lines that look like template placeholders or comments showing format
+                if re.search(r"\{[^}]+\}|<[^>]+>|^\s*#", line):
+                    continue
+                hits["HIGH"].append((lineno, f"Credential leak ({label}): {line.strip()[:120]}"))
+
+        # Private path patterns
+        for pattern, label in PRIVATE_PATH_PATTERNS:
+            if re.search(pattern, line):
+                # Skip if it looks like it's inside a code block showing a variable
+                if "vars." in line or "{{" in line:
+                    continue
+                hits["MEDIUM"].append((lineno, f"Private path ({label}): {line.strip()[:120]}"))
+
+    # Broken links
+    if check_links:
+        links = extract_links(text)
+        for url in links:
+            if not check_link(url):
+                hits["LOW"].append((0, f"Broken link: {url}"))
+
+    return hits
+
+
+def main() -> int:
+    if not DOCS_DIR.exists():
+        print("[scan-doc-vulnerabilities] docs/ directory not found — skipping.")
+        return 0
+
+    # Link checking can be slow; skip if there are many docs
+    md_files = sorted(DOCS_DIR.rglob("*.md"))
+    check_links = len(md_files) <= 20  # Only check links for small doc sets
+
+    total_high = 0
+    total_medium = 0
+    total_low = 0
+    any_hit = False
+
+    for md_file in md_files:
+        hits = scan_file(md_file, check_links)
+        for severity, entries in hits.items():
+            for lineno, message in entries:
+                any_hit = True
+                loc = f"{md_file}:{lineno}" if lineno else str(md_file)
+                print(f"  [{severity}] {loc} — {message}")
+                if severity == "HIGH":
+                    total_high += 1
+                elif severity == "MEDIUM":
+                    total_medium += 1
+                else:
+                    total_low += 1
+
+    if not any_hit:
+        print("[scan-doc-vulnerabilities] No vulnerabilities found.")
+        return 0
+
+    print(
+        f"\n[scan-doc-vulnerabilities] Summary: "
+        f"HIGH={total_high} MEDIUM={total_medium} LOW={total_low}"
+    )
+    if total_high > 0:
+        print("HIGH-severity findings must be resolved before merging.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/jenkins/scripts/scan-outdated-docs.py
+++ b/jenkins/scripts/scan-outdated-docs.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+scan-outdated-docs.py
+
+Scan docs/ for stale references: removed CLI flags, removed backend names,
+renamed classes/paths, and deprecated APIs.
+
+Exit 0 — findings are warnings only; pipeline continues.
+Exit 1 — if any HIGH-severity stale references are found.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+DOCS_DIR = Path("docs")
+
+# Each entry: (pattern, severity, reason)
+STALE_PATTERNS: list[tuple[str, str, str]] = [
+    # Removed Docker backend
+    (r"\bdocker\b", "HIGH", "docker support was removed; Podman is the only backend"),
+    (r"DockerBackend", "HIGH", "DockerBackend was removed"),
+    (r"--backend\s+docker", "HIGH", "docker backend flag no longer valid"),
+
+    # Renamed directories
+    (r"\bcontainers/resources\b", "HIGH", "renamed to resources/buildtime/"),
+    (r"\bcontainers/\b(?!card)", "MEDIUM", "containers/ directory renamed to resources/"),
+
+    # Renamed group names
+    (r"\bgroup:\s*main\b", "MEDIUM", "group 'main' renamed to 'snf-gui' or 'snf-blueprint-manager'"),
+
+    # Old CLI flags or commands that may have changed
+    (r"cutip\s+run\s+main\b", "MEDIUM", "group 'main' no longer exists"),
+
+    # Deprecated vars.yaml format (flat, no required:/generated: sections)
+    (r"^\s{0,4}\w+:\s+\"\".*#.*required", "LOW", "old flat vars.yaml format; use required:/generated: sections"),
+]
+
+
+def scan_file(md_file: Path) -> list[tuple[str, int, str, str]]:
+    """Return list of (file, line_num, severity, reason) for each hit."""
+    hits = []
+    lines = md_file.read_text(errors="replace").splitlines()
+    for lineno, line in enumerate(lines, start=1):
+        for pattern, severity, reason in STALE_PATTERNS:
+            if re.search(pattern, line, re.IGNORECASE):
+                hits.append((str(md_file), lineno, severity, reason))
+    return hits
+
+
+def main() -> int:
+    if not DOCS_DIR.exists():
+        print("[scan-outdated-docs] docs/ directory not found — skipping.")
+        return 0
+
+    all_hits: list[tuple[str, int, str, str]] = []
+    for md_file in sorted(DOCS_DIR.rglob("*.md")):
+        all_hits.extend(scan_file(md_file))
+
+    if not all_hits:
+        print("[scan-outdated-docs] No stale references found.")
+        return 0
+
+    high = [h for h in all_hits if h[2] == "HIGH"]
+    medium = [h for h in all_hits if h[2] == "MEDIUM"]
+    low = [h for h in all_hits if h[2] == "LOW"]
+
+    print(f"\n[scan-outdated-docs] Found {len(all_hits)} stale reference(s):")
+    print(f"  HIGH: {len(high)}  MEDIUM: {len(medium)}  LOW: {len(low)}\n")
+
+    for file, lineno, severity, reason in all_hits:
+        print(f"  [{severity}] {file}:{lineno} — {reason}")
+
+    if high:
+        print(
+            "\nHIGH-severity stale references must be resolved before merging."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/jenkins/scripts/update-readme.py
+++ b/jenkins/scripts/update-readme.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+update-readme.py
+
+Detect README drift from the live CLI output.
+
+Checks:
+  1. Whether `cutip --help` output matches what's embedded in README.md.
+  2. Whether install instructions in README.md reference an outdated version.
+
+If drift is found:
+  - Prints a diff of what changed.
+  - Writes the updated CLI help block to /tmp/readme-help-updated.txt for manual review.
+  - Exits 0 (informational — does not fail the pipeline; a human or follow-up
+    automation creates the docs/readme-update branch).
+
+Exit 1 only if README.md is missing entirely.
+"""
+
+import re
+import subprocess
+import sys
+import difflib
+from pathlib import Path
+
+README_PATH = Path("README.md")
+
+# Marker comments that delimit the CLI help block in README.md
+HELP_BLOCK_START = "<!-- cutip-help-start -->"
+HELP_BLOCK_END = "<!-- cutip-help-end -->"
+
+
+def get_live_help() -> str:
+    """Run `cutip --help` and return its stdout."""
+    try:
+        result = subprocess.run(
+            ["uv", "run", "cutip", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.stdout.strip()
+    except Exception as exc:
+        print(f"[update-readme] Could not run `cutip --help`: {exc}")
+        return ""
+
+
+def extract_help_block(readme_text: str) -> str | None:
+    """Extract the CLI help block delimited by marker comments, if present."""
+    start_idx = readme_text.find(HELP_BLOCK_START)
+    end_idx = readme_text.find(HELP_BLOCK_END)
+    if start_idx == -1 or end_idx == -1:
+        return None
+    inner = readme_text[start_idx + len(HELP_BLOCK_START): end_idx]
+    # Strip surrounding code fences if present
+    inner = inner.strip()
+    if inner.startswith("```"):
+        inner = re.sub(r"^```[a-z]*\n?", "", inner)
+        inner = re.sub(r"\n?```$", "", inner)
+    return inner.strip()
+
+
+def main() -> int:
+    if not README_PATH.exists():
+        print("[update-readme] README.md not found — skipping.")
+        return 1
+
+    readme_text = README_PATH.read_text()
+
+    # --- Check 1: CLI help block ---
+    embedded_help = extract_help_block(readme_text)
+    if embedded_help is None:
+        print(
+            f"[update-readme] No CLI help block found in README.md "
+            f"(add {HELP_BLOCK_START} / {HELP_BLOCK_END} markers to enable drift detection)."
+        )
+    else:
+        live_help = get_live_help()
+        if live_help and live_help != embedded_help:
+            diff = list(
+                difflib.unified_diff(
+                    embedded_help.splitlines(keepends=True),
+                    live_help.splitlines(keepends=True),
+                    fromfile="README.md (embedded)",
+                    tofile="cutip --help (live)",
+                )
+            )
+            print("[update-readme] CLI help drift detected:\n")
+            print("".join(diff[:80]))  # Cap output to first 80 diff lines
+            Path("/tmp/readme-help-updated.txt").write_text(live_help)
+            print(
+                "\n[update-readme] Updated help written to /tmp/readme-help-updated.txt. "
+                "Create a docs/readme-update branch and replace the block manually."
+            )
+        else:
+            print("[update-readme] CLI help block is up to date.")
+
+    # --- Check 2: Install version ---
+    version_match = re.search(
+        r"pip install cutip==([0-9]+\.[0-9]+\.[0-9]+)", readme_text
+    )
+    if version_match:
+        readme_version = version_match.group(1)
+        # Read version from pyproject.toml
+        pyproject = Path("pyproject.toml")
+        if pyproject.exists():
+            pyproject_text = pyproject.read_text()
+            pkg_version_match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject_text, re.MULTILINE)
+            if pkg_version_match:
+                pkg_version = pkg_version_match.group(1)
+                if readme_version != pkg_version:
+                    print(
+                        f"[update-readme] Install version drift: "
+                        f"README says {readme_version}, pyproject.toml says {pkg_version}. "
+                        f"Update README.md install instructions."
+                    )
+                else:
+                    print(f"[update-readme] Install version ({readme_version}) matches pyproject.toml.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -252,7 +252,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
## Summary

- Adds Jenkins `build` and `docs` declarative pipelines mirroring the GHA workflows
- Expands the feature-fix playbook to mandate full e2e through integration forward and branch prune
- Updates the release notes template to use capability-typed "Features" and "Patch Notes" sections instead of "What's Changed"

## Changes

- `jenkins/build.Jenkinsfile`: 6-stage pipeline (Checkout → Install → Unit Tests → Smoke Test → E2E → Build Wheel); mirrors `pr-checks.yml` + `wheel-build.yml`
- `jenkins/docs.Jenkinsfile`: 8-stage pipeline (Checkout → Install → Analyze Coverage → Scan Outdated → Scan Vulnerabilities → Update README → gh-deploy → Build & Verify); triggers on staging push or `docs/**`
- `jenkins/scripts/analyze-doc-coverage.py`: cross-references changed `.py` files against `docs/` for documentation gaps
- `jenkins/scripts/scan-outdated-docs.py`: finds stale references (removed docker backend, renamed dirs/groups); exits 1 on HIGH severity
- `jenkins/scripts/scan-doc-vulnerabilities.py`: credential regex + private path leak + broken link detection; exits 1 on HIGH severity
- `jenkins/scripts/update-readme.py`: detects CLI help block drift and install version drift; informational
- `.claude/workflows/feature-fix.md`: added Steps 10–12 (docs PR merge, staging→integration forward, branch prune), updated completion criteria, added e2e mandate rule
- `.claude/templates/github-release-notes.md`: replaced `## What's Changed` with `## Features` (feat/* caps) + `## Patch Notes` (bug/* caps); updated patch-notes.md entry format to split by type

## Test plan

- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes
- [ ] Jenkins pipeline YAML syntax validates via declarative linter
- [ ] Python scripts pass `ast.parse()` syntax check (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
