### PR TITLE
Forward staging → integration (cap024–cap027)

### DIFF
--- a/.claude/github/issues.md
+++ b/.claude/github/issues.md
@@ -1,0 +1,82 @@
+# GitHub Issue Pipeline
+
+How CUTIP handles automated issue diagnosis and resolution via GitHub Actions.
+
+---
+
+## State Machine
+
+Issues progress through labels that represent pipeline stages:
+
+```
+(new issue)
+    │
+    ▼ code owner adds `claude-review` label
+claude-review
+    │
+    ▼ workflow runs diagnosis
+claude-diagnosing  (transient — while Claude is working)
+    │
+    ▼ diagnosis posted as comment
+claude-diagnosed
+    │
+    ▼ user comments `/acknowledge`
+claude-acknowledged
+    │
+    ▼ code owner comments `/continue`
+claude-fixing  (transient — while Claude generates fix)
+    │
+    ▼ fix branch pushed + TestPyPI published
+claude-fixed
+    │
+    ├─▶ user comments `/approve` → waits for code owner `/continue`
+    │       │
+    │       ▼ PR opened to staging
+    │   claude-staging
+    │
+    └─▶ user comments `/deny` → resets to claude-diagnosed
+            (re-entry template posted)
+```
+
+## Labels
+
+| Label | Color | Description | Transient? |
+|-------|-------|-------------|------------|
+| `claude-review` | `#0075ca` | Needs Claude diagnosis | No |
+| `claude-diagnosing` | `#e4e669` | Claude is diagnosing | Yes |
+| `claude-diagnosed` | `#cfd3d7` | Claude diagnosis posted | No |
+| `claude-acknowledged` | `#c2e0c6` | User acknowledged diagnosis | No |
+| `claude-fixing` | `#e4e669` | Claude is generating fix | Yes |
+| `claude-fixed` | `#0e8a16` | Claude fix ready for review | No |
+| `claude-staging` | `#1d76db` | Fix PR opened to staging | No |
+
+## Slash Commands
+
+| Command | Who | When (required label) | Effect |
+|---------|-----|-----------------------|--------|
+| `/continue` | Code owner | `claude-review` (no label) | Start diagnosis |
+| `/continue` | Code owner | `claude-acknowledged` | Start fix generation |
+| `/continue` | Code owner | `claude-fixed` + `/approve` | Open PR to staging |
+| `/acknowledge` | User | `claude-diagnosed` | Accept diagnosis, wait for code owner |
+| `/approve` | User | `claude-fixed` | Approve the fix (needs code owner `/continue`) |
+| `/deny` | User | `claude-fixed` | Reject fix, post re-entry template |
+
+## Workflow File
+
+`.github/workflows/issues.yml` — triggered by `issues: [labeled]` and `issue_comment: [created]`.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `.github/scripts/diagnose-issue.py` | Calls Claude API to diagnose root cause |
+| `.github/scripts/fix-issue.py` | Calls Claude API to generate minimal fix |
+| `.github/scripts/deny-template.md` | Re-entry template for rejected fixes |
+
+## Bot Identity
+
+Comments are posted by `cutip-bot` (GitHub App). Falls back to `github-actions[bot]` if the App is not configured. See cap025 for setup.
+
+## Self-Service Mode
+
+Users with `ANTHROPIC_API_KEY` can bypass the pipeline and run diagnosis/fixes locally via `cutip issue diagnose` and `cutip issue fix`. See cap027.

--- a/.claude/github/prs.md
+++ b/.claude/github/prs.md
@@ -1,0 +1,57 @@
+# GitHub PR Conventions
+
+Pull request standards for the CUTIP project.
+
+---
+
+## Branch → PR Mapping
+
+| Branch pattern | Base branch | Label | Assignee |
+|----------------|-------------|-------|----------|
+| `feat/cap{N}-*` | `staging` | `feature` | `joshuajerome` |
+| `bug/cap{N}-*` | `staging` | `bugfix` | `joshuajerome` |
+| `docs/cap{N}-*` | `staging` | `documentation` | `joshuajerome` |
+| `gh/*` | `staging` | `automation` | `joshuajerome` |
+| `claude/*` | `staging` | — | `joshuajerome` |
+| `release/v*` | — | — | — (handled by release.yml) |
+
+## PR Title Format
+
+```
+[cap{N}] Short imperative description
+```
+
+For non-cap branches (gh/*, claude/*): use a descriptive title without cap prefix.
+
+## PR Body Template
+
+Use `.claude/templates/pr-body.md` — pick the section matching your branch type.
+
+## CI Expectations
+
+All PRs to `staging` and `integration` run `.github/workflows/pr-checks.yml`:
+- Wheel build
+- Unit tests (`pytest tests/ -v --ignore=tests/e2e`)
+- Lint / type checks (if configured)
+
+PRs must pass all checks before merge. For transient CI failures:
+```bash
+gh run rerun <run-id> --failed
+```
+
+## Label Rules
+
+- **`feature`** — NOT "feat". Use `--label "feature"` for feature PRs.
+- **`bugfix`** — for bug fix PRs
+- **`documentation`** — for docs-only PRs
+- **`automation`** — for CI/CD and workflow changes
+
+## Merge Strategy
+
+- Squash merge for feature/bug branches → staging
+- Merge commit for staging → integration (preserves history)
+- Never force-push to `staging` or `integration`
+
+## Auto-generated PRs
+
+After a PR merges to `staging`, `.github/workflows/docs-generate.yml` auto-creates a `docs/cap{N}-*` PR with updated patch notes and capability registry entries.

--- a/.claude/github/releases.md
+++ b/.claude/github/releases.md
@@ -1,0 +1,59 @@
+# GitHub Release Pipeline
+
+How CUTIP versions are cut and published.
+
+---
+
+## Release Flow
+
+```
+integration (stable) → release/v{X}.{Y}.{Z} branch
+    → release.yml creates git tag v{X.Y.Z}
+    → GitHub Release page created
+    → Wheel asset attached
+    → Branch deleted (tag is the durable marker)
+```
+
+## Steps (automated by `.claude/workflows/release.md`)
+
+1. Determine version: read `pyproject.toml`, increment per semver
+2. Identify shipped caps: all `merged` caps since last release tag
+3. Draft release notes using `.claude/templates/github-release-notes.md`
+4. Version bump PR to `staging` (updates `pyproject.toml` + `docs/patch-notes.md`)
+5. Update `docs/capabilities.md` status for shipped caps
+6. Forward `staging` → `integration` via PR
+7. Cut `release/v{X}.{Y}.{Z}` branch from `integration`
+8. Edit GitHub Release: remove non-wheel assets (source archives)
+9. Clean up: delete release branch (tag persists)
+10. Print final report
+
+## Release Notes Format
+
+Use `.claude/templates/github-release-notes.md` template. Sections:
+
+- **What's New** — user-facing features
+- **Bug Fixes** — resolved issues
+- **Internal** — CI, docs, refactoring (if any)
+- **Install** — pip/uv install command with version
+
+## Asset Cleanup
+
+GitHub auto-attaches source archives (`.tar.gz`, `.zip`) to releases. The `release.yml` workflow builds and attaches the wheel (`.whl`). After release:
+- Keep: `.whl` file
+- Remove: source archives (users should install from PyPI, not source)
+
+## Test PyPI
+
+Every push to `staging` or `integration` publishes a dev build to Test PyPI. Users can test pre-release:
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "cutip>=0.1.5.dev0"
+```
+
+## Version Convention
+
+- `{major}.{minor}.{patch}` — semver
+- Tags: `v{major}.{minor}.{patch}` (e.g., `v0.1.9`)
+- Dev builds on Test PyPI: `{version}.dev{N}`

--- a/.github/scripts/deny-template.md
+++ b/.github/scripts/deny-template.md
@@ -1,0 +1,19 @@
+## Fix Denied — Please Provide Feedback
+
+The automated fix was rejected. To help Claude generate a better fix, please fill in the details below and comment `/acknowledge` followed by a code owner `/continue` to retry.
+
+### What went wrong with the fix?
+
+<!-- Describe what the fix got wrong — incorrect logic, wrong file, missing edge case, etc. -->
+
+### What is the expected behavior?
+
+<!-- Describe what the correct fix should do instead. -->
+
+### Additional context or logs
+
+<!-- Paste any relevant logs, stack traces, or screenshots that would help. -->
+
+---
+
+*The issue has been reset to `claude-diagnosed`. After adding feedback above, comment `/acknowledge` to accept the updated diagnosis, then a code owner can comment `/continue` to generate a new fix.*

--- a/.github/scripts/diagnose-issue.py
+++ b/.github/scripts/diagnose-issue.py
@@ -110,6 +110,16 @@ Respond with a structured diagnosis in **exactly** this format (use the exact he
     return message.content[0].text
 
 
+def _is_low_confidence(diagnosis: str) -> bool:
+    """Check if the diagnosis indicates low confidence or needs more info."""
+    lower = diagnosis.lower()
+    if "**confidence:** low" in lower:
+        return True
+    if "need more information" in lower or "needs more info" in lower:
+        return True
+    return False
+
+
 def main() -> None:
     issue_number = _env("ISSUE_NUMBER")
     issue_title = _env("ISSUE_TITLE")
@@ -129,6 +139,18 @@ def main() -> None:
         issue_body=issue_body,
         source_context=source_context,
     )
+
+    if _is_low_confidence(diagnosis):
+        print(
+            "LOW CONFIDENCE: diagnosis may need more info from the reporter.",
+            file=sys.stderr,
+        )
+        diagnosis += (
+            "\n\n---\n\n"
+            "⚠️ **Low confidence diagnosis.** "
+            "Please provide more details (logs, reproduction steps, expected behavior) "
+            "and comment `/continue` for a fresh diagnosis."
+        )
 
     print(diagnosis)
 

--- a/.github/scripts/fix-issue.py
+++ b/.github/scripts/fix-issue.py
@@ -50,6 +50,9 @@ ALL_SOURCE_FILES = [
     "cutip/workspace/discovery.py",
     "cutip/workspace/registry.py",
     "cutip/workspace/scaffold.py",
+    "cutip/cli/commands/issue.py",
+    "cutip/issue/template.py",
+    "cutip/issue/claude.py",
 ]
 
 

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,31 +7,64 @@ on:
     types: [created]
 
 jobs:
-  # ── Diagnose on claude-review label ─────────────────────────────────────────
-  diagnose:
-    name: Diagnose issue with Claude
+  # ── /continue — dispatches based on current label state ─────────────────────
+  handle-continue:
+    name: Handle /continue
     runs-on: ubuntu-latest
-    if: github.event_name == 'issues' && github.event.label.name == 'claude-review'
+    if: |
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/continue')
 
     permissions:
       issues: write
-      contents: read
+      contents: write
+      pull-requests: write
 
     steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Ensure required labels exist
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
-          gh label create "claude-review"      --color "0075ca" --description "Needs Claude diagnosis"   --force --repo ${{ github.repository }}
-          gh label create "claude-diagnosing"  --color "e4e669" --description "Claude is diagnosing"     --force --repo ${{ github.repository }}
-          gh label create "claude-diagnosed"   --color "cfd3d7" --description "Claude diagnosis posted"  --force --repo ${{ github.repository }}
-          gh label create "claude-fixing"      --color "e4e669" --description "Claude is generating fix" --force --repo ${{ github.repository }}
-          gh label create "claude-fixed"       --color "0e8a16" --description "Claude fix ready"         --force --repo ${{ github.repository }}
-          gh label create "claude-staging"     --color "1d76db" --description "Fix PR opened to staging" --force --repo ${{ github.repository }}
+          gh label create "claude-review"        --color "0075ca" --description "Needs Claude diagnosis"        --force --repo ${{ github.repository }}
+          gh label create "claude-diagnosing"    --color "e4e669" --description "Claude is diagnosing"          --force --repo ${{ github.repository }}
+          gh label create "claude-diagnosed"     --color "cfd3d7" --description "Claude diagnosis posted"       --force --repo ${{ github.repository }}
+          gh label create "claude-acknowledged"  --color "c2e0c6" --description "User acknowledged diagnosis"   --force --repo ${{ github.repository }}
+          gh label create "claude-fixing"        --color "e4e669" --description "Claude is generating fix"      --force --repo ${{ github.repository }}
+          gh label create "claude-fixed"         --color "0e8a16" --description "Claude fix ready"              --force --repo ${{ github.repository }}
+          gh label create "claude-staging"       --color "1d76db" --description "Fix PR opened to staging"      --force --repo ${{ github.repository }}
 
-      - name: Apply claude-diagnosing label
+      - name: Determine current state
+        id: state
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json labels --jq '.labels[].name' | tr '\n' ' ')
+          echo "Issue labels: $LABELS"
+
+          if echo "$LABELS" | grep -qw "claude-fixed"; then
+            echo "action=merge" >> "$GITHUB_OUTPUT"
+          elif echo "$LABELS" | grep -qw "claude-acknowledged"; then
+            echo "action=fix" >> "$GITHUB_OUTPUT"
+          else
+            echo "action=diagnose" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Diagnose path (no claude label or claude-review) ──────────────────
+      - name: Apply claude-diagnosing label
+        if: steps.state.outputs.action == 'diagnose'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
@@ -53,6 +86,7 @@ jobs:
           uv pip install anthropic
 
       - name: Run Claude diagnosis
+        if: steps.state.outputs.action == 'diagnose'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -61,16 +95,18 @@ jobs:
         run: uv run python .github/scripts/diagnose-issue.py > /tmp/diagnosis.md
 
       - name: Post diagnosis comment
+        if: steps.state.outputs.action == 'diagnose'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           gh issue comment ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
             --body-file /tmp/diagnosis.md
 
       - name: Update labels to claude-diagnosed
+        if: steps.state.outputs.action == 'diagnose'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
@@ -79,18 +115,19 @@ jobs:
             --repo ${{ github.repository }} \
             --remove-label "claude-diagnosing" 2>/dev/null || true
 
-      - name: Post follow-up prompt comment
+      - name: Post follow-up prompt
+        if: steps.state.outputs.action == 'diagnose'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           gh issue comment ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
-            --body "Reply \`/approve\` to proceed with the automated fix, or add more detail and re-apply \`claude-review\` for a fresh diagnosis."
+            --body "Reply \`/acknowledge\` to accept this diagnosis, or add more detail and comment \`/continue\` for a fresh diagnosis."
 
-      - name: Revert labels on failure
-        if: failure()
+      - name: Revert labels on diagnosis failure
+        if: failure() && steps.state.outputs.action == 'diagnose'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
@@ -100,56 +137,23 @@ jobs:
             --remove-label "claude-diagnosing" 2>/dev/null || true
           gh issue comment ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
-            --body "Diagnosis failed (check [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details). Re-applying \`claude-review\` to retry."
+            --body "Diagnosis failed (check [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details). Re-apply \`claude-review\` and comment \`/continue\` to retry."
 
-  # ── /approve → generate fix, push branch ────────────────────────────────────
-  handle-approve:
-    name: Handle /approve
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'issue_comment' &&
-      !github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/approve')
-
-    permissions:
-      issues: write
-      contents: write
-      pull-requests: write
-
-    steps:
-      - name: Check claude-diagnosed label
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          LABELS=$(gh issue view ${{ github.event.issue.number }} \
-            --repo ${{ github.repository }} \
-            --json labels --jq '.labels[].name' | tr '\n' ' ')
-          echo "Issue labels: $LABELS"
-          if echo "$LABELS" | grep -qw "claude-diagnosed"; then
-            echo "valid=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "valid=false" >> "$GITHUB_OUTPUT"
-            echo "Issue does not have claude-diagnosed label — ignoring."
-          fi
-
+      # ── Fix path (claude-acknowledged → generate fix) ─────────────────────
       - name: Apply claude-fixing label
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'fix'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
             --add-label "claude-fixing"
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
-            --remove-label "claude-diagnosed" 2>/dev/null || true
-
-      - uses: actions/checkout@v4
-        if: steps.check.outputs.valid == 'true'
+            --remove-label "claude-acknowledged" 2>/dev/null || true
 
       - name: Determine next cap ID and branch name
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'fix'
         id: cap
         run: |
           LAST_ID=$(grep -oP 'cap\d+' docs/capabilities.md | sort -V | tail -1)
@@ -169,31 +173,21 @@ jobs:
           echo "Cap ID: $NEXT_ID  Branch: $BRANCH"
 
       - name: Fetch Claude diagnosis from issue comments
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'fix'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
-          gh issue view ${{ github.event.issue.number }} \
+          # Try bot comments first, fall back to github-actions[bot]
+          BOT_NAME="cutip-bot[bot]"
+          DIAGNOSIS=$(gh issue view ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
             --json comments \
-            --jq '.comments | map(select(.author.login == "github-actions[bot]")) | if length > 0 then first.body else "" end' \
-            > /tmp/diagnosis.md
+            --jq ".comments | map(select(.author.login == \"${BOT_NAME}\" or .author.login == \"github-actions[bot]\")) | map(select(.body | test(\"Claude Diagnosis\"))) | if length > 0 then last.body else \"\" end")
+          echo "$DIAGNOSIS" > /tmp/diagnosis.md
           echo "Diagnosis fetched: $(wc -c < /tmp/diagnosis.md) bytes"
 
-      - name: Install uv
-        if: steps.check.outputs.valid == 'true'
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
-
-      - name: Install script dependencies
-        if: steps.check.outputs.valid == 'true'
-        run: |
-          uv venv .venv
-          uv pip install anthropic
-
       - name: Generate fix via Claude
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'fix'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -203,14 +197,23 @@ jobs:
           CAP_ID: ${{ steps.cap.outputs.cap_id }}
         run: uv run python .github/scripts/fix-issue.py > /tmp/fix-summary.md
 
+      - name: Build wheel and publish to TestPyPI
+        if: steps.state.outputs.action == 'fix'
+        continue-on-error: true
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          uv build
+          uv publish --publish-url https://test.pypi.org/legacy/ dist/*.whl || echo "TestPyPI publish skipped (token not set or version exists)"
+
       - name: Commit and push fix branch
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'fix'
         env:
           CAP_ID: ${{ steps.cap.outputs.cap_id }}
           BRANCH: ${{ steps.cap.outputs.branch }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "cutip-bot[bot]"
+          git config user.email "cutip-bot[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add cutip/
           if git diff --staged --quiet; then
@@ -221,9 +224,9 @@ jobs:
           git push origin "$BRANCH"
 
       - name: Apply claude-fixed label
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'fix'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
@@ -233,9 +236,9 @@ jobs:
             --remove-label "claude-fixing" 2>/dev/null || true
 
       - name: Post fix comment
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'fix'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
           CAP_ID: ${{ steps.cap.outputs.cap_id }}
           BRANCH: ${{ steps.cap.outputs.branch }}
         run: |
@@ -248,117 +251,59 @@ jobs:
             echo ""
             echo "**Branch:** \`${BRANCH}\`"
             echo ""
-            echo "**Try the fix:** Once this PR merges to staging → integration, install the dev build from Test PyPI:"
+            echo "**Try the fix:** Install the dev build from Test PyPI:"
             echo '```bash'
             echo "pip install --index-url https://test.pypi.org/simple/ \\"
             echo "  --extra-index-url https://pypi.org/simple/ \\"
             echo "  \"cutip>=0.1.5.dev0\""
             echo '```'
-            echo "(The \`--extra-index-url\` flag lets pip resolve dependencies from the main PyPI registry.)"
             echo ""
-            echo "Reply \`/acknowledge\` to open a PR from \`${BRANCH}\` to \`staging\` for release."
+            echo "Reply \`/approve\` to accept this fix, or \`/deny\` to reject and provide feedback."
           } > /tmp/fix-comment.md
           gh issue comment ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
             --body-file /tmp/fix-comment.md
 
-      - name: Revert labels on failure
-        if: failure() && steps.check.outputs.valid == 'true'
+      - name: Revert labels on fix failure
+        if: failure() && steps.state.outputs.action == 'fix'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
-            --add-label "claude-diagnosed" 2>/dev/null || true
+            --add-label "claude-acknowledged" 2>/dev/null || true
           gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
             --remove-label "claude-fixing" 2>/dev/null || true
           gh issue comment ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
-            --body "Fix generation failed. Issue reset to \`claude-diagnosed\`. Check [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. Reply \`/approve\` to retry."
+            --body "Fix generation failed. Issue reset to \`claude-acknowledged\`. Check [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. Comment \`/continue\` to retry."
 
-  # ── /reject → keep claude-diagnosed, ask for more detail ────────────────────
-  handle-reject:
-    name: Handle /reject
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'issue_comment' &&
-      !github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/reject')
-
-    permissions:
-      issues: write
-
-    steps:
-      - name: Check claude-diagnosed label
-        id: check
+      # ── Merge path (claude-fixed + /approve received → open PR) ───────────
+      - name: Check for prior /approve
+        if: steps.state.outputs.action == 'merge'
+        id: check-approve
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
-          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+          APPROVED=$(gh issue view ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
-            --json labels --jq '.labels[].name' | tr '\n' ' ')
-          if echo "$LABELS" | grep -qw "claude-diagnosed"; then
-            echo "valid=true" >> "$GITHUB_OUTPUT"
+            --json comments \
+            --jq '[.comments[] | select(.body | startswith("/approve"))] | length')
+          if [ "$APPROVED" -gt 0 ]; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
           else
-            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+            gh issue comment ${{ github.event.issue.number }} \
+              --repo ${{ github.repository }} \
+              --body "The fix needs user approval before opening a PR. Waiting for \`/approve\` comment."
           fi
-
-      - name: Post rejection comment
-        if: steps.check.outputs.valid == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh issue comment ${{ github.event.issue.number }} \
-            --repo ${{ github.repository }} \
-            --body "Diagnosis rejected. Please add more detail to the issue description, then re-apply the \`claude-review\` label to trigger a fresh diagnosis."
-
-  # ── /acknowledge → open PR from fix branch to staging ───────────────────────
-  handle-acknowledge:
-    name: Handle /acknowledge
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'issue_comment' &&
-      !github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/acknowledge')
-
-    permissions:
-      issues: write
-      pull-requests: write
-
-    steps:
-      - name: Check claude-fixed label
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          LABELS=$(gh issue view ${{ github.event.issue.number }} \
-            --repo ${{ github.repository }} \
-            --json labels --jq '.labels[].name' | tr '\n' ' ')
-          if echo "$LABELS" | grep -qw "claude-fixed"; then
-            echo "valid=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "valid=false" >> "$GITHUB_OUTPUT"
-            echo "Issue does not have claude-fixed label — ignoring."
-          fi
-
-      - name: Apply claude-staging label
-        if: steps.check.outputs.valid == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh issue edit ${{ github.event.issue.number }} \
-            --repo ${{ github.repository }} \
-            --add-label "claude-staging"
-          gh issue edit ${{ github.event.issue.number }} \
-            --repo ${{ github.repository }} \
-            --remove-label "claude-fixed" 2>/dev/null || true
 
       - name: Find fix branch for this issue
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'merge' && steps.check-approve.outputs.approved == 'true'
         id: find-branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           ISSUE_NUM="${{ github.event.issue.number }}"
           BRANCH=$(gh api "repos/${{ github.repository }}/git/refs/heads" \
@@ -376,20 +321,34 @@ jobs:
           echo "cap_id=$CAP_ID"   >> "$GITHUB_OUTPUT"
           echo "Found branch: $BRANCH"
 
+      - name: Apply claude-staging label
+        if: steps.state.outputs.action == 'merge' && steps.check-approve.outputs.approved == 'true'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-staging"
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-fixed" 2>/dev/null || true
+
       - name: Open PR to staging
-        if: steps.check.outputs.valid == 'true'
+        if: steps.state.outputs.action == 'merge' && steps.check-approve.outputs.approved == 'true'
         id: open-pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
           BRANCH: ${{ steps.find-branch.outputs.branch }}
           CAP_ID: ${{ steps.find-branch.outputs.cap_id }}
         run: |
           {
-            echo "Automated fix for issue #${{ github.event.issue.number }}, acknowledged by @${{ github.event.comment.user.login }}."
+            echo "Automated fix for issue #${{ github.event.issue.number }}, approved by user and continued by code owner @${{ github.event.comment.user.login }}."
             echo ""
             echo "## Summary"
             echo "- Branch: \`${BRANCH}\`"
-            echo "- Triggered by: \`/acknowledge\` comment on issue #${{ github.event.issue.number }}"
+            echo "- Triggered by: \`/approve\` + \`/continue\` on issue #${{ github.event.issue.number }}"
+            echo ""
+            echo "Closes #${{ github.event.issue.number }}"
             echo ""
             echo "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
           } > /tmp/pr-body.md
@@ -404,12 +363,174 @@ jobs:
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "PR opened: $PR_URL"
 
-      - name: Post acknowledgement comment
-        if: steps.check.outputs.valid == 'true'
+      - name: Post merge comment
+        if: steps.state.outputs.action == 'merge' && steps.check-approve.outputs.approved == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
           PR_URL: ${{ steps.open-pr.outputs.pr_url }}
         run: |
           gh issue comment ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
             --body "PR opened to staging: ${PR_URL}. The fix will be released in the next version once the PR is reviewed and merged."
+
+  # ── /acknowledge — user accepts diagnosis, waits for code owner /continue ──
+  handle-acknowledge:
+    name: Handle /acknowledge
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/acknowledge')
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Check claude-diagnosed label
+        id: check
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json labels --jq '.labels[].name' | tr '\n' ' ')
+          if echo "$LABELS" | grep -qw "claude-diagnosed"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "Issue does not have claude-diagnosed label — ignoring."
+          fi
+
+      - name: Move to claude-acknowledged
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-acknowledged"
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-diagnosed" 2>/dev/null || true
+
+      - name: Post waiting comment
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Diagnosis acknowledged. Waiting for a code owner to comment \`/continue\` to generate the automated fix."
+
+  # ── /approve — user approves the fix (still needs code owner /continue) ────
+  handle-approve:
+    name: Handle /approve
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/approve')
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Check claude-fixed label
+        id: check
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json labels --jq '.labels[].name' | tr '\n' ' ')
+          if echo "$LABELS" | grep -qw "claude-fixed"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "Issue does not have claude-fixed label — ignoring."
+          fi
+
+      - name: Post approval confirmation
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Fix approved by @${{ github.event.comment.user.login }}. Waiting for a code owner to comment \`/continue\` to open the PR to staging."
+
+  # ── /deny — reject fix, post re-entry template ────────────────────────────
+  handle-deny:
+    name: Handle /deny
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/deny')
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Check claude-fixed label
+        id: check
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json labels --jq '.labels[].name' | tr '\n' ' ')
+          if echo "$LABELS" | grep -qw "claude-fixed"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "Issue does not have claude-fixed label — ignoring."
+          fi
+
+      - name: Reset to claude-diagnosed
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "claude-diagnosed"
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "claude-fixed" 2>/dev/null || true
+
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.valid == 'true'
+
+      - name: Post re-entry template
+        if: steps.check.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body-file .github/scripts/deny-template.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,14 @@ Do not stop at writing code. Do not stop at opening a PR. Finish when every comp
 | Release | `.claude/workflows/release.md` | `.claude/templates/github-release-notes.md` |
 | Resolve issues | `.claude/skills/resolve-issues.md` | `.claude/templates/pr-body.md` |
 
+### GitHub Orchestration Docs
+
+| Doc | Purpose |
+|-----|---------|
+| `.claude/github/issues.md` | Issue pipeline stages, label state machine, slash commands |
+| `.claude/github/prs.md` | PR conventions, branch naming, label rules, CI expectations |
+| `.claude/github/releases.md` | Release pipeline, asset cleanup, release notes format |
+
 **Always read the playbook before starting. Always use the template for PRs and release notes.**
 
 The only valid stopping points before completion are:

--- a/cutip/cli/commands/issue.py
+++ b/cutip/cli/commands/issue.py
@@ -1,0 +1,261 @@
+"""cutip issue — local issue management and self-service diagnosis/fix.
+
+Commands:
+    cutip issue create -t "title"   Create a local issue template
+    cutip issue list                List local issues with status
+    cutip issue push <slug>         Push issue to GitHub via gh CLI
+    cutip issue diagnose <slug>     Run Claude diagnosis locally (requires ANTHROPIC_API_KEY)
+    cutip issue fix <slug>          Generate fix locally (requires ANTHROPIC_API_KEY)
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from cutip.workspace.scaffold import _find_project_root
+
+issue_app = typer.Typer(
+    help="Manage local issues and run self-service diagnosis/fix.",
+    no_args_is_help=True,
+)
+
+console = Console()
+
+
+@issue_app.command("create")
+def create_issue(
+    title: str = typer.Option(..., "--title", "-t", help="Issue title"),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Create a local issue YAML from template."""
+    from cutip.issue.template import create_issue as _create
+
+    project_root = path or _find_project_root()
+    issue_path = _create(project_root, title)
+    console.print(f"[green]Created issue:[/green] {issue_path}")
+    console.print(f"[dim]Edit the file to fill in description, then use 'cutip issue push' to create on GitHub.[/dim]")
+
+
+@issue_app.command("list")
+def list_issues(
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """List local issues with status."""
+    from cutip.issue.template import list_issues as _list
+
+    project_root = path or _find_project_root()
+    issues = _list(project_root)
+
+    if not issues:
+        console.print("[dim]No local issues found.[/dim]")
+        return
+
+    table = Table(title="Local Issues")
+    table.add_column("Slug", style="cyan")
+    table.add_column("Title")
+    table.add_column("Status", style="green")
+    table.add_column("GitHub #", style="yellow")
+
+    for _, data in issues:
+        meta = data.get("metadata", {})
+        table.add_row(
+            meta.get("slug", "?"),
+            meta.get("title", "?"),
+            meta.get("status", "?"),
+            str(meta.get("github_number") or "—"),
+        )
+
+    console.print(table)
+
+
+@issue_app.command("push")
+def push_issue(
+    slug: str = typer.Argument(..., help="Issue slug to push to GitHub"),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Create a GitHub issue from a local issue file."""
+    from cutip.issue.template import issues_dir, load_issue, save_issue
+
+    project_root = path or _find_project_root()
+    issue_path = issues_dir(project_root) / f"{slug}.issue.yaml"
+
+    if not issue_path.exists():
+        console.print(f"[red]Issue not found: {issue_path}[/red]")
+        raise typer.Exit(1)
+
+    data = load_issue(issue_path)
+    meta = data["metadata"]
+    spec = data.get("spec", {})
+
+    if meta.get("github_number"):
+        console.print(f"[yellow]Already pushed as #{meta['github_number']}[/yellow]")
+        raise typer.Exit(0)
+
+    title = meta["title"]
+    body = spec.get("description", "")
+    labels = spec.get("labels", [])
+
+    cmd = [
+        "gh", "issue", "create",
+        "--title", title,
+        "--body", body,
+    ]
+    for label in labels:
+        cmd.extend(["--label", label])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        console.print("[red]gh CLI not found. Install it: https://cli.github.com[/red]")
+        raise typer.Exit(1)
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]Failed to create issue: {exc.stderr}[/red]")
+        raise typer.Exit(1)
+
+    # Parse issue URL to get number
+    url = result.stdout.strip()
+    try:
+        issue_number = int(url.rstrip("/").split("/")[-1])
+    except (ValueError, IndexError):
+        issue_number = None
+
+    meta["github_number"] = issue_number
+    meta["status"] = "pushed"
+    save_issue(issue_path, data)
+
+    console.print(f"[green]Issue created:[/green] {url}")
+
+
+@issue_app.command("diagnose")
+def diagnose_issue(
+    slug: str = typer.Argument(..., help="Issue slug to diagnose"),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Run Claude diagnosis locally. Requires ANTHROPIC_API_KEY."""
+    from cutip.issue.claude import _build_local_context, diagnose
+    from cutip.issue.template import issues_dir, load_issue, save_issue
+
+    project_root = path or _find_project_root()
+    issue_path = issues_dir(project_root) / f"{slug}.issue.yaml"
+
+    if not issue_path.exists():
+        console.print(f"[red]Issue not found: {issue_path}[/red]")
+        raise typer.Exit(1)
+
+    data = load_issue(issue_path)
+    meta = data["metadata"]
+    spec = data.get("spec", {})
+
+    console.print(f"[cyan]Diagnosing:[/cyan] {meta['title']}")
+    context = _build_local_context(project_root)
+
+    diagnosis_text = diagnose(
+        title=meta["title"],
+        body=spec.get("description", ""),
+        context=context,
+    )
+
+    console.print()
+    console.print(diagnosis_text)
+
+    # Save diagnosis alongside the issue
+    diag_path = issue_path.with_suffix(".diagnosis.md")
+    diag_path.write_text(diagnosis_text, encoding="utf-8")
+
+    meta["status"] = "diagnosed"
+    save_issue(issue_path, data)
+    console.print(f"\n[green]Diagnosis saved to:[/green] {diag_path}")
+
+
+@issue_app.command("fix")
+def fix_issue(
+    slug: str = typer.Argument(..., help="Issue slug to fix"),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Generate a fix locally. Requires ANTHROPIC_API_KEY and prior diagnosis."""
+    from cutip.issue.claude import _build_local_context, generate_fix
+    from cutip.issue.template import issues_dir, load_issue, save_issue
+
+    project_root = path or _find_project_root()
+    issue_path = issues_dir(project_root) / f"{slug}.issue.yaml"
+
+    if not issue_path.exists():
+        console.print(f"[red]Issue not found: {issue_path}[/red]")
+        raise typer.Exit(1)
+
+    data = load_issue(issue_path)
+    meta = data["metadata"]
+    spec = data.get("spec", {})
+
+    # Load diagnosis
+    diag_path = issue_path.with_suffix(".diagnosis.md")
+    if not diag_path.exists():
+        console.print("[red]No diagnosis found. Run 'cutip issue diagnose' first.[/red]")
+        raise typer.Exit(1)
+
+    diagnosis_text = diag_path.read_text(encoding="utf-8").strip()
+
+    # Determine cap ID from capabilities.md
+    cap_id = _next_cap_id(project_root)
+    console.print(f"[cyan]Generating fix ({cap_id}):[/cyan] {meta['title']}")
+
+    context = _build_local_context(project_root)
+    file_changes, summary = generate_fix(
+        title=meta["title"],
+        body=spec.get("description", ""),
+        diagnosis_text=diagnosis_text,
+        cap_id=cap_id,
+        context=context,
+    )
+
+    if not file_changes:
+        console.print("[red]Claude returned no file changes.[/red]")
+        raise typer.Exit(1)
+
+    # Write changed files
+    cutip_root = Path(__file__).resolve().parent.parent.parent
+    for rel_path, content in file_changes.items():
+        target = cutip_root / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        console.print(f"  [dim]Wrote {rel_path}[/dim]")
+
+    console.print(f"\n[green]Fix applied ({len(file_changes)} file(s)).[/green]")
+    console.print(f"\n{summary}")
+
+    # Create branch
+    branch = f"bug/{cap_id}-issue-{meta.get('github_number', slug)}-{meta['slug']}"[:60]
+    console.print(f"\n[yellow]Suggested branch:[/yellow] {branch}")
+    console.print(f"[dim]Run: git checkout -b {branch} && git add -p && git commit -m '[{cap_id}] fix: {meta['title']}'[/dim]")
+
+    meta["status"] = "fixed"
+    save_issue(issue_path, data)
+
+
+def _next_cap_id(project_root: Path) -> str:
+    """Read docs/capabilities.md and return the next cap ID."""
+    import re
+
+    # Try CUTIP source root
+    cutip_root = Path(__file__).resolve().parent.parent.parent
+    caps_path = cutip_root / "docs" / "capabilities.md"
+
+    if not caps_path.exists():
+        caps_path = project_root / "docs" / "capabilities.md"
+
+    if not caps_path.exists():
+        return "cap001"
+
+    content = caps_path.read_text(encoding="utf-8")
+    ids = re.findall(r"cap(\d+)", content)
+    if not ids:
+        return "cap001"
+
+    max_num = max(int(n) for n in ids)
+    return f"cap{max_num + 1:03d}"

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -6,6 +6,7 @@ import typer
 
 from cutip.cli.commands.compose import from_compose
 from cutip.cli.commands.init import app as init_app
+from cutip.cli.commands.issue import issue_app
 from cutip.cli.commands.upgrade import app as upgrade_app
 from cutip.cli.commands.ls import card_app, group_app, unit_app
 from cutip.cli.commands.plan import plan
@@ -48,6 +49,7 @@ app.add_typer(group_app, name="group")
 app.add_typer(unit_app, name="unit")
 app.add_typer(card_app, name="card")
 app.add_typer(secrets_app, name="secrets")
+app.add_typer(issue_app, name="issue")
 app.command("plan")(plan)
 app.command("run")(run)
 app.command("from-compose")(from_compose)

--- a/cutip/issue/claude.py
+++ b/cutip/issue/claude.py
@@ -1,0 +1,205 @@
+"""Shared Claude API logic for issue diagnosis and fix generation."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _get_api_key() -> str:
+    """Resolve Anthropic API key from environment."""
+    key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not key:
+        print(
+            "ERROR: ANTHROPIC_API_KEY not set. "
+            "Set it in your environment or install cutip[ai].",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return key
+
+
+def _build_local_context(project_root: Path) -> str:
+    """Build source context from the CUTIP codebase for Claude."""
+    context_files = [
+        "cutip/backends/podman/backend.py",
+        "cutip/cli/commands/run.py",
+        "cutip/cli/main.py",
+        "cutip/models/cards/container.py",
+        "cutip/models/cards/image.py",
+        "cutip/models/cards/network.py",
+        "cutip/models/unit.py",
+        "cutip/models/group.py",
+        "cutip/context/workflow.py",
+        "cutip/context/startup.py",
+        "cutip/resolver/refs.py",
+        "cutip/validation/graph.py",
+        "cutip/utils/exceptions.py",
+        "cutip/workspace/discovery.py",
+        "cutip/workspace/registry.py",
+    ]
+
+    # Try CUTIP source root (for development installs)
+    cutip_root = Path(__file__).resolve().parent.parent.parent
+    parts = []
+    for rel_path in context_files:
+        path = cutip_root / rel_path
+        if not path.exists():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+            parts.append(f"### {rel_path}\n```python\n{content}\n```")
+        except Exception:
+            continue
+    return "\n\n".join(parts)
+
+
+def diagnose(title: str, body: str, context: str) -> str:
+    """Run Claude diagnosis on an issue. Returns markdown diagnosis."""
+    try:
+        import anthropic
+    except ImportError:
+        print(
+            "ERROR: anthropic package not installed. Run: uv pip install cutip[ai]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    _get_api_key()
+    client = anthropic.Anthropic()
+
+    prompt = f"""You are a senior engineer maintaining CUTIP (Container Unit Templates in Python) — \
+a deterministic framework for defining and orchestrating container environments using Docker/Podman.
+
+A user has filed an issue. Diagnose the root cause and describe a concise fix approach.
+
+## Issue: {title}
+
+{body or "_No description provided._"}
+
+## Relevant Source Code
+
+{context}
+
+---
+
+Respond with a structured diagnosis in **exactly** this format (use the exact headings):
+
+## Claude Diagnosis
+
+**Root Cause:** (one sentence describing the fundamental problem)
+
+**Affected Location:** `path/to/file.py:line_number` (one or more locations)
+
+**What's Happening:** (2–4 sentences explaining the bug mechanically — what code path leads to the failure)
+
+**Proposed Fix:** (2–5 sentences describing the minimal code change that will resolve it)
+
+**Confidence:** High / Medium / Low — (one sentence explaining confidence level and any uncertainty)
+"""
+
+    message = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=2048,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return message.content[0].text
+
+
+def generate_fix(
+    title: str,
+    body: str,
+    diagnosis_text: str,
+    cap_id: str,
+    context: str,
+) -> tuple[dict[str, str], str]:
+    """Generate a code fix via Claude. Returns (file_changes, summary)."""
+    try:
+        import anthropic
+    except ImportError:
+        print(
+            "ERROR: anthropic package not installed. Run: uv pip install cutip[ai]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    import json
+
+    _get_api_key()
+    client = anthropic.Anthropic()
+
+    prompt = f"""You are a senior engineer maintaining CUTIP (Container Unit Templates in Python) — \
+a deterministic framework for defining and orchestrating container environments using Docker/Podman.
+
+A user filed an issue and you previously diagnosed the root cause. \
+Now generate a minimal, correct code fix.
+
+## Issue: {title}
+
+{body or "_No description provided._"}
+
+## Prior Diagnosis
+
+{diagnosis_text}
+
+## Current Source Code
+
+{context}
+
+---
+
+Generate the minimal fix. Respond in exactly two parts separated by `---SUMMARY---` on its own line:
+
+**Part 1:** A JSON object where:
+- Keys are relative file paths (e.g., `"cutip/cli/commands/run.py"`)
+- Values are the **complete** new file contents (not diffs, not excerpts — full file text)
+- Only include files that actually need to change
+
+Wrap the JSON in a ```json code block.
+
+**Part 2:** A concise markdown summary (3–8 bullet points) of:
+- What changed and in which file(s)
+- Why the change fixes the issue
+- Any caveats or limitations of the automated fix
+
+Example response structure:
+
+```json
+{{
+  "cutip/some/file.py": "#!/usr/bin/env python3\\n..."
+}}
+```
+---SUMMARY---
+- Fixed null-check in `cutip/some/file.py:42` to handle missing key
+- Added `KeyError` guard in the `_validate_vars` path
+"""
+
+    message = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=8192,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    response_text = message.content[0].text
+
+    parts = response_text.split("---SUMMARY---", 1)
+    json_part = parts[0].strip()
+    summary = parts[1].strip() if len(parts) > 1 else "_No summary provided._"
+
+    if "```json" in json_part:
+        json_part = json_part.split("```json", 1)[1]
+        if "```" in json_part:
+            json_part = json_part.rsplit("```", 1)[0]
+    elif "```" in json_part:
+        json_part = json_part.split("```", 1)[1]
+        if "```" in json_part:
+            json_part = json_part.rsplit("```", 1)[0]
+
+    try:
+        file_changes: dict[str, str] = json.loads(json_part.strip())
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: Could not parse Claude's response as JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    return file_changes, summary

--- a/cutip/issue/template.py
+++ b/cutip/issue/template.py
@@ -1,0 +1,98 @@
+"""Issue YAML template generation and loading."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+ISSUE_TEMPLATE = {
+    "apiVersion": "cutip/v1",
+    "kind": "Issue",
+    "metadata": {
+        "title": "",
+        "slug": "",
+        "github_number": None,
+        "status": "draft",
+    },
+    "spec": {
+        "description": (
+            "## What happened\n\n"
+            "## Steps to reproduce\n\n"
+            "## Expected behavior\n"
+        ),
+        "labels": ["bug"],
+    },
+}
+
+ISSUES_DIR = ".cutip/issues"
+
+
+def slugify(title: str) -> str:
+    """Convert a title to a filesystem-safe slug."""
+    slug = title.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    slug = slug.strip("-")
+    return slug[:40]
+
+
+def issues_dir(project_root: Path) -> Path:
+    """Return the issues directory, creating it if needed."""
+    d = project_root / ISSUES_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def create_issue(project_root: Path, title: str) -> Path:
+    """Create a new issue YAML file from template. Returns the file path."""
+    slug = slugify(title)
+    d = issues_dir(project_root)
+    path = d / f"{slug}.issue.yaml"
+
+    data = _deep_copy_template()
+    data["metadata"]["title"] = title
+    data["metadata"]["slug"] = slug
+
+    path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def load_issue(path: Path) -> dict:
+    """Load an issue YAML file."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or data.get("kind") != "Issue":
+        raise ValueError(f"Not a valid issue file: {path}")
+    return data
+
+
+def save_issue(path: Path, data: dict) -> None:
+    """Save an issue YAML file."""
+    path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def list_issues(project_root: Path) -> list[tuple[Path, dict]]:
+    """List all issue files with their data."""
+    d = project_root / ISSUES_DIR
+    if not d.exists():
+        return []
+    results = []
+    for p in sorted(d.glob("*.issue.yaml")):
+        try:
+            results.append((p, load_issue(p)))
+        except (ValueError, yaml.YAMLError):
+            continue
+    return results
+
+
+def _deep_copy_template() -> dict:
+    """Return a deep copy of the issue template."""
+    import copy
+    return copy.deepcopy(ISSUE_TEMPLATE)

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -31,6 +31,10 @@ commit messages, and PR titles.
 | cap021 | Rename vars.yaml → paths.yaml + add cutip/secrets.yaml            | feat | merged | feat/cap021-paths-secrets-split      | #53 | 2026-03-04 |
 | cap022 | Read backend from cutip.yaml project config                       | feat | merged | feat/cap022-yaml-backend             | #55 | 2026-03-04 |
 | cap023 | Add cutip upgrade command for workspace migration                 | bug  | open   | bug/cap023-upgrade-command           | —   | 2026-03-09 |
+| cap024 | Reorganize .claude/ with github/ subdirectory                     | feat | open   | claude/cap024-claude-dir-reorg       | —   | 2026-03-09 |
+| cap025 | Bot identity for GitHub issue comments                            | feat | open   | gh/cap025-bot-identity               | —   | 2026-03-09 |
+| cap026 | Issue pipeline with approval gates                                | feat | open   | feat/cap026-issue-pipeline-gates     | —   | 2026-03-09 |
+| cap027 | Self-service issue CLI with local Claude API                      | feat | open   | feat/cap027-self-service-issues      | —   | 2026-03-09 |
 
 ## ID Assignment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dev = [
     "pytest>=8.0",
     "pytest-cov",
 ]
+ai = [
+    "anthropic>=0.40",
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,38 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.84.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -252,7 +284,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },
@@ -265,6 +297,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+ai = [
+    { name = "anthropic" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -283,6 +318,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'ai'", specifier = ">=0.40" },
     { name = "docker", specifier = ">=6.0" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "<2.0" },
@@ -296,12 +332,21 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
-provides-extras = ["docs", "dev"]
+provides-extras = ["docs", "dev", "ai"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -319,6 +364,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -328,6 +382,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -358,6 +449,91 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/566364c777d2ab450b92100bea11333c64c38d32caf8dc378b48e5b20c46/jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911", size = 319729, upload-time = "2026-02-02T12:35:39.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/560f13ec5e4f116d8ad2658781646cca91b617ae3b8758d4a5076b278f70/jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701", size = 354766, upload-time = "2026-02-02T12:35:40.662Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0d/061faffcfe94608cbc28a0d42a77a74222bdf5055ccdbe5fd2292b94f510/jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c", size = 362587, upload-time = "2026-02-02T12:35:42.025Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/c66a7864982fd38a9773ec6e932e0398d1262677b8c60faecd02ffb67bf3/jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4", size = 487537, upload-time = "2026-02-02T12:35:43.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/86/84eb4352cd3668f16d1a88929b5888a3fe0418ea8c1dfc2ad4e7bf6e069a/jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165", size = 373717, upload-time = "2026-02-02T12:35:44.928Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/09/9fe4c159358176f82d4390407a03f506a8659ed13ca3ac93a843402acecf/jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018", size = 362683, upload-time = "2026-02-02T12:35:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5e/85f3ab9caca0c1d0897937d378b4a515cae9e119730563572361ea0c48ae/jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411", size = 392345, upload-time = "2026-02-02T12:35:48.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4c/05b8629ad546191939e6f0c2f17e29f542a398f4a52fb987bc70b6d1eb8b/jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5", size = 517775, upload-time = "2026-02-02T12:35:49.482Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/88/367ea2eb6bc582c7052e4baf5ddf57ebe5ab924a88e0e09830dfb585c02d/jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3", size = 551325, upload-time = "2026-02-02T12:35:51.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/12/fa377ffb94a2f28c41afaed093e0d70cfe512035d5ecb0cad0ae4792d35e/jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1", size = 204709, upload-time = "2026-02-02T12:35:52.467Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/16/8e8203ce92f844dfcd3d9d6a5a7322c77077248dbb12da52d23193a839cd/jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654", size = 204560, upload-time = "2026-02-02T12:35:53.925Z" },
+    { url = "https://files.pythonhosted.org/packages/44/26/97cc40663deb17b9e13c3a5cf29251788c271b18ee4d262c8f94798b8336/jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5", size = 189608, upload-time = "2026-02-02T12:35:55.304Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/3c29819a27178d0e461a8571fb63c6ae38be6dc36b78b3ec2876bbd6a910/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c", size = 307016, upload-time = "2026-02-02T12:37:42.755Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/60993e4b07b1ac5ebe46da7aa99fdbb802eb986c38d26e3883ac0125c4e0/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2", size = 305024, upload-time = "2026-02-02T12:37:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fa/2227e590e9cf98803db2811f172b2d6460a21539ab73006f251c66f44b14/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434", size = 339337, upload-time = "2026-02-02T12:37:46.668Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/92/015173281f7eb96c0ef580c997da8ef50870d4f7f4c9e03c845a1d62ae04/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d", size = 346395, upload-time = "2026-02-02T12:37:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
 ]
 
 [[package]]
@@ -931,6 +1107,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **cap024**: `.claude/github/` orchestration docs (issues, PRs, releases)
- **cap025**: Bot identity via GitHub App token with graceful fallback
- **cap026**: Issue pipeline with approval gates (`/continue`, `/acknowledge`, `/approve`, `/deny`)
- **cap027**: Self-service `cutip issue` CLI with local Claude API support

All PRs passed CI on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)