### PR TITLE
[cap045] Add MkDocs dark theme and design tokens

### DIFF
--- a/docs/reference/themes.md
+++ b/docs/reference/themes.md
@@ -1,0 +1,61 @@
+# Design Tokens
+
+CUTIP's documentation site uses a custom color palette built on
+[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
+The same tokens are intended for reuse by cutip-desktop and any future
+CUTIP-branded UI.
+
+## Color Palette
+
+### Dark (default)
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| Background | `#1f1f1f` | Page body (`--md-default-bg-color`) |
+| Sidebar / Header | `#181818` | Side navigation, top bar, code blocks |
+| Accent | `#0078d4` | Links, active nav items, buttons |
+| Text | `#cccccc` | Body text (`--md-default-fg-color`) |
+| Footer | `#181818` | Footer background |
+| Footer (dark) | `#141414` | Footer bottom strip |
+
+### Light
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| Accent | `#0078d4` | Links, active nav items, buttons |
+| Header | `#005a9e` | Top bar background (accent-dark) |
+
+## CSS Variables
+
+All tokens live in `docs/stylesheets/cutip.css` and are scoped to the
+Material theme's `data-md-color-scheme` attribute:
+
+```css
+/* Dark */
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: #1f1f1f;
+  --md-default-fg-color: #cccccc;
+  --md-primary-fg-color: #0078d4;
+  --md-accent-fg-color: #0078d4;
+  --md-code-bg-color: #181818;
+}
+
+/* Light */
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #0078d4;
+  --md-accent-fg-color: #0078d4;
+}
+```
+
+## Reuse in cutip-desktop
+
+Desktop or any downstream project should read these tokens from
+`docs/stylesheets/cutip.css` as the single source of truth. The CSS
+variable names follow Material for MkDocs conventions, but the hex
+values are portable to any framework (Qt, Electron, GTK).
+
+## Toggling Themes
+
+The site ships dark by default. Users toggle between dark and light
+with the sun/moon icon in the header. The first palette entry in
+`mkdocs.yml` is the default.

--- a/docs/stylesheets/cutip.css
+++ b/docs/stylesheets/cutip.css
@@ -1,0 +1,32 @@
+/* CUTIP design tokens — dark and light palettes */
+
+/* Dark theme (slate scheme) */
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: #1f1f1f;
+  --md-default-fg-color: #cccccc;
+  --md-primary-fg-color: #0078d4;
+  --md-accent-fg-color: #0078d4;
+  --md-typeset-a-color: #0078d4;
+  --md-code-bg-color: #181818;
+  --md-footer-bg-color: #181818;
+  --md-footer-bg-color--dark: #141414;
+}
+
+[data-md-color-scheme="slate"] .md-sidebar {
+  background: #181818;
+}
+
+[data-md-color-scheme="slate"] .md-header {
+  background: #181818;
+}
+
+/* Light theme (default scheme) */
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #0078d4;
+  --md-accent-fg-color: #0078d4;
+  --md-typeset-a-color: #0078d4;
+}
+
+[data-md-color-scheme="default"] .md-header {
+  background: #005a9e;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,21 +9,24 @@ edit_uri: edit/integration/docs/
 
 docs_dir: docs
 
+extra_css:
+  - stylesheets/cutip.css
+
 theme:
   name: material
   palette:
-    - scheme: default
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-7
-        name: Dark mode
     - scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Light mode
+    - scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Dark mode
   features:
     - navigation.tabs           # top sections render as header tabs
     - navigation.sections       # subsections shown as groups in the sidebar
@@ -91,6 +94,7 @@ nav:
     - CLI: reference/cli.md
     - Workflow Contract: reference/workflow-contract.md
     - Exceptions: reference/exceptions.md
+    - Design Tokens: reference/themes.md
     - Cards:
       - ImageCard: reference/cards/image-card.md
       - ContainerCard: reference/cards/container-card.md


### PR DESCRIPTION
## Summary

- Adds dark theme as the default MkDocs palette with custom CSS variables for both dark and light modes
- Creates `docs/reference/themes.md` documenting all design tokens (reusable by cutip-desktop)
- Updates `mkdocs.yml` with slate scheme, extra_css, and nav entry

## Changes

- `docs/stylesheets/cutip.css`: new CSS custom properties for dark/light themes (bg, sidebar, accent, text colors)
- `mkdocs.yml`: dark palette as default, extra_css reference, themes.md in nav
- `docs/reference/themes.md`: design token documentation

## Test plan

- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes
- [ ] `mkdocs build` succeeds (CI docs build check)
- [ ] Dark theme renders correctly with custom accent colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
