### PR TITLE
[cap016] Add Windows E2E + complex workspace to release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
   e2e-podman-ubuntu:
     name: E2E Podman · Ubuntu
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
 
     env:
       PYTHONUTF8: "1"
@@ -79,8 +79,70 @@ jobs:
       - name: Validate simple workspace
         run: uv run cutip validate --path tests/e2e/simple
 
-      - name: Run E2E group (Podman · Ubuntu)
+      - name: Run E2E group simple (Podman · Ubuntu)
         run: uv run cutip run simple --path tests/e2e/simple --local
+
+      - name: Validate complex workspace
+        run: uv run cutip validate --path tests/e2e/complex
+
+      - name: Run E2E group complex (Podman · Ubuntu)
+        run: uv run cutip run complex --path tests/e2e/complex --local
+
+  e2e-podman-windows:
+    name: E2E Podman · Windows
+    runs-on: windows-latest
+    timeout-minutes: 35
+
+    env:
+      PYTHONUTF8: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install cutip
+        run: |
+          uv venv .venv
+          uv pip install -e .
+
+      - name: Install Podman (Windows)
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $headers = @{ Authorization = "token $env:GITHUB_TOKEN" }
+          $release = Invoke-RestMethod "https://api.github.com/repos/containers/podman/releases/latest" -Headers $headers
+          $version  = $release.tag_name.TrimStart('v')
+          $url      = "https://github.com/containers/podman/releases/download/v${version}/podman-${version}-setup.exe"
+          Write-Host "Downloading Podman $version from $url"
+          Invoke-WebRequest -Uri $url -OutFile "podman-setup.exe"
+          Start-Process -Wait -FilePath ".\podman-setup.exe" -ArgumentList "/S"
+          $podmanPath = "C:\Program Files\RedHat\Podman"
+          echo "$podmanPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "CUTIP_BACKEND_NAME=podman" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          & "$podmanPath\podman.exe" --version
+
+      - name: Start Podman machine (Windows)
+        shell: pwsh
+        run: |
+          podman machine init --cpus 2 --memory 2048 --now
+          podman version
+
+      - name: Validate simple workspace
+        run: uv run cutip validate --path tests/e2e/simple
+
+      - name: Run E2E group simple (Podman · Windows)
+        run: uv run cutip run simple --path tests/e2e/simple
+
+      - name: Validate complex workspace
+        run: uv run cutip validate --path tests/e2e/complex
+
+      - name: Run E2E group complex (Podman · Windows)
+        run: uv run cutip run complex --path tests/e2e/complex
 
   install-validate-macos:
     # GitHub Actions free macOS runners report VZErrorDomain Code=2
@@ -122,7 +184,7 @@ jobs:
   build-and-release:
     name: Build & GitHub Release
     runs-on: ubuntu-latest
-    needs: [unit-tests, smoke-test, e2e-podman-ubuntu, install-validate-macos]
+    needs: [unit-tests, smoke-test, e2e-podman-ubuntu, e2e-podman-windows, install-validate-macos]
 
     permissions:
       contents: write

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -22,7 +22,8 @@ commit messages, and PR titles.
 | cap012 | Docker backend support                                        | feat | planned | —                                       | —   | —          |
 | cap013 | Mac/Apple Silicon Podman CI + docs                           | feat | merged | feat/cap013-mac-podman-ci-docs          | #40 | 2026-03-03 |
 | cap014 | Remove Jenkins, migrate AI doc scripts to GHA               | feat | merged | feat/cap014-remove-jenkins-migrate-gha  | #41 | 2026-03-03 |
-| cap015 | Consolidate GHA workflows + PR auto-label/assign            | feat | open   | feat/cap015-consolidate-workflows       | —   | 2026-03-03 |
+| cap015 | Consolidate GHA workflows + PR auto-label/assign            | feat | merged | feat/cap015-consolidate-workflows       | #42 | 2026-03-03 |
+| cap016 | Add Windows E2E + complex workspace to release gate         | feat | open   | feat/cap016-release-full-matrix         | —   | 2026-03-03 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

- Adds `e2e-podman-windows` job to `release.yml` (simple + complex, matching `ci.yml`)
- Extends `e2e-podman-ubuntu` to run `complex` in addition to `simple`
- Adds `e2e-podman-windows` to the `build-and-release` needs gate
- Increases Ubuntu timeout 25→35 min to match CI

The release gate now runs the same platform matrix as PR checks: Ubuntu (full E2E), Windows (full E2E), macOS (schema-only).

## Test plan

- [ ] All PR checks pass
- [ ] After merge, a test release branch confirms Windows E2E runs and gates the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)