### PR TITLE
[cap019] Revise CI workflow matrix, Test PyPI continuity, and retry policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
     name: E2E Podman · Ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    if: github.event_name == 'pull_request'
 
     env:
       PYTHONUTF8: "1"
@@ -151,6 +152,7 @@ jobs:
     name: E2E Podman · Windows
     runs-on: windows-latest
     timeout-minutes: 35
+    if: github.event_name == 'pull_request'
 
     env:
       PYTHONUTF8: "1"
@@ -213,6 +215,7 @@ jobs:
     name: Install & Validate · macOS
     runs-on: macos-14
     timeout-minutes: 15
+    if: github.event_name == 'pull_request'
 
     env:
       PYTHONUTF8: "1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@ The only valid stopping points before completion are:
 - **Run tests** with: `cd ~/dev/cutip && uv run pytest tests/ -v --ignore=tests/e2e`
 - **Validate a consumer project**: `cd <project> && uv run --project ~/dev/cutip cutip validate`
 - **List workspace artifacts**: `cutip group ls` / `cutip unit ls` / `cutip card ls`
+- **CI failures: retry before force-merging.** For transient GitHub 500 errors:
+  `gh run rerun <run-id> --failed` retries only failed jobs without re-running the whole suite.
+  Use `--admin` only after retries confirm it is a persistent infra failure — not a code issue.
 
 ## Architecture
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -26,6 +26,7 @@ commit messages, and PR titles.
 | cap016 | Add Windows E2E + complex workspace to release gate         | feat | merged | feat/cap016-release-full-matrix         | #43 | 2026-03-03 |
 | cap017 | Fix doc language: imperative/declarative, remove overhead   | feat | merged | feat/cap017-doc-language-fixes          | #44 | 2026-03-03 |
 | cap018 | Document from-compose interoperability in compose comparison | feat | open    | feat/cap018-from-compose-docs           | —   | 2026-03-03 |
+| cap019 | Revise CI workflow matrix, Test PyPI continuity, and retry policy | feat | open | feat/cap019-ci-matrix-testpypi-retry | —   | 2026-03-03 |
 
 ## ID Assignment
 

--- a/docs/development/branching.md
+++ b/docs/development/branching.md
@@ -75,6 +75,12 @@ Every feature or bug fix is assigned a **capability ID** (`cap001`, `cap002`, ..
 8. When staging is stable: open PR → integration
 ```
 
+> [!TIP]
+> If a PR check fails with a transient GitHub error, use `gh run rerun <run-id> --failed`
+> to retry only the failed jobs. Use `--admin` force merge only as a last resort after
+> multiple retries confirm a persistent infrastructure failure — never to bypass real failures.
+> See [CI/CD Workflows Reference](workflows.md#ci-failure-retry-before-force-merging) for the full retry procedure.
+
 ## Workflow: Release
 
 ```
@@ -86,6 +92,10 @@ Every feature or bug fix is assigned a **capability ID** (`cap001`, `cap002`, ..
 ```
 
 Git tags (`v{X.Y.Z}`) are the durable version markers. Release branches are deleted after the GitHub Release is confirmed.
+
+## CI/CD Workflows
+
+For the full workflow trigger matrix, Test PyPI dev artifact flow, and CI retry procedure, see the [CI/CD Workflows Reference](workflows.md).
 
 ## Automated Docs Generation
 

--- a/docs/development/workflows.md
+++ b/docs/development/workflows.md
@@ -1,0 +1,125 @@
+# CI/CD Workflows Reference
+
+Complete reference for CUTIP's GitHub Actions workflows — what triggers what, how Test PyPI dev builds work, and the correct procedure when CI fails.
+
+---
+
+## Workflow Trigger Matrix
+
+| Event | Workflow | Jobs |
+|-------|----------|------|
+| Push to `feat/**`, `bug/**`, `claude/**` | `ci.yml` | unit-tests, smoke-test, docs-build, build-wheel |
+| PR → `staging` or `integration` | `ci.yml` | auto-label, unit-tests, smoke-test, e2e-ubuntu, e2e-windows, install-macos, docs-build |
+| Push to `staging` | `docs.yml` | build, generate, ai-review |
+| Push to `integration` | `docs.yml` + `integration.yml` | build, deploy (gh-pages), **Test PyPI publish**, prune |
+| Push to `docs/**` or PR touching docs / `mkdocs.yml` | `docs.yml` | build |
+| Push to `release/**` | `release.yml` | unit-tests, smoke-test, e2e-ubuntu, e2e-windows, install-macos, build-and-release |
+
+### E2E is PR-only
+
+`e2e-podman-ubuntu`, `e2e-podman-windows`, and `install-validate-macos` carry `if: github.event_name == 'pull_request'`.
+
+On a **push to a feature branch**, only unit-tests, smoke-test, docs-build, and build-wheel run. This prevents expensive E2E from running on every iterative commit during development.
+
+On a **PR to staging or integration**, all jobs run — E2E is still a required merge gate. GitHub treats skipped jobs as passing for branch-protection purposes, so the protection rules are unchanged.
+
+---
+
+## Test PyPI Dev Artifact Flow
+
+Every push to `integration` triggers `integration.yml → publish-dev`.
+
+### Version computation
+
+1. `pyproject.toml` is read for the current version (e.g., `0.1.5`)
+2. Dev version is computed: `{major}.{minor}.{patch+1}.dev{GITHUB_RUN_NUMBER}` → `0.1.6.dev42`
+3. `pyproject.toml` is patched in-place (not committed)
+4. Wheel is built and published to `https://test.pypi.org/legacy/`
+
+### Installing a dev build
+
+```shell
+pip install --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "cutip>=0.1.6.dev0"
+```
+
+Replace `0.1.6.dev0` with the specific dev version shown in the `integration.yml` run logs.
+
+### Prerequisite
+
+The `TEST_PYPI_TOKEN` secret must be set in the GitHub repository:
+
+**Settings → Secrets and variables → Actions → New repository secret**
+
+- Name: `TEST_PYPI_TOKEN`
+- Value: API token from [test.pypi.org](https://test.pypi.org) (account settings → API tokens)
+
+Without this secret, `publish-dev` fails silently on every integration push.
+
+---
+
+## CI Failure: Retry Before Force-Merging
+
+### Step 1 — Read the failure
+
+```shell
+gh run view <run-id> --log-failed
+```
+
+This shows only the failed steps, not the full log.
+
+### Step 2 — Diagnose
+
+- **Code issue** (test failure, lint error, import error): fix locally and push. CI reruns automatically.
+- **Transient infra issue** (GitHub 500, checkout timeout, rate limit): retry the run.
+
+### Step 3 — Retry failed jobs only
+
+```shell
+gh run rerun <run-id> --failed
+```
+
+`--failed` retries only the jobs that failed — it does not re-run the entire suite. This is faster and cheaper than a full rerun.
+
+To get the run ID:
+
+```shell
+gh run list --limit 5
+```
+
+Or from a PR:
+
+```shell
+gh pr checks <PR_NUMBER>
+```
+
+### Step 4 — If retries fail consistently
+
+If the same job fails three times with the same transient error and the failure is clearly not a code issue, `--admin` force merge may be used as a last resort.
+
+**`--admin` is not a convenience tool.** It bypasses all branch protections, including required status checks. It must only be used when:
+
+- The failure is a confirmed persistent infrastructure issue (not a code issue)
+- At least two retry attempts (`gh run rerun --failed`) have been made
+- The PR has been reviewed and the code is correct
+
+```shell
+gh pr merge <PR_NUMBER> --merge --admin --delete-branch
+```
+
+> [!WARNING]
+> Force-merging with `--admin` during a transient GitHub error can allow broken code to reach staging or integration if the failure turns out to be a real test failure. Retry first. Always.
+
+---
+
+## Workflow Files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/ci.yml` | Unit tests, smoke, E2E (PR-only), docs build, wheel archive |
+| `.github/workflows/docs.yml` | Docs build check, staging doc generation, gh-pages deploy |
+| `.github/workflows/integration.yml` | Test PyPI publish, merged-branch pruning |
+| `.github/workflows/release.yml` | Full test matrix + GitHub Release creation |
+
+See [Branching Guide](branching.md) for branch types and the full feature development workflow.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,5 +117,6 @@ nav:
 
   - Development:
     - Branching Guide: development/branching.md
+    - CI/CD Workflows: development/workflows.md
     - Capabilities: capabilities.md
     - Patch Notes: patch-notes.md


### PR DESCRIPTION
## Summary

- Scopes E2E CI jobs to PR-only, removing the expensive per-push runs on feature branches while keeping E2E as a required merge gate
- Adds a complete `docs/development/workflows.md` reference covering the trigger matrix, Test PyPI dev artifact flow, and the mandatory retry-before-force-merge procedure
- Codifies the retry policy in `CLAUDE.md` so it is always in context for automated sessions

## Changes

- `.github/workflows/ci.yml`: added `if: github.event_name == 'pull_request'` to `e2e-podman-ubuntu`, `e2e-podman-windows`, and `install-validate-macos` — these jobs now skip on push events and run on PRs only
- `docs/development/workflows.md`: new file — full trigger matrix table, Test PyPI version computation and install snippet, `TEST_PYPI_TOKEN` secret requirement, and the step-by-step CI retry procedure (`gh run rerun --failed` → `--admin` only as last resort)
- `docs/development/branching.md`: added CI/CD Workflows cross-reference section and a retry tip callout in the Feature Development workflow
- `CLAUDE.md`: added retry policy bullet to Key Conventions
- `mkdocs.yml`: added `development/workflows.md` to nav under Development
- `docs/capabilities.md`: registered cap019

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (29/29)
- [x] `uv run mkdocs build --strict` passes (0 errors)
- [ ] Push to `feat/*` branch → confirm only unit-tests, smoke-test, docs-build, build-wheel run (no E2E)
- [ ] Open a PR to staging → confirm E2E jobs appear in required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
