### PR TITLE
[cap038] Add --no-cache flag to cutip run

### DIFF
--- a/cutip/backends/base.py
+++ b/cutip/backends/base.py
@@ -39,8 +39,12 @@ class CutipBackend(ABC):
         card: ImageCard,
         project_root: Path | None = None,
         vars: dict | None = None,
+        no_cache: bool = False,
     ) -> None:
         """Build an image from a local Dockerfile context."""
+
+    def remove_image(self, name: str) -> None:
+        """Remove an image by name/tag. No-op if not found."""
 
     # ── Network operations ────────────────────────────────────────────────────
 

--- a/cutip/backends/docker/backend.py
+++ b/cutip/backends/docker/backend.py
@@ -77,6 +77,7 @@ class DockerBackend(CutipBackend):
         card: ImageCard,
         project_root: Path | None = None,
         vars: dict | None = None,
+        no_cache: bool = False,
     ) -> None:
         context = Path(card.spec.context or "")
         if not context.is_absolute() and project_root:
@@ -92,6 +93,8 @@ class DockerBackend(CutipBackend):
             "--tag", tag,
             "--file", str(context / card.spec.dockerfile),
         ]
+        if no_cache:
+            cmd.append("--no-cache")
         for k, v in card.spec.build_args.items():
             cmd += ["--build-arg", f"{k}={v}"]
         cmd.append(str(build_ctx))
@@ -112,6 +115,13 @@ class DockerBackend(CutipBackend):
         rc = process.wait()
         if rc != 0:
             raise CutipError(f"Image build failed for '{tag}'")
+
+    def remove_image(self, name: str) -> None:
+        try:
+            self._client.images.remove(name, force=True)
+            logger.info(f"Removed image: {name}")
+        except Exception:
+            logger.debug(f"remove_image: '{name}' not found.")
 
     # ── Network / volume operations ───────────────────────────────────────────
 

--- a/cutip/backends/podman/backend.py
+++ b/cutip/backends/podman/backend.py
@@ -145,6 +145,7 @@ class PodmanBackend(CutipBackend):
         card: ImageCard,
         project_root: Path | None = None,
         vars: dict | None = None,
+        no_cache: bool = False,
     ) -> None:
         context = Path(card.spec.context or "")
         if not context.is_absolute() and project_root:
@@ -161,6 +162,8 @@ class PodmanBackend(CutipBackend):
             "--tag", tag,
             "--file", str(context / card.spec.dockerfile),
         ]
+        if no_cache:
+            cmd.append("--no-cache")
         for k, v in card.spec.build_args.items():
             cmd += ["--build-arg", f"{k}={v}"]
         cmd.append(str(build_ctx))
@@ -181,6 +184,13 @@ class PodmanBackend(CutipBackend):
         rc = process.wait()
         if rc != 0:
             raise CutipError(f"Image build failed for '{tag}'")
+
+    def remove_image(self, name: str) -> None:
+        try:
+            self._client.images.remove(name, force=True)
+            logger.info(f"Removed image: {name}")
+        except Exception:
+            logger.debug(f"remove_image: '{name}' not found.")
 
     # ── Network / volume operations ───────────────────────────────────────────
 

--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -425,8 +425,18 @@ def _prepare_volumes(ctx: CutipContext, client) -> None:
                 logger.debug(f"Created volume: {vol_name}")
 
 
+def _remove_group_images(ctx: CutipContext, backend) -> None:
+    """Remove all images for the group (used by --no-cache)."""
+    for card in ctx.resolved_cards.values():
+        if not isinstance(card, ImageCard):
+            continue
+        alias = image_alias(card)
+        backend.remove_image(alias)
+
+
 def _build_and_pull_images(
     ctx: CutipContext, backend, project_root: Path, paths: dict, secrets: dict,
+    no_cache: bool = False,
 ) -> None:
     """Build or pull every ImageCard resolved in the context."""
     # Merge paths + secrets for build-time interpolation ({{ paths.key }} / {{ secrets.key }})
@@ -436,7 +446,7 @@ def _build_and_pull_images(
             continue
         if card.spec.source == "build":
             logger.info(f"Building image: {card.metadata.name}")
-            backend.build_image(card, project_root=project_root, vars=merged)
+            backend.build_image(card, project_root=project_root, vars=merged, no_cache=no_cache)
         elif card.spec.source == "pull":
             logger.info(f"Pulling image: {card.metadata.name}")
             backend.pull_image(card)
@@ -565,6 +575,12 @@ def run(
         help="Container backend to use (docker or podman). "
              "Defaults to project.backend in cutip.yaml, then docker.",
     ),
+    no_cache: bool = typer.Option(
+        False,
+        "--no-cache",
+        help="Remove existing containers and images for the group, "
+             "then rebuild from scratch (no layer cache).",
+    ),
     local: bool = typer.Option(
         False,
         "--local",
@@ -661,8 +677,13 @@ def run(
             # Step 3: per-unit pre_build hooks (stage build-context files)
             _run_unit_pre_builds(ctx, registry, project_root)
 
+            # --no-cache: remove existing images before rebuilding
+            if no_cache:
+                logger.info("--no-cache: removing existing images for clean rebuild")
+                _remove_group_images(ctx, _backend)
+
             # Steps 4–6: images → networks → create containers (no auto-start)
-            _build_and_pull_images(ctx, _backend, project_root, project_paths, project_secrets)
+            _build_and_pull_images(ctx, _backend, project_root, project_paths, project_secrets, no_cache=no_cache)
             _ensure_networks(ctx, _backend)
             _provision_containers(ctx, _backend, project_paths, project_secrets)
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -44,7 +44,8 @@ commit messages, and PR titles.
 | cap034 | Scaffold rewrite with @action/@orchestrator decorators            | feat | merged | feat/cap034-scaffold-decorators      | #76 | 2026-03-17 |
 | cap035 | Fix project root discovery to anchor on cutip.yaml               | bug  | merged | bug/cap035-project-root-discovery    | #79 | 2026-03-18 |
 | cap036 | cutip info command for version and workspace status              | feat | merged | feat/cap036-info-command             | #81 | 2026-03-18 |
-| cap037 | Dynamic SSH tunnel port for concurrent Podman workspaces        | bug  | open   | bug/cap037-dynamic-tunnel-port       | —   | 2026-03-18 |
+| cap037 | Dynamic SSH tunnel port for concurrent Podman workspaces        | bug  | merged | bug/cap037-dynamic-tunnel-port       | #83 | 2026-03-18 |
+| cap038 | cutip run --no-cache for clean rebuild                          | feat | open   | feat/cap038-no-cache-fresh           | —   | 2026-03-19 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

- Adds `cutip run GROUP --no-cache` flag that removes existing images for the group and rebuilds with `--no-cache` (no layer cache)
- Containers are already recreated on each run; `--no-cache` extends this to images
- Adds `remove_image()` to both Docker and Podman backends
- `build_image()` now accepts `no_cache` parameter on both backends

## Changes

- `cutip/backends/base.py`: Add `no_cache` param to `build_image()`, add `remove_image()`
- `cutip/backends/docker/backend.py`: Implement `no_cache` and `remove_image()`
- `cutip/backends/podman/backend.py`: Implement `no_cache` and `remove_image()`
- `cutip/cli/commands/run.py`: Add `--no-cache` flag, `_remove_group_images()` helper
- `docs/capabilities.md`: Add cap038 row

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57 tests)
- [x] `cutip run --help` shows `--no-cache` flag
- [ ] `cutip run GROUP --no-cache` removes images and rebuilds from scratch

🤖 Generated with [Claude Code](https://claude.com/claude-code)