### PR TITLE
[cap024] Reorganize .claude/ with github/ subdirectory

### DIFF
--- a/.claude/github/issues.md
+++ b/.claude/github/issues.md
@@ -1,0 +1,82 @@
+# GitHub Issue Pipeline
+
+How CUTIP handles automated issue diagnosis and resolution via GitHub Actions.
+
+---
+
+## State Machine
+
+Issues progress through labels that represent pipeline stages:
+
+```
+(new issue)
+    │
+    ▼ code owner adds `claude-review` label
+claude-review
+    │
+    ▼ workflow runs diagnosis
+claude-diagnosing  (transient — while Claude is working)
+    │
+    ▼ diagnosis posted as comment
+claude-diagnosed
+    │
+    ▼ user comments `/acknowledge`
+claude-acknowledged
+    │
+    ▼ code owner comments `/continue`
+claude-fixing  (transient — while Claude generates fix)
+    │
+    ▼ fix branch pushed + TestPyPI published
+claude-fixed
+    │
+    ├─▶ user comments `/approve` → waits for code owner `/continue`
+    │       │
+    │       ▼ PR opened to staging
+    │   claude-staging
+    │
+    └─▶ user comments `/deny` → resets to claude-diagnosed
+            (re-entry template posted)
+```
+
+## Labels
+
+| Label | Color | Description | Transient? |
+|-------|-------|-------------|------------|
+| `claude-review` | `#0075ca` | Needs Claude diagnosis | No |
+| `claude-diagnosing` | `#e4e669` | Claude is diagnosing | Yes |
+| `claude-diagnosed` | `#cfd3d7` | Claude diagnosis posted | No |
+| `claude-acknowledged` | `#c2e0c6` | User acknowledged diagnosis | No |
+| `claude-fixing` | `#e4e669` | Claude is generating fix | Yes |
+| `claude-fixed` | `#0e8a16` | Claude fix ready for review | No |
+| `claude-staging` | `#1d76db` | Fix PR opened to staging | No |
+
+## Slash Commands
+
+| Command | Who | When (required label) | Effect |
+|---------|-----|-----------------------|--------|
+| `/continue` | Code owner | `claude-review` (no label) | Start diagnosis |
+| `/continue` | Code owner | `claude-acknowledged` | Start fix generation |
+| `/continue` | Code owner | `claude-fixed` + `/approve` | Open PR to staging |
+| `/acknowledge` | User | `claude-diagnosed` | Accept diagnosis, wait for code owner |
+| `/approve` | User | `claude-fixed` | Approve the fix (needs code owner `/continue`) |
+| `/deny` | User | `claude-fixed` | Reject fix, post re-entry template |
+
+## Workflow File
+
+`.github/workflows/issues.yml` — triggered by `issues: [labeled]` and `issue_comment: [created]`.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `.github/scripts/diagnose-issue.py` | Calls Claude API to diagnose root cause |
+| `.github/scripts/fix-issue.py` | Calls Claude API to generate minimal fix |
+| `.github/scripts/deny-template.md` | Re-entry template for rejected fixes |
+
+## Bot Identity
+
+Comments are posted by `cutip-bot` (GitHub App). Falls back to `github-actions[bot]` if the App is not configured. See cap025 for setup.
+
+## Self-Service Mode
+
+Users with `ANTHROPIC_API_KEY` can bypass the pipeline and run diagnosis/fixes locally via `cutip issue diagnose` and `cutip issue fix`. See cap027.

--- a/.claude/github/prs.md
+++ b/.claude/github/prs.md
@@ -1,0 +1,57 @@
+# GitHub PR Conventions
+
+Pull request standards for the CUTIP project.
+
+---
+
+## Branch → PR Mapping
+
+| Branch pattern | Base branch | Label | Assignee |
+|----------------|-------------|-------|----------|
+| `feat/cap{N}-*` | `staging` | `feature` | `joshuajerome` |
+| `bug/cap{N}-*` | `staging` | `bugfix` | `joshuajerome` |
+| `docs/cap{N}-*` | `staging` | `documentation` | `joshuajerome` |
+| `gh/*` | `staging` | `automation` | `joshuajerome` |
+| `claude/*` | `staging` | — | `joshuajerome` |
+| `release/v*` | — | — | — (handled by release.yml) |
+
+## PR Title Format
+
+```
+[cap{N}] Short imperative description
+```
+
+For non-cap branches (gh/*, claude/*): use a descriptive title without cap prefix.
+
+## PR Body Template
+
+Use `.claude/templates/pr-body.md` — pick the section matching your branch type.
+
+## CI Expectations
+
+All PRs to `staging` and `integration` run `.github/workflows/pr-checks.yml`:
+- Wheel build
+- Unit tests (`pytest tests/ -v --ignore=tests/e2e`)
+- Lint / type checks (if configured)
+
+PRs must pass all checks before merge. For transient CI failures:
+```bash
+gh run rerun <run-id> --failed
+```
+
+## Label Rules
+
+- **`feature`** — NOT "feat". Use `--label "feature"` for feature PRs.
+- **`bugfix`** — for bug fix PRs
+- **`documentation`** — for docs-only PRs
+- **`automation`** — for CI/CD and workflow changes
+
+## Merge Strategy
+
+- Squash merge for feature/bug branches → staging
+- Merge commit for staging → integration (preserves history)
+- Never force-push to `staging` or `integration`
+
+## Auto-generated PRs
+
+After a PR merges to `staging`, `.github/workflows/docs-generate.yml` auto-creates a `docs/cap{N}-*` PR with updated patch notes and capability registry entries.

--- a/.claude/github/releases.md
+++ b/.claude/github/releases.md
@@ -1,0 +1,59 @@
+# GitHub Release Pipeline
+
+How CUTIP versions are cut and published.
+
+---
+
+## Release Flow
+
+```
+integration (stable) → release/v{X}.{Y}.{Z} branch
+    → release.yml creates git tag v{X.Y.Z}
+    → GitHub Release page created
+    → Wheel asset attached
+    → Branch deleted (tag is the durable marker)
+```
+
+## Steps (automated by `.claude/workflows/release.md`)
+
+1. Determine version: read `pyproject.toml`, increment per semver
+2. Identify shipped caps: all `merged` caps since last release tag
+3. Draft release notes using `.claude/templates/github-release-notes.md`
+4. Version bump PR to `staging` (updates `pyproject.toml` + `docs/patch-notes.md`)
+5. Update `docs/capabilities.md` status for shipped caps
+6. Forward `staging` → `integration` via PR
+7. Cut `release/v{X}.{Y}.{Z}` branch from `integration`
+8. Edit GitHub Release: remove non-wheel assets (source archives)
+9. Clean up: delete release branch (tag persists)
+10. Print final report
+
+## Release Notes Format
+
+Use `.claude/templates/github-release-notes.md` template. Sections:
+
+- **What's New** — user-facing features
+- **Bug Fixes** — resolved issues
+- **Internal** — CI, docs, refactoring (if any)
+- **Install** — pip/uv install command with version
+
+## Asset Cleanup
+
+GitHub auto-attaches source archives (`.tar.gz`, `.zip`) to releases. The `release.yml` workflow builds and attaches the wheel (`.whl`). After release:
+- Keep: `.whl` file
+- Remove: source archives (users should install from PyPI, not source)
+
+## Test PyPI
+
+Every push to `staging` or `integration` publishes a dev build to Test PyPI. Users can test pre-release:
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "cutip>=0.1.5.dev0"
+```
+
+## Version Convention
+
+- `{major}.{minor}.{patch}` — semver
+- Tags: `v{major}.{minor}.{patch}` (e.g., `v0.1.9`)
+- Dev builds on Test PyPI: `{version}.dev{N}`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,14 @@ Do not stop at writing code. Do not stop at opening a PR. Finish when every comp
 | Release | `.claude/workflows/release.md` | `.claude/templates/github-release-notes.md` |
 | Resolve issues | `.claude/skills/resolve-issues.md` | `.claude/templates/pr-body.md` |
 
+### GitHub Orchestration Docs
+
+| Doc | Purpose |
+|-----|---------|
+| `.claude/github/issues.md` | Issue pipeline stages, label state machine, slash commands |
+| `.claude/github/prs.md` | PR conventions, branch naming, label rules, CI expectations |
+| `.claude/github/releases.md` | Release pipeline, asset cleanup, release notes format |
+
 **Always read the playbook before starting. Always use the template for PRs and release notes.**
 
 The only valid stopping points before completion are:


### PR DESCRIPTION
## Summary

- Adds `.claude/github/` subdirectory with orchestration docs for issues, PRs, and releases
- Documents the issue pipeline state machine, label conventions, slash commands, PR standards, and release workflow
- Updates `CLAUDE.md` with references to the new docs

## Changes

- `.claude/github/issues.md`: Issue pipeline stages, label state machine, slash commands
- `.claude/github/prs.md`: PR conventions, branch naming, label rules, CI expectations
- `.claude/github/releases.md`: Release pipeline, asset cleanup, release notes format
- `CLAUDE.md`: Added `.claude/github/` reference table

🤖 Generated with [Claude Code](https://claude.com/claude-code)