### PR TITLE
[cap042] Build-time network mode for image builds

### DIFF
--- a/cutip/backends/docker/backend.py
+++ b/cutip/backends/docker/backend.py
@@ -95,6 +95,8 @@ class DockerBackend(CutipBackend):
         ]
         if no_cache:
             cmd.append("--no-cache")
+        if card.spec.network_mode:
+            cmd += ["--network", card.spec.network_mode]
         for k, v in card.spec.build_args.items():
             cmd += ["--build-arg", f"{k}={v}"]
         cmd.append(str(build_ctx))

--- a/cutip/backends/podman/backend.py
+++ b/cutip/backends/podman/backend.py
@@ -164,6 +164,8 @@ class PodmanBackend(CutipBackend):
         ]
         if no_cache:
             cmd.append("--no-cache")
+        if card.spec.network_mode:
+            cmd += ["--network", card.spec.network_mode]
         for k, v in card.spec.build_args.items():
             cmd += ["--build-arg", f"{k}={v}"]
         cmd.append(str(build_ctx))

--- a/cutip/models/cards/image.py
+++ b/cutip/models/cards/image.py
@@ -69,6 +69,11 @@ class ImageSpec(BaseModel):
     # Defaults to "{context}/buildtime" if not set.
     buildtime_dir: str | None = None
 
+    # Network mode for the build (e.g. "host", "none", "default").
+    # Maps to --network flag on docker/podman build.
+    # If not set, the builder's default network is used.
+    network_mode: str | None = None
+
     @model_validator(mode="after")
     def _validate_source_fields(self) -> "ImageSpec":
         if self.source == "pull":

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -49,6 +49,7 @@ commit messages, and PR titles.
 | cap039 | Backend reconciliation prompt when project.backend is unset    | feat | merged | feat/cap039-backend-prompt           | #85 | 2026-03-19 |
 | cap040 | Timestamped log files with retention                            | feat | merged | feat/cap040-timestamped-logs          | #86 | 2026-03-19 |
 | cap041 | Default bridge network when no networkRef or network_mode set  | feat | merged | feat/cap041-default-bridge-network    | #87 | 2026-03-19 |
+| cap042 | Build-time network mode for image builds                       | feat | open   | feat/cap042-build-network-mode        | —   | 2026-03-19 |
 
 ## ID Assignment
 


### PR DESCRIPTION
## Summary
- Added optional `network_mode` field to `ImageSpec` (maps to `--network` on docker/podman build)
- Both Docker and Podman backends pass `--network <mode>` during builds when set
- Enables builds that need host network access (e.g. local package registries, DNS resolution)

## Test plan
- [x] All unit tests pass locally
- [ ] CI passes on PR
- [ ] Manual: set `network_mode: "host"` on an ImageCard and verify `--network host` is passed to build

🤖 Generated with [Claude Code](https://claude.com/claude-code)