### PR TITLE
[cap022] Make docker the default backend, promote to core dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,13 +139,13 @@ jobs:
         run: uv run cutip validate --path tests/e2e/simple
 
       - name: Run E2E group simple (Podman · Ubuntu)
-        run: uv run cutip run simple --path tests/e2e/simple --local
+        run: uv run cutip run simple --path tests/e2e/simple --backend podman --local
 
       - name: Validate complex workspace
         run: uv run cutip validate --path tests/e2e/complex
 
       - name: Run E2E group complex (Podman · Ubuntu)
-        run: uv run cutip run complex --path tests/e2e/complex --local
+        run: uv run cutip run complex --path tests/e2e/complex --backend podman --local
 
       # ── from-compose: awesome-compose validation suite ──────────────────────
       - name: "from-compose · react-nginx"
@@ -317,13 +317,13 @@ jobs:
         run: uv run cutip validate --path tests/e2e/simple
 
       - name: Run E2E group simple (Podman · Windows)
-        run: uv run cutip run simple --path tests/e2e/simple
+        run: uv run cutip run simple --path tests/e2e/simple --backend podman
 
       - name: Validate complex workspace
         run: uv run cutip validate --path tests/e2e/complex
 
       - name: Run E2E group complex (Podman · Windows)
-        run: uv run cutip run complex --path tests/e2e/complex
+        run: uv run cutip run complex --path tests/e2e/complex --backend podman
 
       # ── from-compose: awesome-compose validation suite ──────────────────────
       - name: "from-compose · react-nginx (Windows)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,13 +80,13 @@ jobs:
         run: uv run cutip validate --path tests/e2e/simple
 
       - name: Run E2E group simple (Podman · Ubuntu)
-        run: uv run cutip run simple --path tests/e2e/simple --local
+        run: uv run cutip run simple --path tests/e2e/simple --backend podman --local
 
       - name: Validate complex workspace
         run: uv run cutip validate --path tests/e2e/complex
 
       - name: Run E2E group complex (Podman · Ubuntu)
-        run: uv run cutip run complex --path tests/e2e/complex --local
+        run: uv run cutip run complex --path tests/e2e/complex --backend podman --local
 
       # ── from-compose: awesome-compose validation suite ──────────────────────
       - name: "from-compose · react-nginx"
@@ -254,13 +254,13 @@ jobs:
         run: uv run cutip validate --path tests/e2e/simple
 
       - name: Run E2E group simple (Podman · Windows)
-        run: uv run cutip run simple --path tests/e2e/simple
+        run: uv run cutip run simple --path tests/e2e/simple --backend podman
 
       - name: Validate complex workspace
         run: uv run cutip validate --path tests/e2e/complex
 
       - name: Run E2E group complex (Podman · Windows)
-        run: uv run cutip run complex --path tests/e2e/complex
+        run: uv run cutip run complex --path tests/e2e/complex --backend podman
 
       # ── from-compose: awesome-compose validation suite ──────────────────────
       - name: "from-compose · react-nginx (Windows)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What is CUTIP
 
-**Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments with structured YAML artifacts and Python workflows. **Podman (default) and Docker are supported backends.** Select with `--backend docker` or `CUTIP_BACKEND=docker`.
+**Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments with structured YAML artifacts and Python workflows. **Docker (default) and Podman are supported backends.** Select with `--backend podman` or `CUTIP_BACKEND=podman`.
 
 ## Deliverables — End-to-End Mandate
 
@@ -226,7 +226,7 @@ integration → release/v{X}.{Y}.{Z} → GitHub Release
 ## Recent Work (this development cycle)
 
 - Renamed `containers/` → `resources/`, `containers/resources/` → `resources/buildtime/`
-- `podman>=4.0` is a core dep; `docker>=6.0` is an optional extra (`pip install cutip[docker]`)
+- Both `podman>=4.0` and `docker>=6.0` are core deps; docker is the default backend
 - Docker backend added (cap012): `--backend docker` / `CUTIP_BACKEND=docker`
 - Renamed groups: `main` → `snf-gui` / `snf-blueprint-manager`
 - Added `_validate_refs()` — checks `{{ paths.X }}` / `{{ secrets.X }}` refs are present + non-empty (skips generated keys)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ cutip run dev
 | `cutip unit ls` | List all units in the workspace |
 | `cutip card ls` | List all cards in the workspace |
 
-`cutip run` uses Podman by default. Pass `--backend docker` (or set `CUTIP_BACKEND=docker`) to use Docker instead. For Docker, install the optional extra: `pip install cutip[docker]`. Pass `--local` for direct socket connection (CI / rootless setups).
+`cutip run` uses Docker by default. Pass `--backend podman` (or set `CUTIP_BACKEND=podman`) to use Podman instead. Set `project.backend` in `cutip.yaml` to persist the choice. Pass `--local` for direct socket connection (CI / rootless setups).
 
 ---
 

--- a/cutip/backends/docker/connection.py
+++ b/cutip/backends/docker/connection.py
@@ -27,7 +27,7 @@ def connect_docker_client():
     except ImportError as exc:
         raise CutipError(
             "The 'docker' package is required for the Docker backend. "
-            "Run: uv pip install 'cutip[docker]'"
+            "Run: uv pip install docker"
         ) from exc
 
     try:

--- a/cutip/cli/commands/compose.py
+++ b/cutip/cli/commands/compose.py
@@ -807,7 +807,7 @@ def from_compose(
             "project": {
                 "name": project_root.name,
                 "version": "0.1.0",
-                "backend": "podman",
+                "backend": "docker",
             },
         }
         cutip_yaml_path.write_text(

--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -544,8 +544,8 @@ def run(
         "--backend",
         "-b",
         envvar="CUTIP_BACKEND",
-        help="Container backend to use (podman or docker). "
-             "Defaults to project.backend in cutip.yaml, then podman.",
+        help="Container backend to use (docker or podman). "
+             "Defaults to project.backend in cutip.yaml, then docker.",
     ),
     local: bool = typer.Option(
         False,
@@ -596,11 +596,11 @@ def run(
     # Honour env-var shortcut in addition to the CLI flag
     is_local = local or os.environ.get("CUTIP_LOCAL", "").lower() in ("1", "true", "yes")
 
-    # Resolve backend: -b / CUTIP_BACKEND → cutip.yaml → podman
+    # Resolve backend: -b / CUTIP_BACKEND → cutip.yaml → docker
     backend_name = (
         backend.lower() if backend
         else _load_project_backend(project_root)
-        or "podman"
+        or "docker"
     )
     logger.debug(f"Using backend: {backend_name}")
 

--- a/cutip/workspace/scaffold.py
+++ b/cutip/workspace/scaffold.py
@@ -800,7 +800,7 @@ class WorkspaceScaffold:
             "project": {
                 "name": project_name,
                 "version": "0.1.0",
-                "backend": "podman",
+                "backend": "docker",
             },
         }
         with config_path.open("w", encoding="utf-8") as fh:

--- a/docs/architecture/backend-interface.md
+++ b/docs/architecture/backend-interface.md
@@ -1,6 +1,6 @@
 # Architecture: Backend Interface
 
-CUTIP's execution layer is abstracted behind `CutipBackend`, an abstract base class in `cutip/backends/base.py`. Two backends are supported: **Podman** (default) and **Docker** (optional, install with `pip install cutip[docker]`). The interface isolates backend-specific code and makes the execution layer testable independently of the runtime.
+CUTIP's execution layer is abstracted behind `CutipBackend`, an abstract base class in `cutip/backends/base.py`. Two backends are supported: **Docker** (default) and **Podman**. Both are core dependencies. The interface isolates backend-specific code and makes the execution layer testable independently of the runtime.
 
 ---
 
@@ -59,8 +59,8 @@ All `ensure_*` and `create_*` methods must be idempotent — calling them when t
 
 | Backend | Package | Connection | CLI flag |
 |---|---|---|---|
-| `PodmanBackend` | `podman>=4.0` (core dep) | SSH tunnel or local socket | `--backend podman` (default) |
-| `DockerBackend` | `docker>=6.0` (optional) | Local daemon via `docker.from_env()` | `--backend docker` |
+| `PodmanBackend` | `podman>=4.0` (core dep) | SSH tunnel or local socket | `--backend podman` |
+| `DockerBackend` | `docker>=6.0` (core dep) | Local daemon via `docker.from_env()` | `--backend docker` (default) |
 
 The `get_backend(name, local)` factory in `cutip/backends/__init__.py` routes the CLI `--backend` flag to the correct class.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,13 +30,13 @@ Summary:
 - **macOS** — `brew install podman && podman machine init --now`
 - **Windows** — Download the MSI from the [Podman releases page](https://github.com/containers/podman/releases), then `podman machine init --now`
 
-### Docker (optional)
+### Docker (default)
 
-Install the Docker extra and have Docker Desktop or the Docker daemon running:
+Docker is included by default. Have Docker Desktop or the Docker daemon running:
 
 ```shell
-pip install cutip[docker]
-cutip run dev --backend docker
+pip install cutip
+cutip run dev
 ```
 
 See the full guide: [guides/runtimes/docker.md](../guides/runtimes/docker.md)

--- a/docs/guides/runtimes/docker.md
+++ b/docs/guides/runtimes/docker.md
@@ -1,31 +1,44 @@
 # Guide: Docker Runtime
 
-Docker is an optional container backend. CUTIP also supports [Podman](podman.md) (the default).
+Docker is the default container backend. CUTIP also supports [Podman](podman.md).
 
 ---
 
 ## Installation
 
-Docker support requires the optional `docker` extra:
+Docker is included as a core dependency — no extras needed:
 
 ```shell
-pip install cutip[docker]
+pip install cutip
 ```
 
-This installs the `docker` Python SDK (`docker>=6.0`). You also need Docker Desktop or the Docker daemon running.
+You also need Docker Desktop or the Docker daemon running.
 
 ---
 
 ## Usage
 
-Pass `--backend docker` to `cutip run`, or set the environment variable:
+Docker is used by default. To be explicit, or to persist the choice per-project:
 
 ```shell
-# CLI flag
+# Default — just works
+cutip run dev
+
+# Explicit CLI flag
 cutip run dev --backend docker
 
 # Environment variable
 CUTIP_BACKEND=docker cutip run dev
+```
+
+Or set `backend: docker` in `cutip.yaml`:
+
+```yaml
+apiVersion: cutip/v1
+project:
+  name: my-project
+  version: 0.1.0
+  backend: docker
 ```
 
 Docker always connects to the local daemon via `docker.from_env()`. The `--local` flag is accepted but has no effect (Docker does not use SSH tunnels).
@@ -75,36 +88,33 @@ docker version
 
 ## CI usage (GitHub Actions)
 
-Docker is pre-installed on `ubuntu-latest` runners. Install CUTIP with the docker extra:
+Docker is pre-installed on `ubuntu-latest` runners:
 
 ```yaml
-- name: Install cutip with docker extra
+- name: Install cutip
   run: |
     uv venv .venv
-    uv pip install -e ".[docker]"
+    uv pip install -e .
 
 - name: Run E2E
-  run: uv run cutip run dev --path tests/e2e/simple --backend docker --local
+  run: uv run cutip run dev --path tests/e2e/simple --local
 ```
 
 ---
 
 ## Differences from Podman
 
-| | Podman | Docker |
+| | Docker (default) | Podman |
 |---|---|---|
-| **Connection** | SSH tunnel (default) or local socket | Local daemon only |
-| **Windows paths** | Translated to WSL2 format (`/mnt/c/...`) | Native — Docker Desktop handles translation |
-| **Network creation** | Raw IPAM dict | `docker.types.IPAMConfig` / `IPAMPool` |
-| **Image build** | `podman build` CLI | `docker build` CLI |
-| **Package** | `podman>=4.0` (core dependency) | `docker>=6.0` (optional extra) |
+| **Connection** | Local daemon only | SSH tunnel (default) or local socket |
+| **Windows paths** | Native — Docker Desktop handles translation | Translated to WSL2 format (`/mnt/c/...`) |
+| **Network creation** | `docker.types.IPAMConfig` / `IPAMPool` | Raw IPAM dict |
+| **Image build** | `docker build` CLI | `podman build` CLI |
+| **Package** | `docker>=6.0` (core dependency) | `podman>=4.0` (core dependency) |
 
 ---
 
 ## Troubleshooting
-
-**`The 'docker' package is required`**
-→ Install the optional extra: `pip install cutip[docker]`
 
 **`Could not connect to the Docker daemon`**
 → Docker Desktop or the Docker daemon is not running. Start it and retry.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -173,20 +173,20 @@ cutip run <group> [--backend BACKEND] [--local] [--path PATH]
 
 CUTIP supports two container backends:
 
-| Backend | Install | Connection |
-|---|---|---|
-| **Podman** (default) | `pip install cutip` | SSH tunnel or local socket |
-| **Docker** | `pip install cutip[docker]` | Local daemon via `docker.from_env()` |
+| Backend | Connection |
+|---|---|
+| **Docker** (default) | Local daemon via `docker.from_env()` |
+| **Podman** | SSH tunnel or local socket |
 
 ```shell
-# Podman (default)
+# Docker (default)
 cutip run dev
 
-# Docker
-cutip run dev --backend docker
+# Podman
+cutip run dev --backend podman
 
 # Or via environment variable
-CUTIP_BACKEND=docker cutip run dev
+CUTIP_BACKEND=podman cutip run dev
 ```
 
 ### Podman connection modes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "loguru>=0.7",
     "rich>=13.0",
     "podman>=4.0",
+    "docker>=6.0",
 ]
 
 [project.urls]
@@ -43,7 +44,6 @@ Repository = "https://github.com/joshuajerome/cutip"
 cutip = "cutip.cli.main:app"
 
 [project.optional-dependencies]
-docker = ["docker>=6.0"]
 docs = [
     "mkdocs-material>=9.5",
     "mkdocs<2.0",              # MkDocs 2.0 is incompatible with mkdocs-material (Feb 2026)

--- a/uv.lock
+++ b/uv.lock
@@ -252,9 +252,10 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "0.1.6"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
+    { name = "docker" },
     { name = "loguru" },
     { name = "podman" },
     { name = "pydantic" },
@@ -267,9 +268,6 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
-]
-docker = [
-    { name = "docker" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -285,7 +283,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "docker", marker = "extra == 'docker'", specifier = ">=6.0" },
+    { name = "docker", specifier = ">=6.0" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "<2.0" },
     { name = "mkdocs-callouts", marker = "extra == 'docs'", specifier = ">=1.14" },
@@ -298,7 +296,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
-provides-extras = ["docker", "docs", "dev"]
+provides-extras = ["docs", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Promotes `docker>=6.0` from optional extra to core dependency — both backends ship with `pip install cutip`
- Changes default backend from podman to docker (more users have Docker installed)
- Updates scaffold, from-compose, and run fallback to default to `docker`
- Updates all docs, README, and CLAUDE.md to reflect docker-first default

## Changes

- `pyproject.toml`: move `docker>=6.0` to core deps, remove `[docker]` extra
- `cutip/cli/commands/run.py`: default fallback `"podman"` → `"docker"`
- `cutip/workspace/scaffold.py`: generated `cutip.yaml` defaults to `backend: docker`
- `cutip/cli/commands/compose.py`: same
- `cutip/backends/docker/connection.py`: remove `cutip[docker]` from error message
- Docs: `backend-interface.md`, `installation.md`, `docker.md`, `cli.md`, `README.md`, `CLAUDE.md`

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (39/39)
- [x] `uv run mkdocs build --strict` passes
- [ ] CI E2E: Docker and Podman jobs both pass (each explicitly passes `--backend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)