### PR TITLE
use ANTHROPIC_API_KEY credential ID, add Claude AI summary stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ site/
 .claude/settings.local.json
 # Git worktrees created by Claude Code live here; never commit them.
 .claude/worktrees/
+
+# ── Jenkins AI Reports ────────────────────────────────────────────────────────
+# claude-reports/ is written at runtime by .jenkins/scripts/* and archived as
+# Jenkins build artifacts. Never commit it.
+claude-reports/

--- a/.jenkins/docs.Jenkinsfile
+++ b/.jenkins/docs.Jenkinsfile
@@ -1,7 +1,11 @@
 // .jenkins/docs.Jenkinsfile
 // Triggered on push to staging (after feat/bug merge) or push to docs/**.
 // Full AI-driven docs verification and deployment pipeline.
-// Requires ANTHROPIC_API_KEY credential configured in Jenkins.
+//
+// Jenkins credentials required (ID must match exactly):
+//   ANTHROPIC_API_KEY  - Anthropic API key (mirror of the GitHub repository secret)
+//   GITHUB_TOKEN       - GitHub PAT with repo scope (for posting PR comments)
+//
 // Agent must have git configured with push access to the repo.
 
 pipeline {
@@ -13,9 +17,9 @@ pipeline {
     }
 
     environment {
-        PYTHONUTF8 = '1'
-        // Bind the Jenkins credential named 'anthropic-api-key' to the env var
-        ANTHROPIC_API_KEY = credentials('anthropic-api-key')
+        PYTHONUTF8        = '1'
+        ANTHROPIC_API_KEY = credentials('ANTHROPIC_API_KEY')
+        GH_TOKEN          = credentials('GITHUB_TOKEN')
     }
 
     stages {
@@ -24,6 +28,8 @@ pipeline {
                 checkout scm
                 // Full history required for mkdocs gh-deploy and git diff
                 sh 'git fetch --unshallow 2>/dev/null || true'
+                // Reports directory — written by AI scripts, archived as artifacts
+                sh 'mkdir -p claude-reports'
             }
         }
 
@@ -66,6 +72,55 @@ pipeline {
             }
         }
 
+        stage('Claude AI Summary') {
+            steps {
+                sh '''
+                    SUMMARY=claude-reports/summary.md
+                    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+                    RUN_DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
+
+                    # Compile all per-script reports into one summary
+                    {
+                        echo "## Claude Documentation Summary"
+                        echo ""
+                        echo "Branch: \`${BRANCH}\` | Run: ${RUN_DATE}"
+                        echo ""
+                        for report in \
+                            claude-reports/analyze-doc-coverage.md \
+                            claude-reports/scan-outdated-docs.md \
+                            claude-reports/scan-doc-vulnerabilities.md \
+                            claude-reports/update-readme.md; do
+                            if [ -f "$report" ]; then
+                                echo "---"
+                                echo "### $(basename $report .md)"
+                                echo ""
+                                cat "$report"
+                                echo ""
+                            fi
+                        done
+                    } > "$SUMMARY"
+
+                    echo "=== Claude AI Summary ==="
+                    cat "$SUMMARY"
+
+                    # Post as a PR comment if an open PR exists for this branch
+                    PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number \
+                        --jq '.[0].number' 2>/dev/null || echo "")
+                    if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+                        gh pr comment "$PR_NUMBER" --body "$(cat $SUMMARY)"
+                        echo "Posted Claude summary to PR #${PR_NUMBER}"
+                    else
+                        echo "No open PR for branch '${BRANCH}' — summary not posted as comment"
+                    fi
+                '''
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: 'claude-reports/**', allowEmptyArchive: true
+                }
+            }
+        }
+
         stage('Update GitHub Pages') {
             steps {
                 sh 'uv run mkdocs gh-deploy --force'
@@ -94,7 +149,7 @@ pipeline {
 
     post {
         always {
-            sh 'rm -rf .venv site/ /tmp/changed_files.txt 2>/dev/null || true'
+            sh 'rm -rf .venv site/ claude-reports/ /tmp/changed_files.txt 2>/dev/null || true'
         }
         failure {
             echo "Docs pipeline failed — check console output above for details."

--- a/.jenkins/scripts/analyze-doc-coverage.py
+++ b/.jenkins/scripts/analyze-doc-coverage.py
@@ -101,9 +101,10 @@ def main() -> None:
     report = message.content[0].text
     print("\n" + report)
 
-    out = Path("/tmp/doc-coverage-report.md")
+    out = REPO_ROOT / "claude-reports" / "analyze-doc-coverage.md"
+    out.parent.mkdir(exist_ok=True)
     out.write_text(report)
-    print(f"\n[analyze-doc-coverage] Full report saved to {out}")
+    print(f"\n[analyze-doc-coverage] Report saved to {out.relative_to(REPO_ROOT)}")
 
 
 if __name__ == "__main__":

--- a/.jenkins/scripts/scan-doc-vulnerabilities.py
+++ b/.jenkins/scripts/scan-doc-vulnerabilities.py
@@ -66,6 +66,10 @@ def main() -> int:
     response = message.content[0].text
     print("\n" + response)
 
+    out = REPO_ROOT / "claude-reports" / "scan-doc-vulnerabilities.md"
+    out.parent.mkdir(exist_ok=True)
+    out.write_text(response)
+
     if "VERDICT: FAIL" in response:
         print("\n[scan-doc-vulnerabilities] HIGH-severity findings — resolve before merging.")
         return 1

--- a/.jenkins/scripts/scan-outdated-docs.py
+++ b/.jenkins/scripts/scan-outdated-docs.py
@@ -97,6 +97,10 @@ def main() -> int:
     response = message.content[0].text
     print("\n" + response)
 
+    out = REPO_ROOT / "claude-reports" / "scan-outdated-docs.md"
+    out.parent.mkdir(exist_ok=True)
+    out.write_text(response)
+
     if "VERDICT: FAIL" in response:
         print("\n[scan-outdated-docs] HIGH-severity stale references found — resolve before merging.")
         return 1

--- a/.jenkins/scripts/update-readme.py
+++ b/.jenkins/scripts/update-readme.py
@@ -82,17 +82,23 @@ def main() -> int:
     drift_report = parts[0].strip()
     updated_sections = parts[1].strip() if len(parts) == 2 else ""
 
+    has_changes = bool(updated_sections) and "No updates required" not in updated_sections
+
     print("\n## Drift Report\n")
     print(drift_report)
 
-    if updated_sections and "No updates required" not in updated_sections:
-        out = Path("/tmp/readme-updated-sections.md")
-        out.write_text(updated_sections)
+    report_lines = [drift_report]
+    if has_changes:
         print(f"\n## Updated Sections\n\n{updated_sections}")
-        print(f"\n[update-readme] Updated sections saved to {out}")
-        print("[update-readme] Apply them manually or via a docs/readme-update branch.")
+        print("\n[update-readme] Apply via a docs/readme-update branch.")
+        report_lines += ["\n## Updated Sections\n", updated_sections]
     else:
         print("\n[update-readme] README is up to date — no changes needed.")
+
+    out = REPO_ROOT / "claude-reports" / "update-readme.md"
+    out.parent.mkdir(exist_ok=True)
+    out.write_text("\n".join(report_lines))
+    print(f"\n[update-readme] Report saved to {out.relative_to(REPO_ROOT)}")
 
     return 0
 


### PR DESCRIPTION
## Summary

- Fixes the Jenkins credential ID for the Anthropic API key to match the GitHub repository secret name (`ANTHROPIC_API_KEY`)
- Adds a "Claude AI Summary" stage that compiles every Claude report into a single visible summary, posts it as a PR comment, and archives it as a Jenkins build artifact
- Scripts now write reports to `claude-reports/` in the workspace (archivable) instead of `/tmp/` (ephemeral)

## Changes

- `.jenkins/docs.Jenkinsfile`: credential `anthropic-api-key` → `ANTHROPIC_API_KEY`; add `GH_TOKEN = credentials('GITHUB_TOKEN')`; add `mkdir -p claude-reports` in Checkout; add "Claude AI Summary" stage; archive `claude-reports/**`
- `.jenkins/scripts/analyze-doc-coverage.py`: write report to `claude-reports/analyze-doc-coverage.md`
- `.jenkins/scripts/scan-outdated-docs.py`: write report to `claude-reports/scan-outdated-docs.md`
- `.jenkins/scripts/scan-doc-vulnerabilities.py`: write report to `claude-reports/scan-doc-vulnerabilities.md`
- `.jenkins/scripts/update-readme.py`: write report to `claude-reports/update-readme.md`
- `.gitignore`: add `claude-reports/`

## How the summary works

After all four AI stages run, the "Claude AI Summary" stage:
1. Concatenates `claude-reports/*.md` into `claude-reports/summary.md`
2. Echoes the full summary to the Jenkins console
3. Posts it as a PR comment via `gh pr comment` if an open PR exists for the current branch
4. Archives `claude-reports/` as a Jenkins build artifact (always — even if no PR comment is posted)

## Jenkins setup required

Two credentials must be configured in Jenkins with these exact IDs:
- `ANTHROPIC_API_KEY` — Anthropic API key (same value as the GitHub repository secret)
- `GITHUB_TOKEN` — GitHub PAT with `repo` scope (for posting PR comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
