### PR TITLE
[cap041] Default bridge network when no networkRef or network_mode set

### DIFF
--- a/cutip/backends/base.py
+++ b/cutip/backends/base.py
@@ -52,10 +52,19 @@ class CutipBackend(ABC):
     def ensure_network(self, card: NetworkCard) -> None:
         """Create a network if it does not already exist."""
 
+    @abstractmethod
+    def ensure_default_network(self, name: str) -> None:
+        """Create a default bridge network by name if it does not exist."""
+
     # ── Container operations ──────────────────────────────────────────────────
 
     @abstractmethod
-    def create_container(self, card: ContainerCard, image_name: str | None = None) -> str:
+    def create_container(
+        self,
+        card: ContainerCard,
+        image_name: str | None = None,
+        default_network: str | None = None,
+    ) -> str:
         """Create (but do not start) a container. Returns the container name."""
 
     @abstractmethod

--- a/cutip/backends/docker/backend.py
+++ b/cutip/backends/docker/backend.py
@@ -144,12 +144,24 @@ class DockerBackend(CutipBackend):
         self._client.networks.create(name, driver=card.spec.driver, ipam=ipam_config)
         logger.info(f"Created network: {name}")
 
+    def ensure_default_network(self, name: str) -> None:
+        """Create a default bridge network by name if it does not exist."""
+        try:
+            self._client.networks.get(name)
+            logger.info(f"Default network already exists: {name}")
+            return
+        except Exception:
+            pass
+        self._client.networks.create(name, driver="bridge")
+        logger.info(f"Created default bridge network: {name}")
+
     # ── Container operations ──────────────────────────────────────────────────
 
     def create_container(
         self,
         card: ContainerCard,
         image_name: str | None = None,
+        default_network: str | None = None,
     ) -> str:
         """Create (but do not start) a container. Returns the container name."""
         name = card.metadata.name
@@ -178,6 +190,8 @@ class DockerBackend(CutipBackend):
             kwargs["network_mode"] = card.spec.network_mode
         elif card.spec.networkRef:
             kwargs["network"] = card.spec.networkRef.ref.split("/")[-1]
+        elif default_network:
+            kwargs["network"] = default_network
 
         if card.spec.command:
             kwargs["command"] = shlex.split(card.spec.command)

--- a/cutip/backends/podman/backend.py
+++ b/cutip/backends/podman/backend.py
@@ -212,12 +212,24 @@ class PodmanBackend(CutipBackend):
         self._client.networks.create(name, driver=card.spec.driver, ipam=ipam)
         logger.info(f"Created network: {name}")
 
+    def ensure_default_network(self, name: str) -> None:
+        """Create a default bridge network by name if it does not exist."""
+        try:
+            self._client.networks.get(name)
+            logger.info(f"Default network already exists: {name}")
+            return
+        except Exception:
+            pass
+        self._client.networks.create(name, driver="bridge")
+        logger.info(f"Created default bridge network: {name}")
+
     # ── Container operations ──────────────────────────────────────────────────
 
     def create_container(
         self,
         card: ContainerCard,
         image_name: str | None = None,
+        default_network: str | None = None,
     ) -> str:
         """Create (but do not start) a container. Returns the container name."""
         name = card.metadata.name
@@ -246,6 +258,8 @@ class PodmanBackend(CutipBackend):
             kwargs["network_mode"] = card.spec.network_mode
         elif card.spec.networkRef:
             kwargs["network"] = card.spec.networkRef.ref.split("/")[-1]
+        elif default_network:
+            kwargs["network"] = default_network
 
         if card.spec.command:
             kwargs["command"] = shlex.split(card.spec.command)

--- a/cutip/cli/commands/run.py
+++ b/cutip/cli/commands/run.py
@@ -452,15 +452,34 @@ def _build_and_pull_images(
             backend.pull_image(card)
 
 
-def _ensure_networks(ctx: CutipContext, backend) -> None:
-    """Create any NetworkCard-backed networks that do not already exist."""
+def _ensure_networks(ctx: CutipContext, backend, group_name: str) -> None:
+    """Create any NetworkCard-backed networks that do not already exist.
+
+    Also creates a default bridge network (``cutip-{group_name}``) when at
+    least one container has neither ``networkRef`` nor ``network_mode`` set.
+    Returns the default network name if one was created, else ``None``.
+    """
     for card in ctx.resolved_cards.values():
         if isinstance(card, NetworkCard):
             backend.ensure_network(card)
 
+    # Check if any container needs a default bridge network
+    needs_default = any(
+        isinstance(card, ContainerCard)
+        and card.spec.networkRef is None
+        and card.spec.network_mode is None
+        for card in ctx.resolved_cards.values()
+    )
+    if needs_default:
+        default_name = f"cutip-{group_name}"
+        backend.ensure_default_network(default_name)
+        return default_name
+    return None
+
 
 def _provision_containers(
     ctx: CutipContext, backend, paths: dict, secrets: dict,
+    default_network: str | None = None,
 ) -> None:
     """Remove stale containers and create fresh ones with refs resolved."""
     for card in ctx.resolved_cards.values():
@@ -484,7 +503,7 @@ def _provision_containers(
         img_card = ctx.resolved_cards.get(img_ref)
         img_name = image_alias(img_card) if isinstance(img_card, ImageCard) else None
 
-        backend.create_container(resolved_card, image_name=img_name)
+        backend.create_container(resolved_card, image_name=img_name, default_network=default_network)
 
 
 def _run_unit_pre_builds(
@@ -747,8 +766,8 @@ def run(
 
             # Steps 4–6: images → networks → create containers (no auto-start)
             _build_and_pull_images(ctx, _backend, project_root, project_paths, project_secrets, no_cache=no_cache)
-            _ensure_networks(ctx, _backend)
-            _provision_containers(ctx, _backend, project_paths, project_secrets)
+            default_net = _ensure_networks(ctx, _backend, group_name)
+            _provision_containers(ctx, _backend, project_paths, project_secrets, default_network=default_net)
 
             # Step 7: group-level workflow main() — starts containers, orchestrates
             workflow_loader = WorkflowLoader(project_root)

--- a/cutip/models/cards/container.py
+++ b/cutip/models/cards/container.py
@@ -39,8 +39,8 @@ class ContainerSpec(BaseModel):
     imageRef: Ref
 
     # -- Network ---------------------------------------------------------------
-    # Exactly one of networkRef (bridge to a named NetworkCard) or
-    # network_mode (e.g. "host", "none", "bridge", "slirp4netns") must be given.
+    # At most one of networkRef or network_mode may be given.
+    # If neither is set, CUTIP creates a default bridge network for the group.
     networkRef: Ref | None = None
     network_mode: str | None = None
 
@@ -74,15 +74,11 @@ class ContainerSpec(BaseModel):
 
     @model_validator(mode="after")
     def _validate_network(self) -> "ContainerSpec":
-        if self.networkRef is None and self.network_mode is None:
-            raise ValueError(
-                "Either 'networkRef' (bridge to a named NetworkCard) "
-                "or 'network_mode' (e.g. 'bridge', 'host') must be provided"
-            )
         if self.networkRef is not None and self.network_mode is not None:
             raise ValueError(
                 "Only one of 'networkRef' or 'network_mode' may be provided, not both"
             )
+        # Neither set → CUTIP will create a default bridge at run time
         return self
 
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -48,6 +48,7 @@ commit messages, and PR titles.
 | cap038 | cutip run --no-cache for clean rebuild                          | feat | merged | feat/cap038-no-cache-fresh           | #84 | 2026-03-19 |
 | cap039 | Backend reconciliation prompt when project.backend is unset    | feat | merged | feat/cap039-backend-prompt           | #85 | 2026-03-19 |
 | cap040 | Timestamped log files with retention                            | feat | open   | feat/cap040-timestamped-logs          | —   | 2026-03-19 |
+| cap041 | Default bridge network when no networkRef or network_mode set  | feat | open   | feat/cap041-default-bridge-network    | —   | 2026-03-19 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary
- Containers with neither `networkRef` nor `network_mode` now automatically receive a default bridge network (`cutip-{group_name}`) at runtime
- Added `ensure_default_network(name)` to both Docker and Podman backends
- `_ensure_networks()` in run.py detects containers needing a default bridge and passes the network name through to `_provision_containers()`

## Test plan
- [x] All 57 unit tests pass
- [ ] CI passes on PR
- [ ] Manual: `cutip run` with a container that has no networkRef/network_mode — verify `cutip-{group}` network is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)