### PR TITLE
[cap032] @action/@orchestrator workflow decorators + introspection

### DIFF
--- a/cutip/context/workflow.py
+++ b/cutip/context/workflow.py
@@ -122,6 +122,26 @@ class WorkflowLoader:
         module, workflow_path = self._load_module(group, registry)
 
         if not hasattr(module, "main"):
+            # Fallback: check for @orchestrator-decorated function
+            from cutip.workflow.decorators import _ORCHESTRATOR_ATTR
+
+            orch = next(
+                (
+                    fn
+                    for fn in vars(module).values()
+                    if callable(fn) and getattr(fn, _ORCHESTRATOR_ATTR, False)
+                ),
+                None,
+            )
+            if orch is not None:
+                try:
+                    orch(ctx)
+                except Exception as exc:
+                    raise CutipWorkflowError(
+                        f"Error executing workflow '{workflow_path}': {exc}"
+                    ) from exc
+                return
+
             from loguru import logger as _logger
             _logger.debug(
                 f"Workflow '{workflow_path}' has no main() — skipping group-level execution."

--- a/cutip/workflow/__init__.py
+++ b/cutip/workflow/__init__.py
@@ -1,0 +1,24 @@
+"""cutip.workflow — self-describing workflow decorators.
+
+Public API::
+
+    from cutip.workflow import action, orchestrator, ActionMeta, extract_action_order
+"""
+
+from cutip.workflow.decorators import ActionMeta, action, orchestrator
+from cutip.workflow.introspect import (
+    extract_action_order,
+    extract_action_order_from_module,
+    get_module_actions,
+    get_orchestrator,
+)
+
+__all__ = [
+    "ActionMeta",
+    "action",
+    "orchestrator",
+    "extract_action_order",
+    "extract_action_order_from_module",
+    "get_module_actions",
+    "get_orchestrator",
+]

--- a/cutip/workflow/decorators.py
+++ b/cutip/workflow/decorators.py
@@ -1,0 +1,71 @@
+"""Workflow decorators for self-describing CUTIP actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Callable
+
+_ACTION_ATTR = "_cutip_action_meta"
+_ORCHESTRATOR_ATTR = "_cutip_is_orchestrator"
+
+
+@dataclass(frozen=True)
+class ActionMeta:
+    """Metadata attached to an ``@action``-decorated function."""
+
+    name: str
+    description: str = ""
+    container: str | None = None
+    depends_on: list[str] = field(default_factory=list)
+
+
+def action(
+    name: str,
+    description: str = "",
+    container: str | None = None,
+    depends_on: list[str] | None = None,
+) -> Callable:
+    """Parameterized decorator that attaches :class:`ActionMeta` to a function.
+
+    Usage::
+
+        @action(name="Start DB", description="Start the database", container="cutip-db")
+        def start_db(ctx):
+            ctx.container("cutip-db").start()
+    """
+    meta = ActionMeta(
+        name=name,
+        description=description,
+        container=container,
+        depends_on=depends_on or [],
+    )
+
+    def decorator(fn: Callable) -> Callable:
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            return fn(*args, **kwargs)
+
+        setattr(wrapper, _ACTION_ATTR, meta)
+        return wrapper
+
+    return decorator
+
+
+def orchestrator(fn: Callable) -> Callable:
+    """Bare decorator marking the workflow entry point.
+
+    Usage::
+
+        @orchestrator
+        def main(ctx):
+            start_db(ctx)
+            start_web(ctx)
+    """
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    setattr(wrapper, _ORCHESTRATOR_ATTR, True)
+    return wrapper

--- a/cutip/workflow/introspect.py
+++ b/cutip/workflow/introspect.py
@@ -1,0 +1,205 @@
+"""AST-based introspection for workflow action ordering."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Callable
+
+from cutip.workflow.decorators import _ACTION_ATTR, _ORCHESTRATOR_ATTR, ActionMeta
+
+
+def get_module_actions(module: ModuleType) -> dict[str, ActionMeta]:
+    """Return a mapping of function-name → ActionMeta for all @action functions."""
+    actions: dict[str, ActionMeta] = {}
+    for attr_name in dir(module):
+        obj = getattr(module, attr_name)
+        if callable(obj):
+            meta = getattr(obj, _ACTION_ATTR, None)
+            if isinstance(meta, ActionMeta):
+                actions[attr_name] = meta
+    return actions
+
+
+def get_orchestrator(module: ModuleType) -> Callable | None:
+    """Return the @orchestrator-decorated function, or None."""
+    for attr_name in dir(module):
+        obj = getattr(module, attr_name)
+        if callable(obj) and getattr(obj, _ORCHESTRATOR_ATTR, False):
+            return obj
+    return None
+
+
+def extract_action_order(workflow_path: Path) -> list[ActionMeta]:
+    """Extract the ordered list of actions from a workflow file using AST analysis.
+
+    Strategy:
+    1. Parse file with ast.parse
+    2. Find @action-decorated functions and their ActionMeta kwargs
+    3. Find @orchestrator function (or ``main``)
+    4. Walk orchestrator body for call nodes matching action function names
+    5. Return ActionMeta list in call order
+    6. Fallback to definition order if orchestrator not found
+    """
+    source = workflow_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(workflow_path))
+
+    # Step 1: Find all @action-decorated functions and extract their metadata
+    action_funcs: dict[str, ActionMeta] = {}  # func_name → ActionMeta
+    action_order: list[str] = []  # definition order
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for deco in node.decorator_list:
+            if _is_action_decorator(deco):
+                meta = _extract_meta_from_decorator(deco)
+                if meta is not None:
+                    action_funcs[node.name] = meta
+                    action_order.append(node.name)
+                break
+
+    if not action_funcs:
+        return []
+
+    # Step 2: Find orchestrator body and extract call order
+    orch_body = _find_orchestrator_body(tree)
+    if orch_body is None:
+        # Fallback: definition order
+        return [action_funcs[name] for name in action_order]
+
+    # Step 3: Walk orchestrator body for calls to action functions
+    call_order: list[str] = []
+    _collect_action_calls(orch_body, action_funcs, call_order)
+
+    if not call_order:
+        # No recognized calls found (dynamic dispatch?) → definition order
+        return [action_funcs[name] for name in action_order]
+
+    return [action_funcs[name] for name in call_order]
+
+
+def extract_action_order_from_module(module: ModuleType) -> list[ActionMeta]:
+    """Extract action order from an already-loaded module.
+
+    Uses the module's __file__ for AST analysis, falling back to runtime
+    introspection in definition order.
+    """
+    mod_file = getattr(module, "__file__", None)
+    if mod_file is not None:
+        return extract_action_order(Path(mod_file))
+
+    # No file available — fall back to runtime introspection
+    actions = get_module_actions(module)
+    return list(actions.values())
+
+
+def _is_action_decorator(deco: ast.expr) -> bool:
+    """Check if a decorator node is an @action(...) call."""
+    if isinstance(deco, ast.Call):
+        func = deco.func
+        if isinstance(func, ast.Name) and func.id == "action":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "action":
+            return True
+    return False
+
+
+def _extract_meta_from_decorator(deco: ast.Call) -> ActionMeta | None:
+    """Parse ActionMeta fields from an @action(...) AST call node."""
+    kwargs: dict[str, str | list[str] | None] = {}
+
+    # Positional: first arg is name
+    if deco.args:
+        name_node = deco.args[0]
+        if isinstance(name_node, ast.Constant) and isinstance(name_node.value, str):
+            kwargs["name"] = name_node.value
+
+    # Keyword arguments
+    for kw in deco.keywords:
+        if kw.arg is None:
+            continue
+        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            kwargs[kw.arg] = kw.value.value
+        elif isinstance(kw.value, ast.List):
+            items = []
+            for elt in kw.value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    items.append(elt.value)
+            kwargs[kw.arg] = items
+
+    name = kwargs.get("name")
+    if not isinstance(name, str):
+        return None
+
+    description = kwargs.get("description", "")
+    container = kwargs.get("container")
+    depends_on = kwargs.get("depends_on", [])
+
+    return ActionMeta(
+        name=name,
+        description=description if isinstance(description, str) else "",
+        container=container if isinstance(container, str) else None,
+        depends_on=depends_on if isinstance(depends_on, list) else [],
+    )
+
+
+def _find_orchestrator_body(tree: ast.Module) -> list[ast.stmt] | None:
+    """Find the body of the @orchestrator or main() function."""
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        # Check for @orchestrator decorator
+        for deco in node.decorator_list:
+            if isinstance(deco, ast.Name) and deco.id == "orchestrator":
+                return node.body
+            if isinstance(deco, ast.Attribute) and deco.attr == "orchestrator":
+                return node.body
+        # Fallback: look for main()
+        if node.name == "main":
+            return node.body
+    return None
+
+
+def _collect_action_calls(
+    stmts: list[ast.stmt],
+    action_funcs: dict[str, ActionMeta],
+    call_order: list[str],
+) -> None:
+    """Recursively walk statements collecting calls to action functions in order."""
+    for stmt in stmts:
+        # Direct call: action_func(ctx) as expression
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            _check_call(stmt.value, action_funcs, call_order)
+        # Assignment: result = action_func(ctx)
+        elif isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+            value = stmt.value if isinstance(stmt, ast.Assign) else stmt.value
+            if isinstance(value, ast.Call):
+                _check_call(value, action_funcs, call_order)
+        # If/else blocks
+        elif isinstance(stmt, ast.If):
+            _collect_action_calls(stmt.body, action_funcs, call_order)
+            _collect_action_calls(stmt.orelse, action_funcs, call_order)
+        # For/while loops
+        elif isinstance(stmt, (ast.For, ast.While)):
+            _collect_action_calls(stmt.body, action_funcs, call_order)
+        # Try blocks
+        elif isinstance(stmt, ast.Try):
+            _collect_action_calls(stmt.body, action_funcs, call_order)
+            for handler in stmt.handlers:
+                _collect_action_calls(handler.body, action_funcs, call_order)
+
+
+def _check_call(
+    call: ast.Call,
+    action_funcs: dict[str, ActionMeta],
+    call_order: list[str],
+) -> None:
+    """If *call* targets a known action function, append to *call_order*."""
+    func = call.func
+    if isinstance(func, ast.Name) and func.id in action_funcs:
+        if func.id not in call_order:
+            call_order.append(func.id)

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -39,6 +39,7 @@ commit messages, and PR titles.
 | cap029 | Backend default prompt + status display                           | feat | merged | feat/cap029-backend-default-prompt   | #70 | 2026-03-14 |
 | cap030 | cutip stop command for graceful group teardown                    | feat | merged | feat/cap030-stop-command             | #71 | 2026-03-15 |
 | cap031 | @claude commands, welcome message, auto-diagnose for owner        | feat | open   | feat/cap031-claude-commands          | —   | 2026-03-15 |
+| cap032 | @action/@orchestrator workflow decorators + introspection         | feat | open   | feat/cap032-workflow-decorators      | —   | 2026-03-15 |
 
 ## ID Assignment
 

--- a/tests/fixtures/workflow_decorated.py
+++ b/tests/fixtures/workflow_decorated.py
@@ -1,0 +1,32 @@
+"""Test fixture: a workflow using @action/@orchestrator decorators."""
+
+from __future__ import annotations
+
+from cutip.workflow import action, orchestrator
+
+
+@action(name="Start DB", description="Start the database", container="cutip-db")
+def start_db(ctx):
+    pass
+
+
+@action(
+    name="Wait for DB",
+    description="Poll until DB accepts connections",
+    container="cutip-db",
+    depends_on=["Start DB"],
+)
+def wait_for_db(ctx):
+    pass
+
+
+@action(name="Start Web", description="Start the web app", container="cutip-web")
+def start_web(ctx):
+    pass
+
+
+@orchestrator
+def main(ctx):
+    start_db(ctx)
+    wait_for_db(ctx)
+    start_web(ctx)

--- a/tests/test_workflow_decorators.py
+++ b/tests/test_workflow_decorators.py
@@ -1,0 +1,162 @@
+"""Tests for cutip.workflow decorators and introspection."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from cutip.workflow import ActionMeta, action, orchestrator
+from cutip.workflow.decorators import _ACTION_ATTR, _ORCHESTRATOR_ATTR
+from cutip.workflow.introspect import (
+    extract_action_order,
+    extract_action_order_from_module,
+    get_module_actions,
+    get_orchestrator,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ── Decorator unit tests ─────────────────────────────────────────────────────
+
+
+def test_action_decorator_attaches_meta():
+    @action(name="Test Action", description="A test", container="my-ctr")
+    def my_action(ctx):
+        pass
+
+    meta = getattr(my_action, _ACTION_ATTR)
+    assert isinstance(meta, ActionMeta)
+    assert meta.name == "Test Action"
+    assert meta.description == "A test"
+    assert meta.container == "my-ctr"
+    assert meta.depends_on == []
+
+
+def test_orchestrator_decorator_marks_function():
+    @orchestrator
+    def main(ctx):
+        pass
+
+    assert getattr(main, _ORCHESTRATOR_ATTR) is True
+
+
+def test_action_preserves_function_behavior():
+    @action(name="Add One")
+    def add_one(x):
+        return x + 1
+
+    assert add_one(5) == 6
+
+
+def test_action_with_depends_on():
+    @action(name="Step 2", depends_on=["Step 1"])
+    def step_two(ctx):
+        pass
+
+    meta = getattr(step_two, _ACTION_ATTR)
+    assert meta.depends_on == ["Step 1"]
+
+
+def test_action_with_container_hint():
+    @action(name="Deploy", container="deploy-ctr")
+    def deploy(ctx):
+        pass
+
+    meta = getattr(deploy, _ACTION_ATTR)
+    assert meta.container == "deploy-ctr"
+
+
+# ── Runtime introspection tests ──────────────────────────────────────────────
+
+
+def _load_fixture_module():
+    """Load the decorated workflow fixture as a module."""
+    fixture_path = FIXTURES / "workflow_decorated.py"
+    spec = importlib.util.spec_from_file_location("test_fixture_wf", fixture_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test_fixture_wf"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_module_actions_returns_all_actions():
+    module = _load_fixture_module()
+    actions = get_module_actions(module)
+    assert len(actions) == 3
+    assert "start_db" in actions
+    assert "wait_for_db" in actions
+    assert "start_web" in actions
+    assert actions["start_db"].name == "Start DB"
+    assert actions["wait_for_db"].container == "cutip-db"
+
+
+def test_get_orchestrator_finds_decorated():
+    module = _load_fixture_module()
+    orch = get_orchestrator(module)
+    assert orch is not None
+    assert getattr(orch, _ORCHESTRATOR_ATTR) is True
+
+
+# ── AST-based action order extraction ────────────────────────────────────────
+
+
+def test_extract_action_order_simple():
+    actions = extract_action_order(FIXTURES / "workflow_decorated.py")
+    assert len(actions) == 3
+    assert actions[0].name == "Start DB"
+    assert actions[1].name == "Wait for DB"
+    assert actions[2].name == "Start Web"
+
+
+def test_extract_action_order_no_decorators_returns_empty(tmp_path):
+    wf = tmp_path / "workflow.py"
+    wf.write_text(
+        textwrap.dedent("""\
+        def main(ctx):
+            ctx.container("foo").start()
+        """)
+    )
+    actions = extract_action_order(wf)
+    assert actions == []
+
+
+def test_extract_action_order_fallback_to_definition_order(tmp_path):
+    """When orchestrator body has no recognized action calls, fall back to definition order."""
+    wf = tmp_path / "workflow.py"
+    wf.write_text(
+        textwrap.dedent("""\
+        from cutip.workflow import action, orchestrator
+
+        @action(name="Alpha")
+        def alpha(ctx):
+            pass
+
+        @action(name="Beta")
+        def beta(ctx):
+            pass
+
+        @orchestrator
+        def main(ctx):
+            # Dynamic dispatch — no direct calls to alpha/beta
+            for fn in [alpha, beta]:
+                fn(ctx)
+        """)
+    )
+    actions = extract_action_order(wf)
+    assert len(actions) == 2
+    # Falls back to definition order since the for-loop iteration
+    # doesn't produce direct ast.Call nodes matching function names
+    assert actions[0].name == "Alpha"
+    assert actions[1].name == "Beta"
+
+
+def test_extract_action_order_from_module():
+    module = _load_fixture_module()
+    actions = extract_action_order_from_module(module)
+    assert len(actions) == 3
+    assert actions[0].name == "Start DB"


### PR DESCRIPTION
## Summary

- Adds `@action` and `@orchestrator` decorators so workflow.py files are self-describing — each action carries a name, description, container hint, and dependency list as metadata
- AST-based introspection extracts action execution order from workflow files without importing them, enabling static analysis by external tools (cutip-desktop)
- WorkflowLoader falls back to `@orchestrator`-decorated functions when `main()` is absent, maintaining full backward compatibility

## Changes

- `cutip/workflow/__init__.py`: New package re-exporting `action`, `orchestrator`, `ActionMeta`, and introspection functions
- `cutip/workflow/decorators.py`: `@action` (parameterized) and `@orchestrator` (bare) decorators with `ActionMeta` frozen dataclass
- `cutip/workflow/introspect.py`: AST-based `extract_action_order()`, `get_module_actions()`, `get_orchestrator()`, and module-level variant
- `cutip/context/workflow.py`: Added `@orchestrator` fallback in `WorkflowLoader.run()` when no `main()` exists
- `docs/capabilities.md`: Added cap032 entry
- `tests/test_workflow_decorators.py`: 11 tests covering decorators, runtime introspection, and AST extraction
- `tests/fixtures/workflow_decorated.py`: Test fixture with 3 decorated actions

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (50 tests)
- [x] `uv run python -c "from cutip.workflow import action, orchestrator, ActionMeta; print('ok')"` succeeds
- [x] Existing workflow.py files without decorators continue to work via `main()` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
