### PR TITLE
[cap029] Backend default prompt + status display

### DIFF
--- a/cutip/cli/commands/init.py
+++ b/cutip/cli/commands/init.py
@@ -29,13 +29,37 @@ def init(
     scaffold.init()
 
     root = scaffold.project_root
+
+    # Detect available backends
+    backends = []
+    for name, mod in [("docker", "docker"), ("podman", "podman")]:
+        try:
+            __import__(mod)
+            backends.append(name)
+        except ImportError:
+            pass
+
+    backend_line = ""
+    if backends:
+        backend_line = (
+            f"\n\n  [bold]Backend[/bold]: docker (default in cutip.yaml)"
+            f"\n  [dim]Available[/dim]: {', '.join(backends)}"
+            f"\n  [dim]Override[/dim]:  cutip run GROUP -b podman"
+        )
+    else:
+        backend_line = (
+            "\n\n  [yellow]No backends installed.[/yellow]"
+            "\n  Run: pip install docker  (or: pip install podman)"
+        )
+
     console.print(
         Panel.fit(
             f"[bold green]CUTIP workspace initialized[/bold green]\n"
             f"  Project root: [cyan]{root}[/cyan]\n\n"
             f"  [dim]cutip/[/dim]          ← version-controlled artifacts\n"
             f"  [dim].cutip/[/dim]         ← runtime state (add to .gitignore)\n"
-            f"  [dim]cutip.yaml[/dim]       ← project config",
+            f"  [dim]cutip.yaml[/dim]       ← project config"
+            + backend_line,
             title="cutip init",
             border_style="green",
         )

--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -529,6 +529,23 @@ def _load_project_backend(project_root: Path) -> str | None:
     return None
 
 
+def _save_project_backend(project_root: Path, backend_name: str) -> None:
+    """Write ``project.backend`` to ``cutip.yaml``."""
+    import yaml as _yaml
+
+    config_path = project_root / "cutip.yaml"
+    if not config_path.exists():
+        return
+
+    data = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if "project" not in data:
+        data["project"] = {}
+    data["project"]["backend"] = backend_name
+
+    with config_path.open("w", encoding="utf-8") as fh:
+        _yaml.dump(data, fh, default_flow_style=False, sort_keys=False)
+
+
 # ---------------------------------------------------------------------------
 # CLI command
 # ---------------------------------------------------------------------------
@@ -663,6 +680,21 @@ def run(
         run_error = str(exc)
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)
+    else:
+        # Prompt to save backend as default if user explicitly passed -b
+        # and it differs from the currently configured default.
+        if backend and status == "success":
+            configured = _load_project_backend(project_root)
+            if configured != backend_name:
+                save = typer.confirm(
+                    f"Use '{backend_name}' as the default backend in cutip.yaml?",
+                    default=False,
+                )
+                if save:
+                    _save_project_backend(project_root, backend_name)
+                    console.print(
+                        f"[green]Default backend set to '{backend_name}' in cutip.yaml[/green]"
+                    )
     finally:
         write_run_record(
             cutip_dir / "runs",

--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 from pathlib import Path
 
 import typer
@@ -683,7 +684,8 @@ def run(
     else:
         # Prompt to save backend as default if user explicitly passed -b
         # and it differs from the currently configured default.
-        if backend and status == "success":
+        # Skip when stdin is not a TTY (CI, pipes, etc.).
+        if backend and status == "success" and sys.stdin.isatty():
             configured = _load_project_backend(project_root)
             if configured != backend_name:
                 save = typer.confirm(

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -20,6 +20,36 @@ from cutip.cli.commands.show import app as show_app
 from cutip.cli.commands.tree import app as tree_app
 from cutip.cli.commands.validate import app as validate_app
 
+def _backend_status() -> str:
+    """Detect available backends and the current default."""
+    available = []
+    for name, mod in [("docker", "docker"), ("podman", "podman")]:
+        try:
+            __import__(mod)
+            available.append(name)
+        except ImportError:
+            pass
+
+    if not available:
+        return "[bold]Backends[/bold]: none installed (pip install docker / podman)"
+
+    # Try to read configured default from cutip.yaml in cwd
+    default = None
+    try:
+        from cutip.workspace.scaffold import _find_project_root
+        from cutip.cli.commands.run import _load_project_backend
+        default = _load_project_backend(_find_project_root())
+    except Exception:
+        pass
+
+    default = default or "docker"
+    parts = []
+    for name in available:
+        label = f"[bold green]{name}[/bold green] (default)" if name == default else name
+        parts.append(label)
+    return "[bold]Backends[/bold]: " + ", ".join(parts)
+
+
 _EPILOG = (
     "[bold]Getting Started[/bold]: "
     "cutip init · cutip from-compose FILE · cutip validate · cutip run GROUP\n\n"
@@ -62,7 +92,8 @@ def _main(
         help="Show version and exit.",
     ),
 ) -> None:
-    pass
+    # Inject live backend status into the epilog
+    app.info.epilog = _EPILOG + "\n\n" + _backend_status()
 
 
 _SHELLS = {"bash", "zsh", "fish", "powershell", "pwsh"}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -36,6 +36,7 @@ commit messages, and PR titles.
 | cap026 | Issue pipeline with approval gates                                | feat | merged | feat/cap026-issue-pipeline-gates     | #61 | 2026-03-09 |
 | cap027 | Self-service issue CLI with local Claude API                      | feat | merged | feat/cap027-self-service-issues      | #62 | 2026-03-09 |
 | cap028 | CLI help grouping + repo setup documentation                     | feat | merged | feat/cap028-cli-help-repo-docs       | #64 | 2026-03-09 |
+| cap029 | Backend default prompt + status display                           | feat | open   | feat/cap029-backend-default-prompt   | —   | 2026-03-14 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

- Prompts user to save backend as default in `cutip.yaml` when they explicitly pass `-b <backend>` and the run succeeds
- Shows available backends and current default in `cutip --help` epilog and `cutip init` output
- Backend resolution chain unchanged: CLI `-b` flag → `CUTIP_BACKEND` env → `cutip.yaml` → `docker`

## Changes

- `cutip/cli/commands/run.py`: Added `_save_project_backend()` helper and post-run prompt when explicit `-b` differs from configured default
- `cutip/cli/main.py`: Added `_backend_status()` function that detects installed backends and reads the configured default; injected into epilog via `_main` callback
- `cutip/cli/commands/init.py`: Added backend availability info to the init output panel
- `docs/capabilities.md`: Registered cap029

## Test plan

- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes
- [ ] `cutip --help` shows backend status line with available backends and default
- [ ] `cutip init` (in a temp dir) shows backend availability in output panel
- [ ] `cutip run GROUP -b podman` prompts to save as default after successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
