### PR TITLE
[cap035] Fix project root discovery to anchor on cutip.yaml

### DIFF
--- a/cutip/cli/commands/compose.py
+++ b/cutip/cli/commands/compose.py
@@ -635,7 +635,7 @@ def from_compose(
         None,
         "--output-dir",
         "-o",
-        help="Output directory. Defaults to git root or cwd.",
+        help="Output directory. Defaults to nearest cutip.yaml, git root, or cwd.",
         show_default=False,
     ),
 ) -> None:

--- a/cutip/cli/commands/init.py
+++ b/cutip/cli/commands/init.py
@@ -15,17 +15,25 @@ app = typer.Typer()
 
 @app.callback(invoke_without_command=True)
 def init(
-    path: Path = typer.Option(
+    path: Path = typer.Argument(
         None,
-        "--path",
-        "-p",
-        help="Project root directory. Defaults to git root or cwd.",
+        help="Project root directory. Defaults to nearest cutip.yaml, git root, or cwd.",
         show_default=False,
     ),
 ) -> None:
-    """Initialize a CUTIP workspace in the current project."""
+    """Initialize a CUTIP workspace.
+
+    Usage: cutip init [PATH]
+
+    Examples:
+      cutip init          # initialize in auto-detected project root
+      cutip init .        # initialize in current directory
+      cutip init ../foo   # initialize in ../foo
+    """
     setup_logging()
-    scaffold = WorkspaceScaffold(project_root=path)
+    # Resolve the path argument relative to cwd
+    resolved = Path(path).resolve() if path is not None else None
+    scaffold = WorkspaceScaffold(project_root=resolved)
     scaffold.init()
 
     root = scaffold.project_root

--- a/cutip/cli/commands/ls.py
+++ b/cutip/cli/commands/ls.py
@@ -31,7 +31,7 @@ def _get_registry(path: Path | None):
 @group_app.command("ls")
 def group_ls(
     path: Path = typer.Option(None, "--path", "-p", show_default=False,
-                              help="Project root. Defaults to git root or cwd."),
+                              help="Project root. Defaults to nearest cutip.yaml, git root, or cwd."),
 ) -> None:
     """List all groups discovered in the workspace."""
     try:
@@ -61,7 +61,7 @@ def group_ls(
 @unit_app.command("ls")
 def unit_ls(
     path: Path = typer.Option(None, "--path", "-p", show_default=False,
-                              help="Project root. Defaults to git root or cwd."),
+                              help="Project root. Defaults to nearest cutip.yaml, git root, or cwd."),
 ) -> None:
     """List all units discovered in the workspace."""
     try:
@@ -89,7 +89,7 @@ def unit_ls(
 @card_app.command("ls")
 def card_ls(
     path: Path = typer.Option(None, "--path", "-p", show_default=False,
-                              help="Project root. Defaults to git root or cwd."),
+                              help="Project root. Defaults to nearest cutip.yaml, git root, or cwd."),
 ) -> None:
     """List all cards (images, containers, networks) discovered in the workspace."""
     try:

--- a/cutip/cli/commands/tree.py
+++ b/cutip/cli/commands/tree.py
@@ -20,7 +20,7 @@ def tree(
         None,
         "--path",
         "-p",
-        help="Project root. Defaults to git root or cwd.",
+        help="Project root. Defaults to nearest cutip.yaml, git root, or cwd.",
         show_default=False,
     ),
 ) -> None:

--- a/cutip/cli/commands/validate.py
+++ b/cutip/cli/commands/validate.py
@@ -20,7 +20,7 @@ def validate(
         None,
         "--path",
         "-p",
-        help="Project root. Defaults to git root or cwd.",
+        help="Project root. Defaults to nearest cutip.yaml, git root, or cwd.",
         show_default=False,
     ),
 ) -> None:

--- a/cutip/workspace/scaffold.py
+++ b/cutip/workspace/scaffold.py
@@ -709,7 +709,21 @@ CMD ["python", "-c", "import time; print('cutip-web started'); time.sleep(86400)
 
 
 def _find_project_root() -> Path:
-    """Return the git root if inside a repo, otherwise cwd."""
+    """Find the CUTIP project root.
+
+    Strategy (first match wins):
+    1. Walk up from cwd looking for ``cutip.yaml`` — supports multiple
+       CUTIP projects inside a single git repo.
+    2. Fall back to the git root (``git rev-parse --show-toplevel``).
+    3. Fall back to cwd.
+    """
+    # 1. Walk up looking for cutip.yaml
+    current = Path.cwd().resolve()
+    for parent in [current, *current.parents]:
+        if (parent / "cutip.yaml").is_file():
+            return parent
+
+    # 2. Fall back to git root
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -719,7 +733,10 @@ def _find_project_root() -> Path:
         )
         return Path(result.stdout.strip())
     except (subprocess.CalledProcessError, FileNotFoundError):
-        return Path.cwd()
+        pass
+
+    # 3. Fall back to cwd
+    return Path.cwd()
 
 
 def _write_file(path: Path, content: str, label: str) -> None:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -42,6 +42,7 @@ commit messages, and PR titles.
 | cap032 | @action/@orchestrator workflow decorators + introspection         | feat | merged | feat/cap032-workflow-decorators      | #74 | 2026-03-17 |
 | cap033 | cutip desktop command for workspace registration                  | feat | merged | feat/cap033-desktop-command           | #75 | 2026-03-17 |
 | cap034 | Scaffold rewrite with @action/@orchestrator decorators            | feat | merged | feat/cap034-scaffold-decorators      | #76 | 2026-03-17 |
+| cap035 | Fix project root discovery to anchor on cutip.yaml               | bug  | open   | bug/cap035-project-root-discovery    | —   | 2026-03-18 |
 
 ## ID Assignment
 

--- a/tests/test_project_root.py
+++ b/tests/test_project_root.py
@@ -1,0 +1,59 @@
+"""Tests for _find_project_root() discovery logic."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from cutip.workspace.scaffold import _find_project_root
+
+
+def test_find_project_root_prefers_cutip_yaml(tmp_path, monkeypatch):
+    """cutip.yaml in a subdirectory should win over .git in parent."""
+    # Simulate: parent has .git, child has cutip.yaml
+    parent = tmp_path / "monorepo"
+    parent.mkdir()
+    (parent / ".git").mkdir()
+
+    child = parent / "subproject"
+    child.mkdir()
+    (child / "cutip.yaml").write_text("apiVersion: cutip/v1\n")
+
+    monkeypatch.chdir(child)
+    assert _find_project_root() == child
+
+
+def test_find_project_root_walks_up_to_cutip_yaml(tmp_path, monkeypatch):
+    """Walking up from a subdirectory should find the nearest cutip.yaml."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "cutip.yaml").write_text("apiVersion: cutip/v1\n")
+
+    subdir = project / "cutip" / "groups" / "mygroup"
+    subdir.mkdir(parents=True)
+
+    monkeypatch.chdir(subdir)
+    assert _find_project_root() == project
+
+
+def test_find_project_root_falls_back_to_git(tmp_path, monkeypatch):
+    """Without cutip.yaml, fall back to .git root."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    subdir = repo / "src"
+    subdir.mkdir()
+
+    monkeypatch.chdir(subdir)
+    # No cutip.yaml anywhere, so it should use git rev-parse.
+    # Since tmp_path/.git isn't a real git repo, git rev-parse will fail
+    # and we'll fall back to cwd.
+    root = _find_project_root()
+    assert root == subdir
+
+
+def test_find_project_root_falls_back_to_cwd(tmp_path, monkeypatch):
+    """Without cutip.yaml or .git, return cwd."""
+    monkeypatch.chdir(tmp_path)
+    assert _find_project_root() == tmp_path


### PR DESCRIPTION
## Summary

**Root cause:** `_find_project_root()` used `git rev-parse --show-toplevel` as the primary discovery method, returning the git root for all subdirectories. In monorepos with multiple CUTIP projects (e.g., `snf-dev/snf-gui-dev/` and `snf-dev/snf-blueprint-manager-dev/`), every command resolved to the same wrong project root.

**Fix:** Rewrite `_find_project_root()` to walk up from cwd looking for `cutip.yaml` first (nearest wins), falling back to git root, then cwd. Also changes `cutip init` to accept path as a positional argument (`cutip init .` instead of `cutip init -p .`), and updates help text across all commands.

## Changes

- `cutip/workspace/scaffold.py`: Rewrite `_find_project_root()` — cutip.yaml-first discovery
- `cutip/cli/commands/init.py`: Change path from `typer.Option` to `typer.Argument` (positional)
- `cutip/cli/commands/ls.py`: Update help text for `--path` in group/unit/card ls
- `cutip/cli/commands/validate.py`: Update help text for `--path`
- `cutip/cli/commands/tree.py`: Update help text for `--path`
- `cutip/cli/commands/compose.py`: Update help text for `--output-dir`
- `docs/capabilities.md`: Add cap035 row
- `tests/test_project_root.py`: 4 new tests covering cutip.yaml priority, walk-up, git fallback, cwd fallback

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57 tests)
- [ ] `cutip init .` works (positional argument)
- [ ] In monorepo: `cd project-a && cutip group ls` shows project-a groups only
- [ ] In monorepo: `cd project-b && cutip group ls` shows project-b groups only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
