### PR TITLE
[cap033] cutip desktop command for workspace registration

### DIFF
--- a/cutip/cli/commands/desktop.py
+++ b/cutip/cli/commands/desktop.py
@@ -1,0 +1,54 @@
+"""cutip desktop — register workspace in cutip-desktop and open graph tab."""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import typer
+import yaml
+
+from cutip.workspace.scaffold import _find_project_root
+
+
+def desktop(
+    url: str = typer.Option("http://localhost:5173", "--url", help="cutip-desktop server URL."),
+    path: Path = typer.Option(None, "--path", "-p", help="Project root (auto-detected if omitted)."),
+) -> None:
+    """Register this workspace in cutip-desktop and open the graph tab."""
+    project_root = path or _find_project_root()
+    config_path = project_root / "cutip.yaml"
+
+    if not config_path.is_file():
+        typer.echo(f"No cutip.yaml found at {project_root}", err=True)
+        raise typer.Exit(1)
+
+    with config_path.open(encoding="utf-8") as fh:
+        config = yaml.safe_load(fh)
+
+    project_name = config.get("project", {}).get("name", project_root.name)
+
+    payload = json.dumps({"name": project_name, "path": str(project_root)}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{url.rstrip('/')}/api/workspaces",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            body = json.loads(resp.read())
+            workspace_id = body.get("id", "unknown")
+            typer.echo(f"Workspace registered: {url}/workspace/{workspace_id}/graph")
+    except urllib.error.URLError as exc:
+        typer.echo(
+            f"Could not connect to cutip-desktop at {url}\n"
+            f"Start it first: cd cutip-desktop && npm run dev\n"
+            f"Error: {exc.reason}",
+            err=True,
+        )
+        raise typer.Exit(1)

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import typer
 
 from cutip.cli.commands.compose import from_compose
+from cutip.cli.commands.desktop import desktop
 from cutip.cli.commands.init import app as init_app
 from cutip.cli.commands.issue import issue_app
 from cutip.cli.commands.upgrade import app as upgrade_app
@@ -223,6 +224,7 @@ app.command("run", rich_help_panel=_WF)(run)
 app.command("stop", rich_help_panel=_WF)(stop)
 app.command("plan", rich_help_panel=_WF)(plan)
 app.command("from-compose", rich_help_panel=_WF)(from_compose)
+app.command("desktop", rich_help_panel=_WF)(desktop)
 
 # ── Inspect ──────────────────────────────────────────────────────────────────
 _IN = "Inspect"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -40,6 +40,7 @@ commit messages, and PR titles.
 | cap030 | cutip stop command for graceful group teardown                    | feat | merged | feat/cap030-stop-command             | #71 | 2026-03-15 |
 | cap031 | @claude commands, welcome message, auto-diagnose for owner        | feat | open   | feat/cap031-claude-commands          | —   | 2026-03-15 |
 | cap032 | @action/@orchestrator workflow decorators + introspection         | feat | open   | feat/cap032-workflow-decorators      | —   | 2026-03-15 |
+| cap033 | cutip desktop command for workspace registration                  | feat | open   | feat/cap033-desktop-command           | —   | 2026-03-15 |
 
 ## ID Assignment
 

--- a/tests/test_desktop_command.py
+++ b/tests/test_desktop_command.py
@@ -1,0 +1,46 @@
+"""Tests for the cutip desktop command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from cutip.cli.main import app
+
+runner = CliRunner()
+
+
+def test_desktop_no_cutip_yaml_exits(tmp_path):
+    result = runner.invoke(app, ["desktop", "--path", str(tmp_path)])
+    assert result.exit_code != 0
+    assert "No cutip.yaml found" in result.output
+
+
+def test_desktop_connection_refused(tmp_path):
+    config = {"apiVersion": "cutip/v1", "project": {"name": "test-proj"}}
+    (tmp_path / "cutip.yaml").write_text(yaml.dump(config))
+
+    result = runner.invoke(app, ["desktop", "--path", str(tmp_path), "--url", "http://localhost:19999"])
+    assert result.exit_code != 0
+    assert "Could not connect" in result.output
+
+
+def test_desktop_success(tmp_path):
+    config = {"apiVersion": "cutip/v1", "project": {"name": "test-proj"}}
+    (tmp_path / "cutip.yaml").write_text(yaml.dump(config))
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps({"id": "abc123"}).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("cutip.cli.commands.desktop.urllib.request.urlopen", return_value=mock_resp):
+        result = runner.invoke(app, ["desktop", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "abc123" in result.output
+        assert "/graph" in result.output


### PR DESCRIPTION
## Summary

- Adds `cutip desktop` command that registers the current workspace in cutip-desktop via POST to `/api/workspaces`
- Uses stdlib `urllib.request` — no new dependencies needed
- On success prints the graph URL; on connection error prints clear instructions to start cutip-desktop

## Changes

- `cutip/cli/commands/desktop.py`: New command — reads project name from `cutip.yaml`, POSTs to cutip-desktop API
- `cutip/cli/main.py`: Registered `desktop` command under the Workflow help panel
- `docs/capabilities.md`: Added cap033 entry

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (53 tests)
- [x] `cutip desktop --help` shows help text
- [x] Missing `cutip.yaml` exits with error
- [x] Connection refused shows clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
