### PR TITLE
[cap012] Update all documentation for Docker backend support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,8 @@ integration → release/v{X}.{Y}.{Z} → GitHub Release
 ## Recent Work (this development cycle)
 
 - Renamed `containers/` → `resources/`, `containers/resources/` → `resources/buildtime/`
-- Moved `podman>=4.0` to core deps (docker removed as supported backend)
+- `podman>=4.0` is a core dep; `docker>=6.0` is an optional extra (`pip install cutip[docker]`)
+- Docker backend added (cap012): `--backend docker` / `CUTIP_BACKEND=docker`
 - Renamed groups: `main` → `snf-gui` / `snf-blueprint-manager`
 - Added `_validate_vars()` — checks `{{ vars.X }}` refs are present + non-empty (skips generated keys)
 - Added `_prepare_generated_dirs()` — creates generated var directories before lifecycle

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-3776ab)](https://www.python.org/downloads/)
 [![Pydantic v2](https://img.shields.io/badge/pydantic-v2-e92063)](https://docs.pydantic.dev/latest/)
 [![uv](https://img.shields.io/badge/uv-package_manager-6e44ff)](https://github.com/astral-sh/uv)
-[![Runtime](https://img.shields.io/badge/runtime-podman-892ca0)](https://podman.io/)
+[![Runtime](https://img.shields.io/badge/runtime-podman%20%7C%20docker-892ca0)](https://joshuajerome.github.io/cutip/getting-started/installation/)
 [![CI](https://github.com/joshuajerome/cutip/actions/workflows/pr-checks.yml/badge.svg)](https://github.com/joshuajerome/cutip/actions/workflows/pr-checks.yml)
 [![Docs](https://img.shields.io/badge/docs-github%20pages-0969da)](https://joshuajerome.github.io/cutip)
 
@@ -14,7 +14,7 @@ CUTIP is not a replacement for `docker-compose`. It is designed for a different 
 | | docker-compose | CUTIP |
 |---|---|---|
 | **Startup ordering** | `depends_on` with condition polling | Python loop — exec into container, branch on result |
-| **Post-start hooks** | None native | `startup(ctx)` per unit — full podman-py API |
+| **Post-start hooks** | None native | `startup(ctx)` per unit — full container API |
 | **Pre-build file staging** | None | `pre_build(ctx)` — generate config, copy deps before build |
 | **Config variables** | `.env` flat substitution | `vars.yaml` with required/generated sections + fail-fast validation |
 | **Validation** | Runtime only | Static graph validation — no backend required |
@@ -55,7 +55,7 @@ cutip --help
 > **Contributing?** Clone the repo and use `uv pip install -e .` for an editable install — see the [installation guide](https://joshuajerome.github.io/cutip/getting-started/installation/).
 
 > [!NOTE]
-> `cutip init`, `cutip from-compose`, `cutip tree`, `cutip validate`, `cutip show`, and `cutip plan` run without any container runtime installed. Only `cutip run` requires Podman.
+> `cutip init`, `cutip from-compose`, `cutip tree`, `cutip validate`, `cutip show`, and `cutip plan` run without any container runtime installed. Only `cutip run` requires a container backend (Podman or Docker).
 
 ---
 
@@ -116,12 +116,12 @@ cutip run dev
 | `cutip show unit <name>` | Show a unit's resolved card graph |
 | `cutip show group <name>` | Show a group's units and workflow status |
 | `cutip plan <group> [--path]` | Dry-run: print execution table, start nothing |
-| `cutip run <group> [--local] [--path]` | Validate → connect → execute workflow |
+| `cutip run <group> [-b backend] [--local] [--path]` | Validate → connect → execute workflow |
 | `cutip group ls` | List all groups in the workspace |
 | `cutip unit ls` | List all units in the workspace |
 | `cutip card ls` | List all cards in the workspace |
 
-`cutip run` connects to the Podman socket over SSH by default. Pass `--local` to use the local socket directly (useful in CI or rootless setups).
+`cutip run` uses Podman by default. Pass `--backend docker` (or set `CUTIP_BACKEND=docker`) to use Docker instead. For Docker, install the optional extra: `pip install cutip[docker]`. Pass `--local` for direct socket connection (CI / rootless setups).
 
 ---
 
@@ -150,7 +150,7 @@ Full documentation at **[joshuajerome.github.io/cutip](https://joshuajerome.gith
 | [Getting Started](https://joshuajerome.github.io/cutip/getting-started/installation/) | Installation, quickstart, workspace layout |
 | [Concepts](https://joshuajerome.github.io/cutip/concepts/overview/) | The 4-layer model, cards, units, groups, graph resolution |
 | [Reference](https://joshuajerome.github.io/cutip/reference/cli/) | CLI flags, card schemas, workflow contract, exceptions |
-| [Guides](https://joshuajerome.github.io/cutip/guides/runtimes/podman/) | Podman setup, writing workflows, CI/CD |
+| [Guides](https://joshuajerome.github.io/cutip/guides/runtimes/podman/) | Podman/Docker setup, writing workflows, CI/CD |
 
 ---
 

--- a/docs/architecture/backend-interface.md
+++ b/docs/architecture/backend-interface.md
@@ -1,6 +1,6 @@
 # Architecture: Backend Interface
 
-CUTIP's execution layer is abstracted behind `CutipBackend`, an abstract base class in `cutip/backends/base.py`. Podman is the only supported backend. The interface exists to isolate the Podman-specific code and make the execution layer testable independently of the runtime.
+CUTIP's execution layer is abstracted behind `CutipBackend`, an abstract base class in `cutip/backends/base.py`. Two backends are supported: **Podman** (default) and **Docker** (optional, install with `pip install cutip[docker]`). The interface isolates backend-specific code and makes the execution layer testable independently of the runtime.
 
 ---
 
@@ -55,12 +55,23 @@ All `ensure_*` and `create_*` methods must be idempotent — calling them when t
 
 ---
 
+## Available backends
+
+| Backend | Package | Connection | CLI flag |
+|---|---|---|---|
+| `PodmanBackend` | `podman>=4.0` (core dep) | SSH tunnel or local socket | `--backend podman` (default) |
+| `DockerBackend` | `docker>=6.0` (optional) | Local daemon via `docker.from_env()` | `--backend docker` |
+
+The `get_backend(name, local)` factory in `cutip/backends/__init__.py` routes the CLI `--backend` flag to the correct class.
+
+---
+
 ## Implementing a new backend
 
-1. Create `cutip/backends/myruntime.py`
+1. Create `cutip/backends/myruntime/` package
 2. Subclass `CutipBackend` and implement all abstract methods
 3. Add a `connect()` classmethod that returns a connected instance and raises `CutipError` on failure
-4. Wire the new backend into `cutip/cli/commands/run.py` (replace the `PodmanBackend` instantiation with a dispatch on `CUTIP_BACKEND_NAME`)
+4. Register the backend in `cutip/backends/__init__.py` → `get_backend()`
 5. Add the optional dependency to `pyproject.toml` under `[project.optional-dependencies]`
 
 Minimal skeleton:

--- a/docs/architecture/design-decisions.md
+++ b/docs/architecture/design-decisions.md
@@ -59,11 +59,13 @@ Compare this to a base class that requires `super().__init__()`, registering met
 
 ---
 
-## Why SSH tunnel + local socket as separate modes
+## Why SSH tunnel + local socket as separate modes (Podman)
 
-The SSH tunnel mode (`PodmanBackend.connect()`) mirrors how Podman Desktop and the Podman CLI communicate with machines on macOS and Windows — they proxy a Unix socket over SSH. This is the safe, production default.
+The SSH tunnel mode (`PodmanBackend.connect()`) mirrors how Podman Desktop and the Podman CLI communicate with machines on macOS and Windows — they proxy a Unix socket over SSH. This is the safe, production default for the Podman backend.
 
 The local socket mode (`--local`) exists for CI environments where the daemon is already local. Forcing CI to configure SSH keys and connections would be impractical. `CONTAINER_HOST` is the standard Podman convention for this, so CUTIP adopts it rather than inventing its own variable.
+
+The Docker backend always connects locally via `docker.from_env()` — Docker Desktop handles all socket/pipe management internally, so no SSH tunnel or `--local` distinction is needed.
 
 ---
 

--- a/docs/concepts/groups.md
+++ b/docs/concepts/groups.md
@@ -50,7 +50,7 @@ Run them independently:
 
 ```shell
 cutip plan dev
-cutip run staging --backend podman
+cutip run staging
 ```
 
 ---

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | Python | 3.11 | 3.12+ recommended |
 | [uv](https://github.com/astral-sh/uv) | latest | Package manager and virtual environment tool |
-| Podman | any recent | Required only for `cutip run` |
+| Podman **or** Docker | any recent | Required only for `cutip run` — Podman is the default backend |
 
 ---
 
@@ -21,7 +21,7 @@ cutip --help
 
 ## Runtime Setup
 
-### Podman
+### Podman (default)
 
 See the full per-platform guide: [guides/runtimes/podman.md](../guides/runtimes/podman.md)
 
@@ -29,6 +29,17 @@ Summary:
 - **Ubuntu** — `sudo apt-get install podman`, start the user socket
 - **macOS** — `brew install podman && podman machine init --now`
 - **Windows** — Download the MSI from the [Podman releases page](https://github.com/containers/podman/releases), then `podman machine init --now`
+
+### Docker (optional)
+
+Install the Docker extra and have Docker Desktop or the Docker daemon running:
+
+```shell
+pip install cutip[docker]
+cutip run dev --backend docker
+```
+
+See the full guide: [guides/runtimes/docker.md](../guides/runtimes/docker.md)
 
 ---
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-This guide walks you from an empty directory to a running container group in under 10 minutes. It assumes CUTIP is installed and Podman is available.
+This guide walks you from an empty directory to a running container group in under 10 minutes. It assumes CUTIP is installed and a container backend (Podman or Docker) is available.
 
 For installation, see [installation.md](installation.md).
 

--- a/docs/getting-started/why-cutip.md
+++ b/docs/getting-started/why-cutip.md
@@ -10,7 +10,7 @@ This page is an honest comparison. If `docker-compose` does what you need, use i
 |---|---|---|
 | **Model** | Declarative convergence — describe desired state, the runtime figures out transitions | Declarative definitions + imperative Python — YAML for structure, Python for orchestration |
 | **Startup ordering** | `depends_on` with `condition: service_healthy` — polls a healthcheck defined in the file | Full Python: loop, exec into the container, branch on result, log progress |
-| **Post-start hooks** | None native — you write shell scripts and call them yourself | `startup(ctx)` per unit — runs after the container starts, has full `podman-py` API |
+| **Post-start hooks** | None native — you write shell scripts and call them yourself | `startup(ctx)` per unit — runs after the container starts, has full container API |
 | **Pre-build file staging** | None — build context must be ready before `docker compose up` | `pre_build(ctx)` per unit — generate config files, copy local deps, write secrets to build context |
 | **Config variables** | `.env` flat substitution — one level, no validation | `vars.yaml` with `required:` / `generated:` sections — fails fast with a clear error if any required value is missing |
 | **Validation** | Runtime only — errors surface when the daemon tries to create the container | Static graph validation — `cutip validate` checks every ref before any backend is contacted |
@@ -40,7 +40,7 @@ This page is an honest comparison. If `docker-compose` does what you need, use i
 
 The `complex` project runs a **PostgreSQL database** and a **Python web application** that connects to it. It is a realistic setup and it demonstrates four CUTIP capabilities that compose cannot replicate cleanly:
 
-1. **Pre-build config generation** — a Python script writes `config.yaml` into the build context before `podman build` runs
+1. **Pre-build config generation** — a Python script writes `config.yaml` into the build context before the image build runs
 2. **Health-check loop in Python** — the workflow waits for postgres to be ready by exec-ing into it
 3. **Isolated container network** — both containers live on a private network defined in a NetworkCard
 4. **Post-start verification** — startup.py for the web unit confirms the app is serving
@@ -55,7 +55,7 @@ generated:
   db_data_dir: ".cutip-complex-data"   # cutip creates this automatically
 ```
 
-`db_password` is a required var. CUTIP will refuse to run if it is empty — before touching Podman, before pulling images. No silent misconfigurations.
+`db_password` is a required var. CUTIP will refuse to run if it is empty — before touching the container backend, before pulling images. No silent misconfigurations.
 
 `db_data_dir` is a generated var. CUTIP creates `.cutip-complex-data/` at the project root automatically.
 
@@ -125,7 +125,7 @@ The data volume `db_data` is a named volume. CUTIP creates it automatically.
 
 ### Step 4 — Pre-build config generation
 
-The web app reads a `config.yaml` that is baked into its image at build time. CUTIP generates this file before `podman build` runs:
+The web app reads a `config.yaml` that is baked into its image at build time. CUTIP generates this file before the image build runs:
 
 ```python
 # cutip/units/web/startup.py
@@ -153,7 +153,7 @@ def pre_build(ctx: CutipContext) -> None:
     logger.info("Generated resources/buildtime/config.yaml")
 ```
 
-This runs before `podman build`. The Dockerfile copies `config.yaml` from the build context:
+This runs before the image build. The Dockerfile copies `config.yaml` from the build context:
 
 ```dockerfile
 # resources/dockerfiles/web.dockerfile
@@ -279,7 +279,7 @@ INFO    ✓ complex → units/web
 INFO    ✓ complex: workflow.py
 ```
 
-Every ref in every card is resolved. The workflow file is confirmed to exist. The `{{ vars.db_password }}` ref is confirmed non-empty. No Podman socket required. This runs cleanly in CI before any image is pulled.
+Every ref in every card is resolved. The workflow file is confirmed to exist. The `{{ vars.db_password }}` ref is confirmed non-empty. No container runtime required. This runs cleanly in CI before any image is pulled.
 
 ---
 
@@ -295,8 +295,8 @@ cutip plan complex      # prints execution table, starts nothing
 
 cutip run complex
 # pre_build(ctx) generates resources/buildtime/config.yaml
-# podman build web image
-# podman pull postgres:16
+# build web image
+# pull postgres:16
 # workflow.main() starts db, waits 3s for postgres, starts web
 # startup(ctx) confirms web is serving
 # ✓ done

--- a/docs/guides/ci-cd/github-actions.md
+++ b/docs/guides/ci-cd/github-actions.md
@@ -38,13 +38,13 @@ These run on every push and every PR:
     .wheel-test/bin/cutip --help
 ```
 
-Unit tests live in `tests/`. The E2E directory (`tests/e2e/`) is excluded from the unit test job — it requires a live Podman runtime.
+Unit tests live in `tests/`. The E2E directory (`tests/e2e/`) is excluded from the unit test job — it requires a live container runtime (Podman or Docker).
 
 ---
 
-## E2E — Podman (PR-only)
+## E2E — Podman and Docker (PR-only)
 
-E2E runs against two workspaces plus a from-compose validation suite, on Ubuntu and Windows.
+E2E runs against two workspaces plus a from-compose validation suite. Podman E2E runs on Ubuntu and Windows. Docker E2E runs on Ubuntu (Docker is pre-installed on `ubuntu-latest` runners).
 
 ### How each platform gets a working Podman socket
 

--- a/docs/guides/runtimes/docker.md
+++ b/docs/guides/runtimes/docker.md
@@ -1,0 +1,113 @@
+# Guide: Docker Runtime
+
+Docker is an optional container backend. CUTIP also supports [Podman](podman.md) (the default).
+
+---
+
+## Installation
+
+Docker support requires the optional `docker` extra:
+
+```shell
+pip install cutip[docker]
+```
+
+This installs the `docker` Python SDK (`docker>=6.0`). You also need Docker Desktop or the Docker daemon running.
+
+---
+
+## Usage
+
+Pass `--backend docker` to `cutip run`, or set the environment variable:
+
+```shell
+# CLI flag
+cutip run dev --backend docker
+
+# Environment variable
+CUTIP_BACKEND=docker cutip run dev
+```
+
+Docker always connects to the local daemon via `docker.from_env()`. The `--local` flag is accepted but has no effect (Docker does not use SSH tunnels).
+
+---
+
+## Platform setup
+
+### Ubuntu / Linux
+
+Docker is pre-installed on most CI environments (including GitHub Actions `ubuntu-latest`). For local development:
+
+```shell
+# Install Docker Engine (official docs: https://docs.docker.com/engine/install/)
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Add your user to the docker group (avoids sudo)
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Verify
+docker version
+```
+
+### macOS
+
+Install [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/):
+
+```shell
+# Or via Homebrew
+brew install --cask docker
+
+# Start Docker Desktop, then verify
+docker version
+```
+
+### Windows
+
+Install [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/). Docker Desktop handles Windows path translation natively — no WSL path conversion is needed (unlike Podman).
+
+```powershell
+docker version
+```
+
+---
+
+## CI usage (GitHub Actions)
+
+Docker is pre-installed on `ubuntu-latest` runners. Install CUTIP with the docker extra:
+
+```yaml
+- name: Install cutip with docker extra
+  run: |
+    uv venv .venv
+    uv pip install -e ".[docker]"
+
+- name: Run E2E
+  run: uv run cutip run dev --path tests/e2e/simple --backend docker --local
+```
+
+---
+
+## Differences from Podman
+
+| | Podman | Docker |
+|---|---|---|
+| **Connection** | SSH tunnel (default) or local socket | Local daemon only |
+| **Windows paths** | Translated to WSL2 format (`/mnt/c/...`) | Native — Docker Desktop handles translation |
+| **Network creation** | Raw IPAM dict | `docker.types.IPAMConfig` / `IPAMPool` |
+| **Image build** | `podman build` CLI | `docker build` CLI |
+| **Package** | `podman>=4.0` (core dependency) | `docker>=6.0` (optional extra) |
+
+---
+
+## Troubleshooting
+
+**`The 'docker' package is required`**
+→ Install the optional extra: `pip install cutip[docker]`
+
+**`Could not connect to the Docker daemon`**
+→ Docker Desktop or the Docker daemon is not running. Start it and retry.
+
+**`Permission denied` on Linux**
+→ Add your user to the `docker` group: `sudo usermod -aG docker $USER`

--- a/docs/guides/runtimes/podman.md
+++ b/docs/guides/runtimes/podman.md
@@ -1,6 +1,6 @@
 # Guide: Podman Runtime
 
-Podman is the only supported container backend. CUTIP supports two connection modes:
+Podman is the default container backend. CUTIP also supports [Docker](docker.md). Podman offers two connection modes:
 
 | Mode | Command | Use case |
 |---|---|---|

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-3776ab)](https://www.python.org/downloads/)
 [![Pydantic v2](https://img.shields.io/badge/pydantic-v2-e92063)](https://docs.pydantic.dev/latest/)
 [![uv](https://img.shields.io/badge/uv-package_manager-6e44ff)](https://github.com/astral-sh/uv)
-[![Runtime](https://img.shields.io/badge/runtime-podman-892ca0)](https://podman.io/)
+[![Runtime](https://img.shields.io/badge/runtime-podman%20%7C%20docker-892ca0)](getting-started/installation.md)
 
 **Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments using structured YAML artifacts and Python workflows.
 
@@ -41,7 +41,7 @@ cutip --help
 > **Contributing?** Clone the repo and use `uv pip install -e .` for an editable install — see [Installation](getting-started/installation.md).
 
 > [!NOTE]
-> `cutip init`, `cutip tree`, `cutip validate`, `cutip show`, and `cutip plan` run without any container runtime installed. Only `cutip run` requires Podman.
+> `cutip init`, `cutip tree`, `cutip validate`, `cutip show`, and `cutip plan` run without any container runtime installed. Only `cutip run` requires a container backend (Podman or Docker).
 
 ---
 
@@ -88,6 +88,6 @@ cutip run dev
 | `cutip show unit <name>` | Show a unit's resolved card graph |
 | `cutip show group <name>` | Show a group's units and workflow status |
 | `cutip plan <group> [--path]` | Dry-run: print execution table, start nothing |
-| `cutip run <group> [--local] [--path]` | Validate → connect → execute workflow |
+| `cutip run <group> [-b backend] [--local] [--path]` | Validate → connect → execute workflow |
 
 Full reference: [CLI Reference](reference/cli.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -160,15 +160,36 @@ Plan for group: dev
 Validate, connect to the backend, and execute the group's workflow.
 
 ```shell
-cutip run <group> [--local] [--path PATH]
+cutip run <group> [--backend BACKEND] [--local] [--path PATH]
 ```
 
 | Flag | Default | Description |
 |---|---|---|
-| `--local / -l` | `false` | Connect to the local Podman socket directly (no SSH tunnel). Required for CI. |
+| `--backend / -b` | `podman` | Container backend to use (`podman` or `docker`). |
+| `--local / -l` | `false` | Connect to the local Podman socket directly (no SSH tunnel). Required for CI. Ignored by Docker. |
 | `--path / -p` | git root / cwd | Override project root |
 
-### Connection modes
+### Backend selection
+
+CUTIP supports two container backends:
+
+| Backend | Install | Connection |
+|---|---|---|
+| **Podman** (default) | `pip install cutip` | SSH tunnel or local socket |
+| **Docker** | `pip install cutip[docker]` | Local daemon via `docker.from_env()` |
+
+```shell
+# Podman (default)
+cutip run dev
+
+# Docker
+cutip run dev --backend docker
+
+# Or via environment variable
+CUTIP_BACKEND=docker cutip run dev
+```
+
+### Podman connection modes
 
 **SSH tunnel (default):**
 
@@ -193,9 +214,9 @@ Connects directly to the local Podman socket. Socket URL is resolved in priority
 
 | Variable | Effect |
 |---|---|
+| `CUTIP_BACKEND` | Backend name (`podman` or `docker`) — equivalent to `--backend` |
 | `CUTIP_LOCAL=1` | Equivalent to passing `--local` |
 | `CONTAINER_HOST` | Podman socket URL (used by `--local`) |
-| `CUTIP_BACKEND_NAME` | Informational — passed to `workflow.py` via `os.environ` |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - Guides:
     - Runtimes:
       - Podman: guides/runtimes/podman.md
+      - Docker: guides/runtimes/docker.md
     - Workflows:
       - Writing Workflows: guides/workflows/writing-workflows.md
       - Plan-Safe Workflows: guides/workflows/plan-safe.md


### PR DESCRIPTION
## Summary

- Scanned every documentation file for outdated "Podman-only" references after cap012 added Docker backend support
- Updated 14 files across README, docs site, architecture docs, CLI reference, guides, and CLAUDE.md
- Created new `docs/guides/runtimes/docker.md` runtime guide

## Changes

- `README.md`: Updated badge (podman | docker), comparison table, install note, CLI table, run description, guides link
- `docs/index.md`: Updated badge, install note, CLI table
- `docs/architecture/backend-interface.md`: Removed "only supported backend", added backends table, updated "implementing a backend" instructions
- `docs/architecture/design-decisions.md`: Added Docker context to SSH tunnel design decision
- `docs/concepts/groups.md`: Removed outdated `--backend podman` CLI example
- `docs/getting-started/installation.md`: Added Docker to requirements table, added Docker runtime setup section
- `docs/getting-started/quickstart.md`: Changed "Podman is available" → "container backend is available"
- `docs/getting-started/why-cutip.md`: Replaced "podman-py API" → "container API", made all `podman build` references backend-agnostic
- `docs/guides/ci-cd/github-actions.md`: Updated E2E section to mention Docker alongside Podman
- `docs/guides/runtimes/podman.md`: Changed "only supported" → "default", added link to Docker guide
- `docs/guides/runtimes/docker.md`: **New file** — full Docker runtime guide (install, usage, platform setup, CI, differences from Podman, troubleshooting)
- `docs/reference/cli.md`: Added `--backend` flag, backend selection table, updated env vars table
- `mkdocs.yml`: Added Docker guide to nav
- `CLAUDE.md`: Updated "Recent Work" section

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (39/39)
- [x] `uv run mkdocs build --strict` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
