### PR TITLE
[cap007] Improve init scaffold, validate logs, group name matching

### DIFF
--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -26,15 +26,63 @@ console = Console()
 
 
 # ---------------------------------------------------------------------------
-# Tab-completion helper
+# Group name helpers — partial matching + tab completion
 # ---------------------------------------------------------------------------
 
+def _match_group_name(incomplete: str, group_names: list[str]) -> list[str]:
+    """Return group names that match *incomplete* by full prefix or segment prefix.
+
+    Matching rules (in priority order — first match type wins):
+      1. Full prefix:    ``snf-bl``      matches ``snf-blueprint-manager``
+      2. Segment prefix: ``bl``          matches ``snf-blueprint-manager``
+                         ``blueprint``   matches ``snf-blueprint-manager``
+
+    A "segment" is any hyphen-delimited part of the group name.
+    """
+    # 1. Full prefix matches
+    full_prefix = [n for n in group_names if n.startswith(incomplete)]
+    if full_prefix:
+        return full_prefix
+
+    # 2. Segment prefix matches
+    return [
+        n for n in group_names
+        if any(seg.startswith(incomplete) for seg in n.split("-"))
+    ]
+
+
+def _resolve_group_name(name: str, registry) -> str:
+    """Resolve a full or partial group name to an exact registry key.
+
+    Accepts an exact name, a unique full-name prefix, or a unique segment prefix.
+    Raises :class:`~cutip.utils.exceptions.CutipError` when the name is
+    missing or ambiguous.
+    """
+    if name in registry.groups:
+        return name
+
+    candidates = _match_group_name(name, list(registry.groups))
+
+    if len(candidates) == 1:
+        resolved = candidates[0]
+        logger.debug(f"Resolved group '{name}' → '{resolved}'")
+        return resolved
+
+    if len(candidates) > 1:
+        raise CutipError(
+            f"Ambiguous group name '{name}': matches {candidates}. "
+            f"Be more specific."
+        )
+
+    raise CutipError(f"Group '{name}' not found in registry")
+
+
 def _complete_group_name(incomplete: str) -> list[str]:
-    """Return group names that start with *incomplete* (used by shell completion)."""
+    """Return group names that match *incomplete* (used by shell completion)."""
     try:
         project_root = _find_project_root()
         registry = WorkspaceDiscovery(project_root).discover()
-        return [name for name in registry.groups if name.startswith(incomplete)]
+        return _match_group_name(incomplete, list(registry.groups))
     except Exception:
         return []
 
@@ -438,6 +486,12 @@ def run(
     setup_logging(log_dir=cutip_dir / "logs")
 
     registry = WorkspaceDiscovery(project_root).discover()
+
+    try:
+        group_name = _resolve_group_name(group_name, registry)
+    except CutipError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
 
     # Validate first
     result = GraphValidator(registry, project_root=project_root).validate()

--- a/cutip/validation/graph.py
+++ b/cutip/validation/graph.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from loguru import logger
+
 from cutip.models.cards.container import ContainerCard
 from cutip.models.cards.image import ImageCard
 from cutip.models.cards.network import NetworkCard
@@ -31,7 +33,15 @@ class GraphValidator:
 
     def validate(self) -> ValidationResult:
         result = ValidationResult(ok=True)
+        n_cards = len(self.registry.cards)
+        n_units = len(self.registry.units)
+        n_groups = len(self.registry.groups)
+        logger.info(
+            f"Discovered {n_cards} card(s), {n_units} unit(s), {n_groups} group(s)"
+        )
+        logger.info(f"Validating {n_cards} card(s) ...")
         self._validate_units(result)
+        logger.info(f"Validating {n_groups} group(s) ...")
         self._validate_groups(result)
         return result
 
@@ -44,28 +54,35 @@ class GraphValidator:
                 container_card = self._resolver.resolve_card(container_ref, ContainerCard)
             except CutipRefError as exc:
                 result.add(f"[UnitResolve] {unit_name}: {exc.reason} (ref: '{container_ref}')")
+                logger.warning(f"  ✗ {container_ref} — {exc.reason}")
                 continue
+
+            logger.info(f"  ✓ {container_ref}")
 
             # Resolve imageRef from ContainerCard
             image_ref = container_card.spec.imageRef.ref
             try:
                 self._resolver.resolve_card(image_ref, ImageCard)
+                logger.info(f"  ✓ {image_ref}")
             except CutipRefError as exc:
                 result.add(
                     f"[CardResolve] {unit_name} → {container_card.name}: "
                     f"{exc.reason} (imageRef: '{image_ref}')"
                 )
+                logger.warning(f"  ✗ {image_ref} — {exc.reason}")
 
             # Resolve networkRef from ContainerCard (skipped when network_mode is used)
             if container_card.spec.networkRef is not None:
                 network_ref = container_card.spec.networkRef.ref
                 try:
                     self._resolver.resolve_card(network_ref, NetworkCard)
+                    logger.info(f"  ✓ {network_ref}")
                 except CutipRefError as exc:
                     result.add(
                         f"[CardResolve] {unit_name} → {container_card.name}: "
                         f"{exc.reason} (networkRef: '{network_ref}')"
                     )
+                    logger.warning(f"  ✗ {network_ref} — {exc.reason}")
 
     def _validate_groups(self, result: ValidationResult) -> None:
         for group_name, group in self.registry.groups.items():
@@ -74,8 +91,10 @@ class GraphValidator:
                 ref = unit_ref.ref
                 try:
                     self._resolver.resolve_unit(ref)
+                    logger.info(f"  ✓ {group_name} → {ref}")
                 except CutipRefError as exc:
                     result.add(f"[GroupResolve] {group_name}: {exc.reason} (ref: '{ref}')")
+                    logger.warning(f"  ✗ {group_name} → {ref} — {exc.reason}")
 
             # Verify workflow path exists
             group_source = self.registry.source_of(f"groups/{group_name}")
@@ -93,3 +112,6 @@ class GraphValidator:
                         f"[WorkflowPath] {group_name}: workflow file not found: "
                         f"'{workflow_path}'"
                     )
+                    logger.warning(f"  ✗ {group_name}: workflow not found: '{workflow_path}'")
+                else:
+                    logger.info(f"  ✓ {group_name}: {group.spec.workflow}")

--- a/cutip/workspace/scaffold.py
+++ b/cutip/workspace/scaffold.py
@@ -116,7 +116,10 @@ spec:
   # Use the default bridge network
   network_mode: bridge
 
-  command: 'sh -c "echo Hello from CUTIP!"'
+  # tail -f /dev/null keeps the container alive indefinitely so you can
+  # `podman exec -it cutip-hello /bin/sh` into it at any time.
+  # workflow.py execs a one-shot echo on every `cutip run hello`.
+  command: "tail -f /dev/null"
 
   environment:
     LANG: "C.UTF-8"
@@ -228,8 +231,9 @@ def startup(ctx: CutipContext) -> None:
     cc = next(c for c in ctx.resolved_cards.values() if isinstance(c, ContainerCard))
     cname = cc.metadata.name
 
-    logger.success(f\"Container '{cname}' is running.\")
+    logger.success(f\"Container '{cname}' is running (tail -f /dev/null).\")
     logger.info(f\"  Connect:  podman exec -it {cname} /bin/sh\")
+    logger.info(f\"  Stop:     podman stop {cname}\")
 """
 
 _EXAMPLE_WORKFLOW_PY = """\
@@ -245,17 +249,23 @@ each unit's startup.py, not here.
 
 from __future__ import annotations
 
+from loguru import logger
+
 from cutip.context.workflow import CutipContext
 
 
 def main(ctx: CutipContext) -> None:
-    \"\"\"Start the hello container.
+    \"\"\"Start the hello container and exec a greeting.
 
-    CUTIP has already built the image, created the container, and ensured
-    the network.  Call .start() here to bring it up, then startup.py
-    handles any post-start logic.
+    The container runs ``tail -f /dev/null`` so it stays alive — you can
+    ``podman exec -it cutip-hello /bin/sh`` into it at any time.  Here we
+    exec a one-shot echo on every ``cutip run hello`` to show the exec API.
     \"\"\"
-    ctx.container(\"cutip-hello\").start()
+    container = ctx.container(\"cutip-hello\")
+    container.start()
+
+    _, output = container.exec_run([\"sh\", \"-c\", \"echo 'hello from container'\"])
+    logger.info(output.decode(\"utf-8\", errors=\"replace\").strip())
 """
 
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -14,6 +14,7 @@ commit messages, and PR titles.
 | cap004 | Add MIT license                                        | feat | merged | feat/cap004-mit-license             | #9  | 2026-02-28 |
 | cap005 | Remove deprecated --backend flag from e2e steps        | bug  | merged | bug/cap005-fix-e2e-backend-flag     | #10 | 2026-02-28 |
 | cap006 | Translate Windows bind-mount paths to WSL2 format      | bug  | open   | bug/cap006-win-path-wsl-translation | —   | 2026-03-02 |
+| cap007 | Improve init scaffold, validate logs, group name match | feat | open   | feat/cap007-scaffold-validate-completion | —   | 2026-03-03 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

- `cutip init` hello scaffold now uses `tail -f /dev/null` as the container command so it stays alive for manual `podman exec` sessions; `workflow.py` execs `echo 'hello from container'` on each `cutip run hello`; `startup.py` prints connect and stop hints
- `cutip validate` now emits intermediary progress logs: discovered counts, `Validating N card(s)/group(s) ...`, and per-ref `✓`/`✗` lines instead of a single final "Validation OK"
- `cutip run <partial>` resolves group names by full prefix or hyphen-segment prefix — `cutip run bl` finds `snf-blueprint-manager`; tab completion uses the same logic; ambiguous matches error with the candidate list

## Changes

- `cutip/workspace/scaffold.py`: container command → `tail -f /dev/null`; workflow template adds `exec_run`; startup template adds stop hint
- `cutip/validation/graph.py`: import loguru; `validate()` logs discovered counts and stage headers; `_validate_units()` and `_validate_groups()` log `✓`/`✗` per ref
- `cutip/cli/commands/run.py`: add `_match_group_name()` (full-prefix then segment-prefix), `_resolve_group_name()` (exact → unique prefix → error); `_complete_group_name()` delegates to `_match_group_name`; `run()` resolves name before registry lookup
- `docs/capabilities.md`: registered cap007

## Test plan

- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes (29/29 ✓)
- [ ] `cutip init` → inspect generated container YAML has `tail -f /dev/null`
- [ ] `cutip validate` in a project shows per-ref ✓ lines
- [ ] `cutip run bl` resolves to `snf-blueprint-manager` (or equivalent partial)
- [ ] `cutip run snf` errors with "Ambiguous" listing all snf-* groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
