### PR TITLE
[cap022] Read backend from cutip.yaml project config

### DIFF
--- a/cutip/cli/commands/compose.py
+++ b/cutip/cli/commands/compose.py
@@ -804,7 +804,11 @@ def from_compose(
 
         doc = {
             "apiVersion": "cutip/v1",
-            "project": {"name": project_root.name, "version": "0.1.0"},
+            "project": {
+                "name": project_root.name,
+                "version": "0.1.0",
+                "backend": "podman",
+            },
         }
         cutip_yaml_path.write_text(
             _yaml.dump(doc, default_flow_style=False, sort_keys=False),

--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -506,6 +506,30 @@ def _run_unit_startups(
 
 
 # ---------------------------------------------------------------------------
+# Project config helpers
+# ---------------------------------------------------------------------------
+
+def _load_project_backend(project_root: Path) -> str | None:
+    """Read ``project.backend`` from ``cutip.yaml`` if it exists.
+
+    Returns the backend name (e.g. ``"podman"``, ``"docker"``) or ``None``
+    when the file is missing or the field is absent.
+    """
+    import yaml as _yaml
+
+    config_path = project_root / "cutip.yaml"
+    if not config_path.exists():
+        return None
+
+    data = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    project = data.get("project") or {}
+    backend_val = project.get("backend")
+    if backend_val is not None:
+        return str(backend_val).lower()
+    return None
+
+
+# ---------------------------------------------------------------------------
 # CLI command
 # ---------------------------------------------------------------------------
 
@@ -516,11 +540,12 @@ def run(
         autocompletion=_complete_group_name,
     ),
     backend: str = typer.Option(
-        "podman",
+        None,
         "--backend",
         "-b",
         envvar="CUTIP_BACKEND",
-        help="Container backend to use (podman or docker).",
+        help="Container backend to use (podman or docker). "
+             "Defaults to project.backend in cutip.yaml, then podman.",
     ),
     local: bool = typer.Option(
         False,
@@ -571,8 +596,15 @@ def run(
     # Honour env-var shortcut in addition to the CLI flag
     is_local = local or os.environ.get("CUTIP_LOCAL", "").lower() in ("1", "true", "yes")
 
+    # Resolve backend: -b / CUTIP_BACKEND → cutip.yaml → podman
+    backend_name = (
+        backend.lower() if backend
+        else _load_project_backend(project_root)
+        or "podman"
+    )
+    logger.debug(f"Using backend: {backend_name}")
+
     # Connect backend
-    backend_name = backend.lower()
     try:
         from cutip.backends import get_backend
         _backend = get_backend(backend_name, local=is_local)

--- a/cutip/workspace/scaffold.py
+++ b/cutip/workspace/scaffold.py
@@ -800,6 +800,7 @@ class WorkspaceScaffold:
             "project": {
                 "name": project_name,
                 "version": "0.1.0",
+                "backend": "podman",
             },
         }
         with config_path.open("w", encoding="utf-8") as fh:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -29,6 +29,7 @@ commit messages, and PR titles.
 | cap019 | Revise CI workflow matrix, Test PyPI continuity, and retry policy | feat | merged | feat/cap019-ci-matrix-testpypi-retry | #47 | 2026-03-03 |
 | cap020 | Add from-compose E2E tests for 5 awesome-compose projects         | feat | open   | feat/cap020-e2e-from-compose-matrix  | #48 | 2026-03-03 |
 | cap021 | Rename vars.yaml → paths.yaml + add cutip/secrets.yaml            | feat | merged | feat/cap021-paths-secrets-split      | #53 | 2026-03-04 |
+| cap022 | Read backend from cutip.yaml project config                       | feat | open   | feat/cap022-yaml-backend             | —   | 2026-03-04 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

- Reads `project.backend` from `cutip.yaml` so the backend choice persists across runs
- Resolution order: `-b` flag / `CUTIP_BACKEND` env → `cutip.yaml project.backend` → `podman`
- Scaffold and from-compose now include `backend: podman` in generated `cutip.yaml`

## Changes

- `cutip/cli/commands/run.py`: Add `_load_project_backend()` helper; change typer default to `None` and layer resolution
- `cutip/workspace/scaffold.py`: Include `backend: podman` in generated `cutip.yaml`
- `cutip/cli/commands/compose.py`: Include `backend: podman` in generated `cutip.yaml`
- `docs/capabilities.md`: Register cap022

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (39/39)
- [ ] `cutip init` generates `cutip.yaml` with `backend: podman`
- [ ] Setting `backend: docker` in `cutip.yaml` causes `cutip run` to use Docker without `-b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
