### PR TITLE
[cap017] Fix doc language: imperative/declarative, remove overhead bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments using structured YAML artifacts and Python workflows.
 
-CUTIP is not a replacement for `docker-compose`. It is designed for a different use case: environments where the startup sequence is a program, not a declaration.
+CUTIP is not a replacement for `docker-compose`. It is designed for a different use case: environments where the startup sequence is imperative, not declarative.
 
 | | docker-compose | CUTIP |
 |---|---|---|

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -23,7 +23,8 @@ commit messages, and PR titles.
 | cap013 | Mac/Apple Silicon Podman CI + docs                           | feat | merged | feat/cap013-mac-podman-ci-docs          | #40 | 2026-03-03 |
 | cap014 | Remove Jenkins, migrate AI doc scripts to GHA               | feat | merged | feat/cap014-remove-jenkins-migrate-gha  | #41 | 2026-03-03 |
 | cap015 | Consolidate GHA workflows + PR auto-label/assign            | feat | merged | feat/cap015-consolidate-workflows       | #42 | 2026-03-03 |
-| cap016 | Add Windows E2E + complex workspace to release gate         | feat | open   | feat/cap016-release-full-matrix         | —   | 2026-03-03 |
+| cap016 | Add Windows E2E + complex workspace to release gate         | feat | merged | feat/cap016-release-full-matrix         | #43 | 2026-03-03 |
+| cap017 | Fix doc language: imperative/declarative, remove overhead   | feat | open   | feat/cap017-doc-language-fixes          | —   | 2026-03-03 |
 
 ## ID Assignment
 

--- a/docs/getting-started/why-cutip.md
+++ b/docs/getting-started/why-cutip.md
@@ -20,7 +20,7 @@ This page is an honest comparison. If `docker-compose` does what you need, use i
 
 - You are deploying a standard stack (postgres + redis + your app) with no custom startup logic
 - You want maximum ecosystem compatibility (`docker compose`, Portainer, VS Code Dev Containers)
-- Your team is already fluent in compose and the overhead of a new tool isn't worth it
+- Your stack needs no programmatic startup logic and a declarative definition is sufficient
 
 **Use CUTIP when:**
 
@@ -306,6 +306,6 @@ Subsequent runs are idempotent — CUTIP removes stale containers and recreates 
 
 ## Summary
 
-CUTIP is not trying to replace compose for standard stacks. It is designed for environments where the startup sequence is a program, not a declaration — where you need to generate files, exec into containers, branch on health state, and treat container orchestration as code you can test and debug.
+CUTIP is not trying to replace compose for standard stacks. It is designed for environments where the startup sequence is imperative, not declarative — where you need to generate files, exec into containers, branch on health state, and treat container orchestration as code you can test and debug.
 
 If your workflow is "bring up 3 services and let them find each other", use compose. If your workflow is "generate a config file, start the database, wait until it can answer queries, then start the app that depends on it", CUTIP gives you the right primitives.


### PR DESCRIPTION
## Summary

- Replaces "startup sequence is a program, not a declaration" → "is imperative, not declarative" in `why-cutip.md` (×2) and `README.md`
- Replaces "Your team is already fluent in compose and the overhead of a new tool isn't worth it" with "Your stack needs no programmatic startup logic and a declarative definition is sufficient" — the overhead argument is inaccurate once `cutip from-compose` (cap010) ships

## Test plan

- [ ] All checks pass
- [ ] `uv run mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)