### PR TITLE
[cap036] Add cutip info command

### DIFF
--- a/cutip/cli/commands/info.py
+++ b/cutip/cli/commands/info.py
@@ -1,0 +1,62 @@
+"""``cutip info`` — display CUTIP version, workspace, and backend information."""
+from __future__ import annotations
+
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+import typer
+import yaml
+from rich.console import Console
+from rich.panel import Panel
+
+from cutip.workspace.scaffold import _find_project_root
+
+console = Console()
+app = typer.Typer()
+
+
+@app.callback(invoke_without_command=True)
+def info() -> None:
+    """Show CUTIP version, active workspace, and backend info."""
+    ver = _pkg_version("cutip")
+    lines = [f"[bold]Version[/bold]: {ver}"]
+
+    # Active workspace
+    project_root = _find_project_root()
+    config_path = project_root / "cutip.yaml"
+    if config_path.is_file():
+        try:
+            with config_path.open(encoding="utf-8") as fh:
+                doc = yaml.safe_load(fh) or {}
+            project = doc.get("project", {})
+            name = project.get("name", project_root.name)
+            proj_ver = project.get("version", "—")
+            backend = project.get("backend", "docker")
+            lines.append(f"[bold]Workspace[/bold]: {name} (v{proj_ver})")
+            lines.append(f"[bold]Project root[/bold]: [cyan]{project_root}[/cyan]")
+            lines.append(f"[bold]Backend[/bold]: {backend}")
+        except Exception:
+            lines.append(f"[bold]Workspace[/bold]: [yellow]cutip.yaml found but unreadable[/yellow]")
+            lines.append(f"[bold]Project root[/bold]: [cyan]{project_root}[/cyan]")
+    else:
+        lines.append("[bold]Workspace[/bold]: [dim]none (no cutip.yaml found)[/dim]")
+
+    # Available backends
+    available = []
+    for name, mod in [("docker", "docker"), ("podman", "podman")]:
+        try:
+            __import__(mod)
+            available.append(name)
+        except ImportError:
+            pass
+
+    if available:
+        lines.append(f"[bold]Available backends[/bold]: {', '.join(available)}")
+    else:
+        lines.append("[bold]Available backends[/bold]: [yellow]none installed[/yellow]")
+
+    console.print(Panel.fit(
+        "\n".join(lines),
+        title="cutip info",
+        border_style="blue",
+    ))

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -10,6 +10,7 @@ import typer
 
 from cutip.cli.commands.compose import from_compose
 from cutip.cli.commands.desktop import desktop
+from cutip.cli.commands.info import app as info_app
 from cutip.cli.commands.init import app as init_app
 from cutip.cli.commands.issue import issue_app
 from cutip.cli.commands.upgrade import app as upgrade_app
@@ -225,6 +226,8 @@ app.command("stop", rich_help_panel=_WF)(stop)
 app.command("plan", rich_help_panel=_WF)(plan)
 app.command("from-compose", rich_help_panel=_WF)(from_compose)
 app.command("desktop", rich_help_panel=_WF)(desktop)
+
+app.add_typer(info_app, name="info", rich_help_panel=_WF)
 
 # ── Inspect ──────────────────────────────────────────────────────────────────
 _IN = "Inspect"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -42,7 +42,8 @@ commit messages, and PR titles.
 | cap032 | @action/@orchestrator workflow decorators + introspection         | feat | merged | feat/cap032-workflow-decorators      | #74 | 2026-03-17 |
 | cap033 | cutip desktop command for workspace registration                  | feat | merged | feat/cap033-desktop-command           | #75 | 2026-03-17 |
 | cap034 | Scaffold rewrite with @action/@orchestrator decorators            | feat | merged | feat/cap034-scaffold-decorators      | #76 | 2026-03-17 |
-| cap035 | Fix project root discovery to anchor on cutip.yaml               | bug  | open   | bug/cap035-project-root-discovery    | —   | 2026-03-18 |
+| cap035 | Fix project root discovery to anchor on cutip.yaml               | bug  | merged | bug/cap035-project-root-discovery    | #79 | 2026-03-18 |
+| cap036 | cutip info command for version and workspace status              | feat | open   | feat/cap036-info-command             | —   | 2026-03-18 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

- Adds `cutip info` command that displays CUTIP version, active workspace (from nearest cutip.yaml), project root, configured backend, and available backends
- Registered under the Workflow help panel in the CLI

## Changes

- `cutip/cli/commands/info.py`: New command — reads package version and cutip.yaml
- `cutip/cli/main.py`: Register `info` command
- `docs/capabilities.md`: Add cap036 row, mark cap035 as merged

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57 tests)
- [x] `cutip info` outside workspace shows version + "none"
- [x] `cutip info` inside workspace shows name, version, root, backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)