### PR TITLE
[cap039] Backend reconciliation prompt when project.backend is unset

### DIFF
--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -530,6 +530,66 @@ def _load_project_backend(project_root: Path) -> str | None:
     return None
 
 
+def _detect_available_backends() -> list[str]:
+    """Return list of installed backend names."""
+    available = []
+    for name, mod in [("docker", "docker"), ("podman", "podman")]:
+        try:
+            __import__(mod)
+            available.append(name)
+        except ImportError:
+            pass
+    return available
+
+
+def _resolve_backend_interactive(project_root: Path) -> str:
+    """Prompt user to select a backend when project.backend is not set in cutip.yaml.
+
+    In non-interactive mode (CI, pipes), falls back to docker silently.
+    """
+    if not sys.stdin.isatty():
+        return "docker"
+
+    available = _detect_available_backends()
+
+    if not available:
+        console.print(
+            "[yellow]No container backends installed.[/yellow]\n"
+            "  Install one: pip install docker  (or: pip install podman)"
+        )
+        raise typer.Exit(1)
+
+    if len(available) == 1:
+        choice = available[0]
+        console.print(
+            f"[yellow]cutip.yaml has no backend configured.[/yellow] "
+            f"Only [bold]{choice}[/bold] is installed."
+        )
+        save = typer.confirm(f"Use '{choice}' and save to cutip.yaml?", default=True)
+        if save:
+            _save_project_backend(project_root, choice)
+            console.print(f"[green]Saved backend '{choice}' to cutip.yaml[/green]")
+        return choice
+
+    # Multiple backends available — let user pick
+    console.print(
+        "[yellow]cutip.yaml has no backend configured.[/yellow]\n"
+        f"  Available backends: {', '.join(available)}"
+    )
+    choice = ""
+    while choice not in available:
+        choice = typer.prompt(
+            f"Select backend ({'/'.join(available)})",
+            default=available[0],
+        ).lower()
+
+    save = typer.confirm(f"Save '{choice}' as default in cutip.yaml?", default=True)
+    if save:
+        _save_project_backend(project_root, choice)
+        console.print(f"[green]Saved backend '{choice}' to cutip.yaml[/green]")
+    return choice
+
+
 def _save_project_backend(project_root: Path, backend_name: str) -> None:
     """Write ``project.backend`` to ``cutip.yaml``."""
     import yaml as _yaml
@@ -614,12 +674,15 @@ def run(
     # Honour env-var shortcut in addition to the CLI flag
     is_local = local or os.environ.get("CUTIP_LOCAL", "").lower() in ("1", "true", "yes")
 
-    # Resolve backend: -b / CUTIP_BACKEND → cutip.yaml → docker
-    backend_name = (
-        backend.lower() if backend
-        else _load_project_backend(project_root)
-        or "docker"
-    )
+    # Resolve backend: -b / CUTIP_BACKEND → cutip.yaml → prompt/detect
+    if backend:
+        backend_name = backend.lower()
+    else:
+        configured = _load_project_backend(project_root)
+        if configured:
+            backend_name = configured
+        else:
+            backend_name = _resolve_backend_interactive(project_root)
     logger.debug(f"Using backend: {backend_name}")
 
     # Connect backend

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -44,7 +44,8 @@ commit messages, and PR titles.
 | cap034 | Scaffold rewrite with @action/@orchestrator decorators            | feat | merged | feat/cap034-scaffold-decorators      | #76 | 2026-03-17 |
 | cap035 | Fix project root discovery to anchor on cutip.yaml               | bug  | merged | bug/cap035-project-root-discovery    | #79 | 2026-03-18 |
 | cap036 | cutip info command for version and workspace status              | feat | merged | feat/cap036-info-command             | #81 | 2026-03-18 |
-| cap037 | Dynamic SSH tunnel port for concurrent Podman workspaces        | bug  | open   | bug/cap037-dynamic-tunnel-port       | —   | 2026-03-18 |
+| cap037 | Dynamic SSH tunnel port for concurrent Podman workspaces        | bug  | merged | bug/cap037-dynamic-tunnel-port       | #83 | 2026-03-18 |
+| cap039 | Backend reconciliation prompt when project.backend is unset    | feat | open   | feat/cap039-backend-prompt           | —   | 2026-03-19 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary

- When `cutip.yaml` has no `project.backend` and no `-b` flag is given, prompt the user to select from installed backends
- Single backend installed → confirm and save; multiple → choose from list and save
- No backends installed → clear error with install instructions
- Non-interactive (CI/pipes) → falls back to docker silently
- Adds `_detect_available_backends()` and `_resolve_backend_interactive()` helpers

## Changes

- `cutip/cli/commands/run.py`: Replace silent docker fallback with interactive prompt
- `docs/capabilities.md`: Add cap039 row

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57 tests)
- [ ] `cutip run GROUP` without `project.backend` in cutip.yaml prompts for selection
- [ ] `-b docker` bypasses prompt
- [ ] `CUTIP_BACKEND=docker` bypasses prompt
- [ ] Piped input falls back silently to docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)