### PR TITLE
add Test PyPI dev publish workflow, remove per-issue wheel artifacts

### DIFF
--- a/.claude/skills/resolve-issues.md
+++ b/.claude/skills/resolve-issues.md
@@ -1,6 +1,6 @@
 # resolve-issues
 
-Fetch all open GitHub issues, group them by root cause, fix each group on a dedicated branch, open PRs, and comment on every issue with the resolution and a downloadable wheel.
+Fetch all open GitHub issues, group them by root cause, fix each group on a dedicated branch, open PRs, and comment on every issue with the resolution and a Test PyPI install command.
 
 ---
 
@@ -49,15 +49,7 @@ git checkout -b bug/cap{N}-<short-desc>
 - Commit with prefix: `[cap{N}] fix: <description>`
 - Push the branch
 
-### Step 5 — Build a wheel for this fix
-
-```bash
-uv build --wheel
-```
-
-This produces `dist/cutip-X.Y.Z-py3-none-any.whl`. Note the path — it will be attached to the PR and referenced in issue comments.
-
-### Step 6 — Open a PR
+### Step 5 — Open a PR
 
 ```bash
 gh pr create --base staging \
@@ -73,7 +65,7 @@ PR body must include:
 - **Issues resolved**: `Closes #N, Closes #M`
 - **Test plan**: checklist
 
-### Step 7 — Upload wheel and comment on every resolved issue
+### Step 6 — Comment on every resolved issue
 
 For each issue resolved by this group:
 
@@ -89,12 +81,18 @@ Comment body:
 
 **Fix:** <what changed>
 
-**Wheel with fix:** download `cutip-X.Y.Z-py3-none-any.whl` from the PR's wheel-build artifact, or wait for it to ship in the next release.
+**Try the fix:** Once this PR merges to staging → integration, install the dev build from Test PyPI:
+```bash
+pip install --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "cutip>=0.1.5.dev0"
+```
+(The `--extra-index-url` flag lets pip resolve dependencies from the main PyPI registry.)
 
 This issue will be closed automatically when the PR merges to staging.
 ```
 
-### Step 8 — Repeat for all groups
+### Step 7 — Repeat for all groups
 
 Work through all groups and standalone issues. After all PRs are open, print a summary table:
 

--- a/.github/workflows/issue-resolve.yml
+++ b/.github/workflows/issue-resolve.yml
@@ -125,18 +125,6 @@ jobs:
           git commit -m "[${CAP_ID}] fix: automated fix for issue #${{ github.event.issue.number }}"
           git push origin "$BRANCH"
 
-      - name: Build wheel
-        if: steps.check.outputs.valid == 'true'
-        run: uv build --wheel
-
-      - name: Upload wheel artifact
-        if: steps.check.outputs.valid == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: "cutip-fix-${{ steps.cap.outputs.cap_id }}"
-          path: dist/*.whl
-          retention-days: 14
-
       - name: Apply claude-fixed label
         if: steps.check.outputs.valid == 'true'
         env:
@@ -155,7 +143,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CAP_ID: ${{ steps.cap.outputs.cap_id }}
           BRANCH: ${{ steps.cap.outputs.branch }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           {
             echo "## Claude Fix — ${CAP_ID}"
@@ -166,12 +153,13 @@ jobs:
             echo ""
             echo "**Branch:** \`${BRANCH}\`"
             echo ""
-            echo "**Download wheel:** [Workflow run artifacts](${RUN_URL})"
-            echo ""
-            echo "**Install the patched wheel:**"
+            echo "**Try the fix:** Once this PR merges to staging → integration, install the dev build from Test PyPI:"
             echo '```bash'
-            echo "pip install cutip-*.whl"
+            echo "pip install --index-url https://test.pypi.org/simple/ \\"
+            echo "  --extra-index-url https://pypi.org/simple/ \\"
+            echo "  \"cutip>=0.1.5.dev0\""
             echo '```'
+            echo "(The \`--extra-index-url\` flag lets pip resolve dependencies from the main PyPI registry.)"
             echo ""
             echo "Reply \`/acknowledge\` to open a PR from \`${BRANCH}\` to \`staging\` for release."
           } > /tmp/fix-comment.md

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,42 @@
+name: Publish Dev Build
+
+on:
+  push:
+    branches:
+      - integration
+
+jobs:
+  publish-dev:
+    name: Publish dev build to Test PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Compute dev version and patch pyproject.toml
+        run: |
+          CURRENT=$(python -c "import re; m=re.search(r'^version = \"([^\"]+)\"', open('pyproject.toml').read(), re.M); print(m.group(1))")
+          IFS='.' read -r MAJ MIN PATCH <<< "$CURRENT"
+          DEV_VERSION="${MAJ}.${MIN}.$((PATCH+1)).dev${GITHUB_RUN_NUMBER}"
+          echo "DEV_VERSION=$DEV_VERSION" >> "$GITHUB_ENV"
+          sed -i "s/^version = \"${CURRENT}\"/version = \"${DEV_VERSION}\"/" pyproject.toml
+          echo "Patched version: $DEV_VERSION"
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Publish to Test PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          uv publish --publish-url https://test.pypi.org/legacy/
+          echo ""
+          echo "Install with:"
+          echo "  pip install --index-url https://test.pypi.org/simple/ \\"
+          echo "    --extra-index-url https://pypi.org/simple/ \\"
+          echo "    \"cutip>=${DEV_VERSION}\""

--- a/docs/automation/release-pipeline.md
+++ b/docs/automation/release-pipeline.md
@@ -83,6 +83,28 @@ pip install cutip=={X.Y.Z}
 
 ---
 
+## Dev Release Track (Test PyPI)
+
+Every merge to `integration` automatically publishes a dev build to Test PyPI. Issue fixes accumulate in a single installable pre-release version.
+
+**Workflow:** `.github/workflows/publish-dev.yml`
+
+**Version format:** `{major}.{minor}.{patch+1}.dev{RUN_NUMBER}` — e.g. `0.1.5.dev42`
+
+**Install:**
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "cutip>=0.1.5.dev0"
+```
+
+The `--extra-index-url` flag lets pip resolve dependencies from the main PyPI registry.
+
+**Requires secret:** `TEST_PYPI_TOKEN` — add once in repo settings → Secrets → Actions.
+
+---
+
 ## Patch notes
 
 `docs/patch-notes.md` is updated as part of every release. Each entry follows the same structure:


### PR DESCRIPTION
## Summary

- Replace per-issue wheel artifacts with a persistent dev release on Test PyPI — every push to `integration` auto-publishes `0.1.5.dev{RUN_NUMBER}`
- Issue fix comments and the `resolve-issues` skill now point users to a single `pip install` command instead of a one-time workflow artifact download
- Requires `TEST_PYPI_TOKEN` secret (already added to repo settings)

## Changes

- `.github/workflows/publish-dev.yml`: new workflow — triggers on push to `integration`, computes dev version, patches `pyproject.toml` ephemerally, builds wheel, publishes to Test PyPI via `uv publish`
- `.github/workflows/issue-resolve.yml`: removed "Build wheel" and "Upload wheel artifact" steps from `handle-approve`; updated fix comment body to reference Test PyPI install command; removed unused `RUN_URL` env var
- `.claude/skills/resolve-issues.md`: removed Step 5 (build wheel), renumbered steps 6→5 / 7→6 / 8→7, updated issue comment template and skill description
- `docs/automation/release-pipeline.md`: added "Dev Release Track (Test PyPI)" section with version format, install command, and secret requirement

## Test plan

- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes (29/29 ✓)
- [ ] Workflow YAML has no syntax errors
- [ ] `publish-dev.yml` trigger is `push: branches: [integration]`
- [ ] `TEST_PYPI_TOKEN` secret is scoped via `UV_PUBLISH_TOKEN` env var (not exposed to logs)
- [ ] Merge to staging → forward to integration → confirm `publish-dev.yml` runs green and version appears at https://test.pypi.org/project/cutip/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
