### PR TITLE
[cap043] feat: document semantic versioning convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,16 @@ The only valid stopping points before completion are:
 - A required manual action (GitHub web UI, auth) — report exactly what the user must do, then continue everything else
 - The user explicitly asks you to stop
 
+## Versioning Convention
+
+CUTIP follows [Semantic Versioning](https://semver.org/):
+
+- **x** (major) — breaking changes to the artifact schema, lifecycle model, or public API
+- **y** (minor) — new features, new CLI commands, new optional YAML fields
+- **z** (patch) — bug fixes, CI improvements, documentation, formatting, tooling
+
+Non-breaking changes ship as `0.1.z` patches. Breaking changes accumulate and ship together as the next minor or major bump (e.g. `0.2.0`).
+
 ## Key Conventions
 
 - **Never auto-commit.** Only commit when explicitly asked.


### PR DESCRIPTION
## Summary

- Document semantic versioning convention (x=major, y=minor, z=patch) in CLAUDE.md
- Clarifies release strategy: non-breaking changes as 0.1.z patches, breaking changes as minor/major bumps

## Changes

- `CLAUDE.md`: Add "Versioning Convention" section before "Key Conventions"

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes
- [x] Documentation-only change — no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
