### PR TITLE
[cap012] Add Docker backend support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,85 @@ jobs:
           uv run cutip from-compose /tmp/angular.yaml --output-dir /tmp/fc-angular
           uv run cutip validate --path /tmp/fc-angular
 
+  # ── E2E · Docker · Ubuntu ──────────────────────────────────────────────────
+  e2e-docker-ubuntu:
+    name: E2E Docker · Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: github.event_name == 'pull_request'
+
+    env:
+      PYTHONUTF8: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install cutip with docker extra
+        run: |
+          uv venv .venv
+          uv pip install -e ".[docker]"
+
+      - name: Verify Docker is available
+        run: docker version
+
+      - name: Validate simple workspace
+        run: uv run cutip validate --path tests/e2e/simple
+
+      - name: Run E2E group simple (Docker · Ubuntu)
+        run: uv run cutip run simple --path tests/e2e/simple --backend docker --local
+
+      - name: Validate complex workspace
+        run: uv run cutip validate --path tests/e2e/complex
+
+      - name: Run E2E group complex (Docker · Ubuntu)
+        run: uv run cutip run complex --path tests/e2e/complex --backend docker --local
+
+      # ── from-compose: awesome-compose validation suite ──────────────────────
+      - name: "from-compose · react-nginx"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/react-nginx/compose.yaml \
+            -o /tmp/react-nginx.yaml
+          mkdir -p /tmp/fc-react-nginx
+          uv run cutip from-compose /tmp/react-nginx.yaml --output-dir /tmp/fc-react-nginx
+          uv run cutip validate --path /tmp/fc-react-nginx
+
+      - name: "from-compose · fastapi"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/fastapi/compose.yaml \
+            -o /tmp/fastapi.yaml
+          mkdir -p /tmp/fc-fastapi
+          uv run cutip from-compose /tmp/fastapi.yaml --output-dir /tmp/fc-fastapi
+          uv run cutip validate --path /tmp/fc-fastapi
+
+      - name: "from-compose · nginx-flask-mongo"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/nginx-flask-mongo/compose.yaml \
+            -o /tmp/nginx-flask-mongo.yaml
+          mkdir -p /tmp/fc-nginx-flask-mongo
+          uv run cutip from-compose /tmp/nginx-flask-mongo.yaml --output-dir /tmp/fc-nginx-flask-mongo
+          uv run cutip validate --path /tmp/fc-nginx-flask-mongo
+
+      - name: "from-compose · prometheus-grafana"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/prometheus-grafana/compose.yaml \
+            -o /tmp/prometheus-grafana.yaml
+          mkdir -p /tmp/fc-prometheus-grafana
+          uv run cutip from-compose /tmp/prometheus-grafana.yaml --output-dir /tmp/fc-prometheus-grafana
+          uv run cutip validate --path /tmp/fc-prometheus-grafana
+
+      - name: "from-compose · angular"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/angular/compose.yaml \
+            -o /tmp/angular.yaml
+          mkdir -p /tmp/fc-angular
+          uv run cutip from-compose /tmp/angular.yaml --output-dir /tmp/fc-angular
+          uv run cutip validate --path /tmp/fc-angular
+
   # ── E2E · Windows ───────────────────────────────────────────────────────────
   e2e-podman-windows:
     name: E2E Podman · Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,83 @@ jobs:
           uv run cutip from-compose /tmp/angular.yaml --output-dir /tmp/fc-angular
           uv run cutip validate --path /tmp/fc-angular
 
+  e2e-docker-ubuntu:
+    name: E2E Docker · Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      PYTHONUTF8: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install cutip with docker extra
+        run: |
+          uv venv .venv
+          uv pip install -e ".[docker]"
+
+      - name: Verify Docker is available
+        run: docker version
+
+      - name: Validate simple workspace
+        run: uv run cutip validate --path tests/e2e/simple
+
+      - name: Run E2E group simple (Docker · Ubuntu)
+        run: uv run cutip run simple --path tests/e2e/simple --backend docker --local
+
+      - name: Validate complex workspace
+        run: uv run cutip validate --path tests/e2e/complex
+
+      - name: Run E2E group complex (Docker · Ubuntu)
+        run: uv run cutip run complex --path tests/e2e/complex --backend docker --local
+
+      # ── from-compose: awesome-compose validation suite ──────────────────────
+      - name: "from-compose · react-nginx"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/react-nginx/compose.yaml \
+            -o /tmp/react-nginx.yaml
+          mkdir -p /tmp/fc-react-nginx
+          uv run cutip from-compose /tmp/react-nginx.yaml --output-dir /tmp/fc-react-nginx
+          uv run cutip validate --path /tmp/fc-react-nginx
+
+      - name: "from-compose · fastapi"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/fastapi/compose.yaml \
+            -o /tmp/fastapi.yaml
+          mkdir -p /tmp/fc-fastapi
+          uv run cutip from-compose /tmp/fastapi.yaml --output-dir /tmp/fc-fastapi
+          uv run cutip validate --path /tmp/fc-fastapi
+
+      - name: "from-compose · nginx-flask-mongo"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/nginx-flask-mongo/compose.yaml \
+            -o /tmp/nginx-flask-mongo.yaml
+          mkdir -p /tmp/fc-nginx-flask-mongo
+          uv run cutip from-compose /tmp/nginx-flask-mongo.yaml --output-dir /tmp/fc-nginx-flask-mongo
+          uv run cutip validate --path /tmp/fc-nginx-flask-mongo
+
+      - name: "from-compose · prometheus-grafana"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/prometheus-grafana/compose.yaml \
+            -o /tmp/prometheus-grafana.yaml
+          mkdir -p /tmp/fc-prometheus-grafana
+          uv run cutip from-compose /tmp/prometheus-grafana.yaml --output-dir /tmp/fc-prometheus-grafana
+          uv run cutip validate --path /tmp/fc-prometheus-grafana
+
+      - name: "from-compose · angular"
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/awesome-compose/master/angular/compose.yaml \
+            -o /tmp/angular.yaml
+          mkdir -p /tmp/fc-angular
+          uv run cutip from-compose /tmp/angular.yaml --output-dir /tmp/fc-angular
+          uv run cutip validate --path /tmp/fc-angular
+
   e2e-podman-windows:
     name: E2E Podman · Windows
     runs-on: windows-latest
@@ -271,7 +348,7 @@ jobs:
   build-and-release:
     name: Build & GitHub Release
     runs-on: ubuntu-latest
-    needs: [unit-tests, smoke-test, e2e-podman-ubuntu, e2e-podman-windows, install-validate-macos]
+    needs: [unit-tests, smoke-test, e2e-podman-ubuntu, e2e-docker-ubuntu, e2e-podman-windows, install-validate-macos]
 
     permissions:
       contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What is CUTIP
 
-**Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments with structured YAML artifacts and Python workflows. **Podman is the only supported backend** (docker support was removed).
+**Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments with structured YAML artifacts and Python workflows. **Podman (default) and Docker are supported backends.** Select with `--backend docker` or `CUTIP_BACKEND=docker`.
 
 ## Deliverables — End-to-End Mandate
 

--- a/cutip/backends/__init__.py
+++ b/cutip/backends/__init__.py
@@ -15,3 +15,32 @@ Shared utilities:
 
 - :mod:`cutip.backends.shared.image` — ``image_alias`` / ``image_ref`` helpers
 """
+
+from __future__ import annotations
+
+from cutip.backends.base import CutipBackend
+from cutip.utils.exceptions import CutipError
+
+
+def get_backend(name: str, local: bool = False) -> CutipBackend:
+    """Return a connected backend instance by name.
+
+    Args:
+        name:  ``"podman"`` or ``"docker"``.
+        local: For Podman, connect to the local socket instead of SSH tunnel.
+               Ignored for Docker (always uses local daemon).
+
+    Raises:
+        CutipError: If the backend name is unknown or connection fails.
+    """
+    if name == "podman":
+        from cutip.backends.podman import PodmanBackend
+        return PodmanBackend.connect_local() if local else PodmanBackend.connect()
+
+    if name == "docker":
+        from cutip.backends.docker import DockerBackend
+        return DockerBackend.connect()
+
+    raise CutipError(
+        f"Unknown backend '{name}'. Supported backends: podman, docker"
+    )

--- a/cutip/backends/docker/__init__.py
+++ b/cutip/backends/docker/__init__.py
@@ -1,0 +1,5 @@
+"""Docker backend package."""
+
+from cutip.backends.docker.backend import DockerBackend
+
+__all__ = ["DockerBackend"]

--- a/cutip/backends/docker/backend.py
+++ b/cutip/backends/docker/backend.py
@@ -1,0 +1,223 @@
+"""Docker execution backend — container operations.
+
+Connection setup lives in :mod:`cutip.backends.docker.connection`.
+This module contains only the :class:`DockerBackend` class and its
+container/image/network/volume operations.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+from loguru import logger
+
+from cutip.backends.base import CutipBackend
+from cutip.backends.docker.connection import connect_docker_client
+from cutip.backends.shared.build import stage_buildtime_resources
+from cutip.backends.shared.image import image_alias, image_ref
+from cutip.models.cards.container import ContainerCard
+from cutip.models.cards.image import ImageCard
+from cutip.models.cards.network import NetworkCard
+from cutip.utils.exceptions import CutipError
+
+
+class DockerBackend(CutipBackend):
+    """Docker backend — communicates via DockerClient (local daemon)."""
+
+    def __init__(self, client) -> None:
+        self._client = client
+
+    @property
+    def client(self):
+        """The raw DockerClient instance. Injected into ctx.runtime for workflows."""
+        return self._client
+
+    # ── Constructor ───────────────────────────────────────────────────────────
+
+    @classmethod
+    def connect(cls) -> "DockerBackend":
+        """Connect to the local Docker daemon and return a backend instance."""
+        client = connect_docker_client()
+        return cls(client=client)
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    def disconnect(self) -> None:
+        """Close the Docker client."""
+        try:
+            self._client.close()
+        except Exception:
+            pass
+
+    # ── Image operations ──────────────────────────────────────────────────────
+
+    def pull_image(self, card: ImageCard) -> None:
+        alias = image_alias(card)
+        ref   = image_ref(card)
+
+        # Idempotent: skip if the alias already exists locally.
+        all_tags = {t for img in self._client.images.list() for t in (img.tags or [])}
+        if alias in all_tags:
+            logger.info(f"Image already present: {alias}")
+            return
+
+        logger.info(f"Pulling image: {ref}")
+        image = self._client.images.pull(card.spec.image, tag=card.spec.tag)
+
+        # Tag with the card's canonical alias so create_container can reference
+        # the image by card name regardless of registry path.
+        if alias != ref:
+            image.tag(alias)
+            logger.info(f"Tagged {ref} -> {alias}")
+
+    def build_image(
+        self,
+        card: ImageCard,
+        project_root: Path | None = None,
+        vars: dict | None = None,
+    ) -> None:
+        context = Path(card.spec.context or "")
+        if not context.is_absolute() and project_root:
+            context = project_root / context
+
+        # Stage any extra files into {context}/buildtime before building.
+        staging = stage_buildtime_resources(card, project_root, vars=vars)
+        build_ctx = staging if card.spec.buildtime_resources else context
+
+        tag = image_alias(card)
+        cmd = [
+            "docker", "build",
+            "--tag", tag,
+            "--file", str(context / card.spec.dockerfile),
+        ]
+        for k, v in card.spec.build_args.items():
+            cmd += ["--build-arg", f"{k}={v}"]
+        cmd.append(str(build_ctx))
+
+        logger.info(f"Building image {tag} from {build_ctx}/{card.spec.dockerfile}")
+
+        process = subprocess.Popen(
+            cmd,
+            cwd=str(context),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            bufsize=1,
+        )
+        for raw in process.stdout:
+            logger.bind(subprocess=True).debug(raw.rstrip("\n"))
+        rc = process.wait()
+        if rc != 0:
+            raise CutipError(f"Image build failed for '{tag}'")
+
+    # ── Network / volume operations ───────────────────────────────────────────
+
+    def ensure_network(self, card: NetworkCard) -> None:
+        name = card.metadata.name
+        try:
+            self._client.networks.get(name)
+            logger.info(f"Network already exists: {name}")
+            return
+        except Exception:
+            pass
+
+        import ipaddress
+        import docker.types
+
+        network = ipaddress.IPv4Network(card.spec.subnet, strict=False)
+        gateway = card.spec.gateway or str(next(network.hosts()))
+        ipam_pool = docker.types.IPAMPool(subnet=str(network), gateway=gateway)
+        ipam_config = docker.types.IPAMConfig(pool_configs=[ipam_pool])
+        self._client.networks.create(name, driver=card.spec.driver, ipam=ipam_config)
+        logger.info(f"Created network: {name}")
+
+    # ── Container operations ──────────────────────────────────────────────────
+
+    def create_container(
+        self,
+        card: ContainerCard,
+        image_name: str | None = None,
+    ) -> str:
+        """Create (but do not start) a container. Returns the container name."""
+        name = card.metadata.name
+        try:
+            self._client.containers.get(name)
+            logger.info(f"Container already exists: {name}")
+            return name
+        except Exception:
+            pass
+
+        if image_name is None:
+            image_name = f"{card.spec.imageRef.ref.split('/')[-1]}:latest"
+
+        kwargs: dict = {
+            "name": name,
+            "image": image_name,
+            "privileged": card.spec.privileged,
+            "ports": card.spec.ports or {},
+            "environment": card.spec.environment or {},
+            "cap_add": card.spec.cap_add or [],
+            "security_opt": card.spec.security_opts or [],
+            "detach": True,
+        }
+
+        if card.spec.network_mode:
+            kwargs["network_mode"] = card.spec.network_mode
+        elif card.spec.networkRef:
+            kwargs["network"] = card.spec.networkRef.ref.split("/")[-1]
+
+        if card.spec.command:
+            kwargs["command"] = shlex.split(card.spec.command)
+        if card.spec.hostname:
+            kwargs["hostname"] = card.spec.hostname
+        if card.spec.workdir:
+            kwargs["working_dir"] = card.spec.workdir
+        if card.spec.restart_policy:
+            kwargs["restart_policy"] = {"Name": card.spec.restart_policy}
+        if card.spec.mounts:
+            # Docker Desktop handles Windows paths natively — no WSL translation needed.
+            _DOCKER_MOUNT_KEYS = {"type", "source", "target", "read_only"}
+            mounts = []
+            for m in card.spec.mounts:
+                d = {k: v for k, v in m.model_dump().items() if k in _DOCKER_MOUNT_KEYS}
+                mounts.append(d)
+            kwargs["mounts"] = mounts
+        if card.spec.volumes:
+            kwargs["volumes"] = {
+                vol: {"bind": path, "mode": "rw"}
+                for vol, path in card.spec.volumes.items()
+            }
+
+        self._client.containers.create(**kwargs)
+        logger.info(f"Created container: {name}")
+        return name
+
+    def start_container(self, name: str) -> None:
+        self._client.containers.get(name).start()
+        logger.info(f"Started container: {name}")
+
+    def stop_container(self, name: str) -> None:
+        try:
+            self._client.containers.get(name).stop()
+            logger.info(f"Stopped container: {name}")
+        except Exception:
+            logger.debug(f"stop_container: '{name}' not running or not found.")
+
+    def remove_container(self, name: str) -> None:
+        self._client.containers.get(name).remove(force=True)
+        logger.info(f"Removed container: {name}")
+
+    def container_status(self, name: str) -> str:
+        try:
+            return self._client.containers.get(name).status
+        except Exception:
+            return "not_found"
+
+    def container_logs(self, name: str) -> str:
+        raw = self._client.containers.get(name).logs(stdout=True, stderr=True)
+        if isinstance(raw, bytes):
+            return raw.decode("utf-8", errors="replace")
+        return b"".join(raw).decode("utf-8", errors="replace")

--- a/cutip/backends/docker/connection.py
+++ b/cutip/backends/docker/connection.py
@@ -1,0 +1,68 @@
+"""Docker connection management.
+
+Handles connecting to the local Docker daemon via ``docker.from_env()``.
+
+Run standalone to verify connectivity::
+
+    python -m cutip.backends.docker.connection
+"""
+
+from __future__ import annotations
+
+import sys
+
+from loguru import logger
+
+from cutip.utils.exceptions import CutipError
+
+
+def connect_docker_client():
+    """Connect to the local Docker daemon and return a ``DockerClient``.
+
+    Raises:
+        CutipError: If the ``docker`` package is missing or the daemon is unreachable.
+    """
+    try:
+        import docker
+    except ImportError as exc:
+        raise CutipError(
+            "The 'docker' package is required for the Docker backend. "
+            "Run: uv pip install 'cutip[docker]'"
+        ) from exc
+
+    try:
+        client = docker.from_env()
+        client.ping()
+    except Exception as exc:
+        raise CutipError(
+            f"Could not connect to the Docker daemon: {exc}\n"
+            "Is Docker Desktop or the Docker daemon running?"
+        ) from exc
+
+    logger.info("Docker daemon connected.")
+    return client
+
+
+# ── Standalone test ────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    """Verify Docker connectivity without running a full workflow.
+
+    Usage::
+
+        python -m cutip.backends.docker.connection
+    """
+    from cutip.utils.logging import setup_logging
+    setup_logging(level="DEBUG")
+
+    try:
+        client = connect_docker_client()
+    except CutipError as exc:
+        logger.error(str(exc))
+        sys.exit(1)
+
+    logger.info("Ping OK")
+    images = client.images.list()
+    logger.info(f"Images on daemon: {len(images)}")
+    for img in images[:5]:
+        logger.info(f"  {img.tags}")

--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -455,6 +455,13 @@ def run(
         help="Name of the group to run",
         autocompletion=_complete_group_name,
     ),
+    backend: str = typer.Option(
+        "podman",
+        "--backend",
+        "-b",
+        envvar="CUTIP_BACKEND",
+        help="Container backend to use (podman or docker).",
+    ),
     local: bool = typer.Option(
         False,
         "--local",
@@ -465,7 +472,7 @@ def run(
     ),
     path: Path = typer.Option(None, "--path", "-p", show_default=False),
 ) -> None:
-    """Run a group's workflow against the Podman backend.
+    """Run a group's workflow.
 
     CUTIP handles the container lifecycle up to creation; workflow.main(ctx)
     is responsible for starting containers and orchestrating across units.
@@ -504,10 +511,11 @@ def run(
     # Honour env-var shortcut in addition to the CLI flag
     is_local = local or os.environ.get("CUTIP_LOCAL", "").lower() in ("1", "true", "yes")
 
-    # Connect Podman backend
+    # Connect backend
+    backend_name = backend.lower()
     try:
-        from cutip.backends.podman import PodmanBackend
-        _backend = PodmanBackend.connect_local() if is_local else PodmanBackend.connect()
+        from cutip.backends import get_backend
+        _backend = get_backend(backend_name, local=is_local)
     except CutipError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)
@@ -565,7 +573,7 @@ def run(
         write_run_record(
             cutip_dir / "runs",
             group=group_name,
-            backend="podman",
+            backend=backend_name,
             started_at=started_at,
             status=status,
             error=run_error,

--- a/cutip/context/workflow.py
+++ b/cutip/context/workflow.py
@@ -24,7 +24,7 @@ class CutipContext:
         resolved_cards: Mapping of card ref → Card for all transitively resolved cards.
         registry:       The full workspace registry (read-only access).
         project_root:   Absolute path to the project root.
-        runtime:        Raw backend client (PodmanClient). None in dry-run / plan mode.
+        runtime:        Raw backend client (PodmanClient or DockerClient). None in dry-run / plan mode.
         vars:           User-specific variables loaded from ``cutip/vars.yaml``.
                         Replaces the ``.env`` pattern — paths, credentials, and other machine-specific
                         values that should not be committed.  Empty dict if ``cutip/vars.yaml`` is absent.
@@ -39,7 +39,7 @@ class CutipContext:
     vars: dict = field(default_factory=dict)
 
     def container(self, name: str):
-        """Return the live Podman container object for the given container name.
+        """Return the live container object for the given container name.
 
         Use in ``workflow.main()`` to start or inspect a container that CUTIP
         has already created::
@@ -49,8 +49,8 @@ class CutipContext:
 
         The name must match the ``metadata.name`` of the ContainerCard.
 
-        Raises :class:`podman.errors.NotFound` if no container with that name
-        exists (i.e. CUTIP has not yet created it).
+        Raises ``NotFound`` (from the active backend SDK) if no container with
+        that name exists (i.e. CUTIP has not yet created it).
         """
         if self.runtime is None:
             raise RuntimeError(

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -19,7 +19,7 @@ commit messages, and PR titles.
 | cap009 | Rename scaffold hello→simple, add complex project, e2e tests | feat | merged | feat/cap009-scaffold-simple-complex      | #38 | 2026-03-03 |
 | cap010 | cutip from-compose — convert compose.yaml to CUTIP artifacts  | feat | merged  | feat/cap010-from-compose                | #45 | 2026-03-03 |
 | cap011 | cutip push/pull — git-based artifact registry                 | feat | planned | —                                       | —   | —          |
-| cap012 | Docker backend support                                        | feat | planned | —                                       | —   | —          |
+| cap012 | Docker backend support                                        | feat | merged  | feat/cap012-docker-backend              | —   | 2026-03-04 |
 | cap013 | Mac/Apple Silicon Podman CI + docs                           | feat | merged | feat/cap013-mac-podman-ci-docs          | #40 | 2026-03-03 |
 | cap014 | Remove Jenkins, migrate AI doc scripts to GHA               | feat | merged | feat/cap014-remove-jenkins-migrate-gha  | #41 | 2026-03-03 |
 | cap015 | Consolidate GHA workflows + PR auto-label/assign            | feat | merged | feat/cap015-consolidate-workflows       | #42 | 2026-03-03 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "MIT" }
 authors = [
     { name = "Joshua Jerome" },
 ]
-keywords = ["containers", "podman", "devops", "workflow", "infrastructure"]
+keywords = ["containers", "podman", "docker", "devops", "workflow", "infrastructure"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -43,6 +43,7 @@ Repository = "https://github.com/joshuajerome/cutip"
 cutip = "cutip.cli.main:app"
 
 [project.optional-dependencies]
+docker = ["docker>=6.0"]
 docs = [
     "mkdocs-material>=9.5",
     "mkdocs<2.0",              # MkDocs 2.0 is incompatible with mkdocs-material (Feb 2026)

--- a/tests/test_docker_backend.py
+++ b/tests/test_docker_backend.py
@@ -1,0 +1,208 @@
+"""Tests for the Docker backend (all mocked — no real Docker daemon needed)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cutip.utils.exceptions import CutipError
+
+
+# ── Connection tests ─────────────────────────────────────────────────────────
+
+def test_connect_success():
+    mock_client = MagicMock()
+    mock_client.ping.return_value = True
+
+    with patch(
+        "cutip.backends.docker.backend.connect_docker_client",
+        return_value=mock_client,
+    ):
+        from cutip.backends.docker.backend import DockerBackend
+        backend = DockerBackend.connect()
+        assert backend.client is mock_client
+
+
+def test_connect_import_error():
+    with patch(
+        "cutip.backends.docker.backend.connect_docker_client",
+        side_effect=CutipError("The 'docker' package is required"),
+    ):
+        from cutip.backends.docker.backend import DockerBackend
+        with pytest.raises(CutipError, match="docker.*package"):
+            DockerBackend.connect()
+
+
+def test_connect_daemon_error():
+    with patch(
+        "cutip.backends.docker.backend.connect_docker_client",
+        side_effect=CutipError("Could not connect to the Docker daemon"),
+    ):
+        from cutip.backends.docker.backend import DockerBackend
+        with pytest.raises(CutipError, match="Could not connect"):
+            DockerBackend.connect()
+
+
+# ── Image tests ──────────────────────────────────────────────────────────────
+
+def _make_backend(mock_client=None):
+    from cutip.backends.docker.backend import DockerBackend
+    client = mock_client or MagicMock()
+    backend = DockerBackend.__new__(DockerBackend)
+    backend._client = client
+    return backend
+
+
+def _make_image_card(name="hello", image="docker.io/library/alpine", tag="3.20", source="pull"):
+    from cutip.models.cards.image import ImageCard
+    return ImageCard.model_validate({
+        "apiVersion": "cutip/v1",
+        "kind": "ImageCard",
+        "metadata": {"name": name},
+        "spec": {
+            "source": source,
+            "image": image,
+            "tag": tag,
+        },
+    })
+
+
+def test_pull_image_skip_existing():
+    mock_img = MagicMock()
+    mock_img.tags = ["hello:3.20"]
+    client = MagicMock()
+    client.images.list.return_value = [mock_img]
+
+    backend = _make_backend(client)
+    card = _make_image_card()
+    backend.pull_image(card)
+
+    client.images.pull.assert_not_called()
+
+
+def test_pull_image_new():
+    client = MagicMock()
+    client.images.list.return_value = []
+    pulled_img = MagicMock()
+    client.images.pull.return_value = pulled_img
+
+    backend = _make_backend(client)
+    card = _make_image_card()
+    backend.pull_image(card)
+
+    client.images.pull.assert_called_once_with("docker.io/library/alpine", tag="3.20")
+    pulled_img.tag.assert_called_once_with("hello:3.20")
+
+
+# ── Network tests ────────────────────────────────────────────────────────────
+
+def _make_network_card(name="test-net", subnet="10.89.0.0/16", gateway="10.89.0.1"):
+    from cutip.models.cards.network import NetworkCard
+    return NetworkCard.model_validate({
+        "apiVersion": "cutip/v1",
+        "kind": "NetworkCard",
+        "metadata": {"name": name},
+        "spec": {"subnet": subnet, "gateway": gateway},
+    })
+
+
+def test_ensure_network_exists():
+    client = MagicMock()
+    client.networks.get.return_value = MagicMock()
+
+    backend = _make_backend(client)
+    card = _make_network_card()
+    backend.ensure_network(card)
+
+    client.networks.create.assert_not_called()
+
+
+def test_ensure_network_create():
+    client = MagicMock()
+    client.networks.get.side_effect = Exception("not found")
+
+    backend = _make_backend(client)
+    card = _make_network_card()
+
+    # Mock docker.types inside the ensure_network method
+    mock_types = MagicMock()
+    with patch.dict("sys.modules", {"docker": MagicMock(), "docker.types": mock_types}):
+        backend.ensure_network(card)
+
+    client.networks.create.assert_called_once()
+    call_args = client.networks.create.call_args
+    assert call_args[0][0] == "test-net"
+
+
+# ── Container tests ──────────────────────────────────────────────────────────
+
+def test_create_container_no_wsl_translation():
+    """Docker backend should NOT translate Windows paths (Docker Desktop handles them)."""
+    from cutip.models.cards.container import ContainerCard
+    card = ContainerCard.model_validate({
+        "apiVersion": "cutip/v1",
+        "kind": "ContainerCard",
+        "metadata": {"name": "test-ctr"},
+        "spec": {
+            "imageRef": {"ref": "images/hello"},
+            "network_mode": "bridge",
+            "mounts": [
+                {
+                    "type": "bind",
+                    "source": "C:/Users/foo/data",
+                    "target": "/data",
+                }
+            ],
+        },
+    })
+
+    client = MagicMock()
+    client.containers.get.side_effect = Exception("not found")
+
+    backend = _make_backend(client)
+    backend.create_container(card, image_name="hello:3.20")
+
+    call_kwargs = client.containers.create.call_args[1]
+    mounts = call_kwargs["mounts"]
+    # Source must remain as-is — no /mnt/c/ translation
+    assert mounts[0]["source"] == "C:/Users/foo/data"
+
+
+def test_build_image_uses_docker_cli():
+    from cutip.models.cards.image import ImageCard
+    card = ImageCard.model_validate({
+        "apiVersion": "cutip/v1",
+        "kind": "ImageCard",
+        "metadata": {"name": "myimg"},
+        "spec": {
+            "source": "build",
+            "image": "myimg",
+            "tag": "latest",
+            "context": "/tmp/ctx",
+            "dockerfile": "Dockerfile",
+        },
+    })
+
+    backend = _make_backend()
+
+    with patch("cutip.backends.docker.backend.subprocess.Popen") as mock_popen:
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter([])
+        mock_proc.wait.return_value = 0
+        mock_popen.return_value = mock_proc
+
+        with patch("cutip.backends.docker.backend.stage_buildtime_resources") as mock_stage:
+            mock_stage.return_value = "/tmp/ctx"
+            backend.build_image(card)
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[0] == "docker"
+        assert cmd[1] == "build"
+
+
+def test_disconnect():
+    client = MagicMock()
+    backend = _make_backend(client)
+    backend.disconnect()
+    client.close.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -252,7 +252,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },
@@ -268,6 +268,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
+docker = [
+    { name = "docker" },
+]
 docs = [
     { name = "mkdocs" },
     { name = "mkdocs-callouts" },
@@ -282,6 +285,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "docker", marker = "extra == 'docker'", specifier = ">=6.0" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "<2.0" },
     { name = "mkdocs-callouts", marker = "extra == 'docs'", specifier = ">=1.14" },
@@ -294,12 +298,26 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
-provides-extras = ["docs", "dev"]
+provides-extras = ["docker", "docs", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -783,6 +801,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds Docker as a second container backend, selectable via `--backend docker` or `CUTIP_BACKEND=docker`, with Podman remaining the default
- Mirrors PodmanBackend method-for-method: DockerBackend uses `docker.from_env()` for connection, `docker build` CLI for image builds, and `docker.types.IPAMConfig` for networks — no WSL path translation (Docker Desktop handles Windows paths natively)
- Docker SDK is an optional dependency (`pip install cutip[docker]`) so existing Podman-only users are unaffected

## Changes

- `cutip/backends/docker/`: New package with `DockerBackend`, `connect_docker_client()`, and standalone connectivity test
- `cutip/backends/__init__.py`: Added `get_backend(name, local)` factory function
- `cutip/cli/commands/run.py`: Added `--backend`/`-b` option (envvar `CUTIP_BACKEND`), replaced hardcoded PodmanBackend with `get_backend()`
- `cutip/context/workflow.py`: Updated docstrings to be backend-agnostic
- `pyproject.toml`: Added `docker = ["docker>=6.0"]` optional dependency, `"docker"` keyword
- `tests/test_docker_backend.py`: 10 unit tests covering connect, pull, build, network, container, and disconnect (all mocked)
- `.github/workflows/ci.yml`: Added `e2e-docker-ubuntu` job
- `.github/workflows/release.yml`: Added `e2e-docker-ubuntu` job, added to `build-and-release` needs
- `docs/capabilities.md`: Updated cap012 status to merged
- `CLAUDE.md`: Updated backend documentation

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (39/39)
- [x] `cutip run --help` shows `--backend` option
- [ ] CI: e2e-docker-ubuntu job passes on GitHub Actions
- [ ] CI: existing Podman E2E jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
