### PR TITLE
[cap037] Fix Podman SSH tunnel port collision for concurrent workspaces

### DIFF
--- a/cutip/backends/podman/backend.py
+++ b/cutip/backends/podman/backend.py
@@ -15,7 +15,7 @@ from loguru import logger
 
 from cutip.backends.base import CutipBackend
 from cutip.backends.podman.connection import (
-    PODMAN_TCP_URL,
+    TunnelInfo,
     close_ssh_tunnel,
     get_default_connection,
     local_socket_url,
@@ -49,9 +49,9 @@ def _win_to_wsl(path: str) -> str:
 class PodmanBackend(CutipBackend):
     """Podman backend — communicates via PodmanClient (SSH tunnel or local socket)."""
 
-    def __init__(self, client, tunnel_process: subprocess.Popen | None = None) -> None:
+    def __init__(self, client, tunnel: TunnelInfo | None = None) -> None:
         self._client = client
-        self._tunnel = tunnel_process
+        self._tunnel = tunnel
 
     @property
     def client(self):
@@ -65,7 +65,7 @@ class PodmanBackend(CutipBackend):
         """Open an SSH port-forward tunnel and return a connected backend.
 
         Reads the default Podman connection from ``podman system connection ls``
-        and forwards ``localhost:{PODMAN_TCP_PORT}`` to the Podman socket inside
+        and forwards a dynamic localhost port to the Podman socket inside
         the VM.  No daemon service is started inside the guest.
         """
         try:
@@ -78,13 +78,13 @@ class PodmanBackend(CutipBackend):
         conn = get_default_connection()
         tunnel = open_ssh_tunnel(conn)
 
-        client = PodmanClient(base_url=PODMAN_TCP_URL)
+        client = PodmanClient(base_url=tunnel.url)
         if not client.ping():
             close_ssh_tunnel(tunnel)
             raise CutipError("Podman ping failed after opening SSH tunnel.")
 
-        logger.info("Podman connected (SSH tunnel).")
-        return cls(client=client, tunnel_process=tunnel)
+        logger.info(f"Podman connected (SSH tunnel on port {tunnel.port}).")
+        return cls(client=client, tunnel=tunnel)
 
     @classmethod
     def connect_local(cls) -> "PodmanBackend":
@@ -106,7 +106,7 @@ class PodmanBackend(CutipBackend):
             )
 
         logger.info(f"Podman connected (local socket: {url}).")
-        return cls(client=client, tunnel_process=None)
+        return cls(client=client, tunnel=None)
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 

--- a/cutip/backends/podman/connection.py
+++ b/cutip/backends/podman/connection.py
@@ -16,19 +16,36 @@ from __future__ import annotations
 
 import os
 import shlex
+import socket
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from loguru import logger
 
 from cutip.utils.exceptions import CutipError
 
-# ── Constants ──────────────────────────────────────────────────────────────────
 
-PODMAN_TCP_PORT: int = 8080
-PODMAN_TCP_URL: str = f"tcp://localhost:{PODMAN_TCP_PORT}"
+# ── Tunnel result ─────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class TunnelInfo:
+    """Result of opening an SSH tunnel — holds the process and the allocated port."""
+    process: subprocess.Popen
+    port: int
+
+    @property
+    def url(self) -> str:
+        return f"tcp://localhost:{self.port}"
+
+
+def _find_free_port() -> int:
+    """Ask the OS for an available TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
 
 
 # ── Connection enumeration ─────────────────────────────────────────────────────
@@ -94,12 +111,11 @@ def get_default_connection(connections: list[dict[str, str]] | None = None) -> d
 
 # ── SSH tunnel (used by PodmanBackend.connect()) ───────────────────────────────
 
-def open_ssh_tunnel(connection: dict[str, str]) -> subprocess.Popen:
-    """Forward ``localhost:{PODMAN_TCP_PORT}`` → the Podman Unix socket inside the VM.
+def open_ssh_tunnel(connection: dict[str, str]) -> TunnelInfo:
+    """Forward a dynamic localhost port → the Podman Unix socket inside the VM.
 
-    Uses SSH local port forwarding (``-L``), so no ``podman system service``
-    process needs to run inside the guest — SSH holds the port open and
-    transparently proxies HTTP requests to the Podman socket.
+    Uses SSH local port forwarding (``-L``) with an OS-assigned free port,
+    so multiple CUTIP workspaces can run simultaneously without collisions.
 
     Requires OpenSSH ≥ 6.7 (ships with macOS 10.12+ and modern Linux distros).
 
@@ -107,9 +123,8 @@ def open_ssh_tunnel(connection: dict[str, str]) -> subprocess.Popen:
         connection: A connection dict as returned by :func:`get_default_connection`.
 
     Returns:
-        The running SSH :class:`subprocess.Popen` object.
-        Keep this alive for the lifetime of the session; close with
-        :func:`close_ssh_tunnel` when done.
+        A :class:`TunnelInfo` with the running SSH process and allocated port.
+        Keep alive for the session lifetime; close with :func:`close_ssh_tunnel`.
 
     Raises:
         CutipError: If the tunnel exits immediately (bad key, wrong host, etc.).
@@ -134,12 +149,12 @@ def open_ssh_tunnel(connection: dict[str, str]) -> subprocess.Popen:
         else (host_port, "22")
     )
 
-    # -L local_port:remote_unix_socket  →  maps tcp://localhost:8080 on the
-    # host to the Podman REST API socket inside the VM.
+    local_port = _find_free_port()
+
     ssh_cmd = [
         "ssh",
         "-N",                                       # port-forward only, no shell
-        "-L", f"{PODMAN_TCP_PORT}:{socket_path}",
+        "-L", f"{local_port}:{socket_path}",
         "-i", identity,
         "-p", port,
         f"{user}@{host}",
@@ -162,18 +177,22 @@ def open_ssh_tunnel(connection: dict[str, str]) -> subprocess.Popen:
             "Ensure 'podman machine start' has been run and the machine is healthy."
         )
 
-    logger.info(f"SSH tunnel established: {PODMAN_TCP_URL} -> {socket_path}")
-    return process
+    tunnel = TunnelInfo(process=process, port=local_port)
+    logger.info(f"SSH tunnel established: {tunnel.url} -> {socket_path}")
+    return tunnel
 
 
-def close_ssh_tunnel(process: subprocess.Popen, timeout: int = 5) -> None:
+def close_ssh_tunnel(tunnel: TunnelInfo | subprocess.Popen | None, timeout: int = 5) -> None:
     """Terminate the SSH tunnel process gracefully.
 
     Args:
-        process: The :class:`subprocess.Popen` returned by :func:`open_ssh_tunnel`.
+        tunnel: A :class:`TunnelInfo` or raw :class:`subprocess.Popen`.
         timeout: Seconds to wait for graceful termination before force-killing.
     """
-    if process is None or process.poll() is not None:
+    if tunnel is None:
+        return
+    process = tunnel.process if isinstance(tunnel, TunnelInfo) else tunnel
+    if process.poll() is not None:
         return
     logger.debug("Closing SSH tunnel...")
     process.terminate()
@@ -296,9 +315,10 @@ if __name__ == "__main__":
             logger.error("podman-py not installed. Run: uv add podman")
             sys.exit(1)
 
-        process = open_ssh_tunnel(conn)
+        tunnel = open_ssh_tunnel(conn)
+        logger.info(f"Tunnel port: {tunnel.port}")
         try:
-            client = PodmanClient(base_url=PODMAN_TCP_URL)
+            client = PodmanClient(base_url=tunnel.url)
             ok = client.ping()
             if not ok:
                 logger.error("Ping failed — tunnel is up but Podman is not responding.")
@@ -310,4 +330,4 @@ if __name__ == "__main__":
             for img in images[:5]:
                 logger.info(f"  {img.tags}")
         finally:
-            close_ssh_tunnel(process)
+            close_ssh_tunnel(tunnel)

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -44,6 +44,7 @@ commit messages, and PR titles.
 | cap034 | Scaffold rewrite with @action/@orchestrator decorators            | feat | merged | feat/cap034-scaffold-decorators      | #76 | 2026-03-17 |
 | cap035 | Fix project root discovery to anchor on cutip.yaml               | bug  | merged | bug/cap035-project-root-discovery    | #79 | 2026-03-18 |
 | cap036 | cutip info command for version and workspace status              | feat | merged | feat/cap036-info-command             | #81 | 2026-03-18 |
+| cap037 | Dynamic SSH tunnel port for concurrent Podman workspaces        | bug  | open   | bug/cap037-dynamic-tunnel-port       | —   | 2026-03-18 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

**Root cause:** `open_ssh_tunnel()` hardcoded port 8080 for the SSH local port forward to the Podman VM socket. Running two `cutip run` commands simultaneously (e.g., `snf-gui` and `snf-blueprint-manager`) would fail because the second tunnel couldn't bind to the already-occupied port.

**Fix:** Replace hardcoded port with `_find_free_port()` which asks the OS for an available TCP port via `socket.bind(('localhost', 0))`. Each tunnel gets its own dynamic port. Introduced `TunnelInfo` dataclass to carry the process + port together.

## Changes

- `cutip/backends/podman/connection.py`: Add `TunnelInfo` dataclass, `_find_free_port()`, update `open_ssh_tunnel()` to return `TunnelInfo` with dynamic port, update `close_ssh_tunnel()` to accept both `TunnelInfo` and raw `Popen`
- `cutip/backends/podman/backend.py`: Use `TunnelInfo` instead of raw `Popen`, use `tunnel.url` instead of hardcoded `PODMAN_TCP_URL`
- `docs/capabilities.md`: Add cap037 row

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57 tests)
- [x] `_find_free_port()` returns valid port, `TunnelInfo.url` formats correctly
- [ ] Two concurrent `cutip run` with Podman backend no longer collide

🤖 Generated with [Claude Code](https://claude.com/claude-code)