### PR TITLE
[cap030] cutip stop command for graceful group teardown

### DIFF
--- a/cutip/cli/commands/stop.py
+++ b/cutip/cli/commands/stop.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from cutip.backends import get_backend
+from cutip.cli.commands.run import (
+    _complete_group_name,
+    _load_project_backend,
+    _resolve_group_name,
+)
+from cutip.models.cards.container import ContainerCard
+from cutip.resolver.refs import RefResolver
+from cutip.utils.exceptions import CutipError
+from cutip.workspace.discovery import WorkspaceDiscovery
+from cutip.workspace.scaffold import _find_project_root
+
+console = Console()
+
+
+def _resolve_container_names(group_name: str, registry) -> list[str]:
+    """Return container names belonging to *group_name*."""
+    group = registry.get_group(group_name)
+    if group is None:
+        raise CutipError(f"Group '{group_name}' not found in registry")
+
+    resolver = RefResolver(registry)
+    names: list[str] = []
+    for unit_ref in group.spec.units:
+        unit = resolver.resolve_unit(unit_ref.ref)
+        card = resolver.resolve(unit.spec.containerRef.ref)
+        if isinstance(card, ContainerCard):
+            names.append(card.metadata.name)
+    return names
+
+
+def stop(
+    group_name: str = typer.Argument(
+        ...,
+        help="Name of the group to stop",
+        autocompletion=_complete_group_name,
+    ),
+    remove: bool = typer.Option(
+        False,
+        "--rm",
+        help="Remove containers after stopping (like docker compose down).",
+    ),
+    backend: str = typer.Option(
+        None,
+        "--backend",
+        "-b",
+        envvar="CUTIP_BACKEND",
+        help="Container backend (docker or podman). "
+             "Defaults to project.backend in cutip.yaml, then docker.",
+    ),
+    local: bool = typer.Option(
+        False,
+        "--local",
+        "-l",
+        help="Connect to the local Podman socket directly.",
+    ),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Stop all containers in a group.
+
+    Gracefully stops every container belonging to GROUP's units.
+    Use --rm to also remove the stopped containers (equivalent to
+    ``docker compose down``).
+    """
+    project_root = path or _find_project_root()
+    registry = WorkspaceDiscovery(project_root).discover()
+
+    try:
+        group_name = _resolve_group_name(group_name, registry)
+    except CutipError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+    container_names = _resolve_container_names(group_name, registry)
+    if not container_names:
+        console.print(f"[yellow]No containers found for group '{group_name}'[/yellow]")
+        raise typer.Exit(0)
+
+    is_local = local or os.environ.get("CUTIP_LOCAL", "").lower() in ("1", "true", "yes")
+    backend_name = (
+        backend.lower() if backend
+        else _load_project_backend(project_root)
+        or "docker"
+    )
+
+    try:
+        _backend = get_backend(backend_name, local=is_local)
+    except CutipError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+    try:
+        for name in container_names:
+            status = _backend.container_status(name)
+            if status == "not_found":
+                console.print(f"  [dim]{name}[/dim] — not found (skipped)")
+                continue
+
+            if status == "running":
+                _backend.stop_container(name)
+                console.print(f"  [green]Stopped[/green] {name}")
+            else:
+                console.print(f"  [dim]{name}[/dim] — already {status}")
+
+            if remove:
+                _backend.remove_container(name)
+                console.print(f"  [red]Removed[/red] {name}")
+
+        action = "stopped and removed" if remove else "stopped"
+        console.print(f"\n[bold green]Group '{group_name}' {action}.[/bold green]")
+    finally:
+        _backend.disconnect()

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -15,6 +15,7 @@ from cutip.cli.commands.upgrade import app as upgrade_app
 from cutip.cli.commands.ls import card_app, group_app, unit_app
 from cutip.cli.commands.plan import plan
 from cutip.cli.commands.run import run
+from cutip.cli.commands.stop import stop
 from cutip.cli.commands.secrets import secrets_app
 from cutip.cli.commands.show import app as show_app
 from cutip.cli.commands.tree import app as tree_app
@@ -219,6 +220,7 @@ complete -o default -F _cutip_completion cutip'''
 _WF = "Workflow"
 app.add_typer(init_app, name="init", rich_help_panel=_WF)
 app.command("run", rich_help_panel=_WF)(run)
+app.command("stop", rich_help_panel=_WF)(stop)
 app.command("plan", rich_help_panel=_WF)(plan)
 app.command("from-compose", rich_help_panel=_WF)(from_compose)
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -36,7 +36,8 @@ commit messages, and PR titles.
 | cap026 | Issue pipeline with approval gates                                | feat | merged | feat/cap026-issue-pipeline-gates     | #61 | 2026-03-09 |
 | cap027 | Self-service issue CLI with local Claude API                      | feat | merged | feat/cap027-self-service-issues      | #62 | 2026-03-09 |
 | cap028 | CLI help grouping + repo setup documentation                     | feat | merged | feat/cap028-cli-help-repo-docs       | #64 | 2026-03-09 |
-| cap029 | Backend default prompt + status display                           | feat | open   | feat/cap029-backend-default-prompt   | —   | 2026-03-14 |
+| cap029 | Backend default prompt + status display                           | feat | merged | feat/cap029-backend-default-prompt   | #70 | 2026-03-14 |
+| cap030 | cutip stop command for graceful group teardown                    | feat | open   | feat/cap030-stop-command             | —   | 2026-03-15 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

- Adds `cutip stop GROUP` command to gracefully stop all containers belonging to a group's units
- `--rm` flag removes containers after stopping (like `docker compose down`)
- Uses the same backend resolution chain, group name matching, and tab-completion as `cutip run`

## Changes

- `cutip/cli/commands/stop.py`: New command — resolves group → units → container names, stops/removes each via backend
- `cutip/cli/main.py`: Register `stop` command in the Workflow panel
- `docs/capabilities.md`: Registered cap030

## Test plan

- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes
- [ ] `cutip stop --help` shows correct usage
- [ ] `cutip stop simple` stops containers for the simple group
- [ ] `cutip stop simple --rm` stops and removes containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)