### PR TITLE
[cap047] Rewrite documentation with lifecycle and annotations

### DIFF
--- a/docs/architecture/design-decisions.md
+++ b/docs/architecture/design-decisions.md
@@ -28,7 +28,7 @@ Several container orchestration tools (Pulumi, CDK for Terraform) use a Python D
 
 ---
 
-## Why `main(ctx)` instead of a class or decorator
+## Why `main(ctx)` with optional decorators
 
 A simple function contract is harder to break than a framework interface. It has one entry point, one argument, and returns nothing. This makes workflows trivially testable:
 
@@ -44,6 +44,8 @@ ctx.runtime.create_container.assert_called_once()
 ```
 
 Compare this to a base class that requires `super().__init__()`, registering methods, or implementing abstract properties.
+
+The `@action` and `@orchestrator` decorators layer metadata on top of this contract without changing it. A decorated function executes identically to an undecorated one --- the decorators exist purely for introspection, planning output, and tooling. This means you can adopt them incrementally: start with a plain `main(ctx)`, add `@action` when your workflow grows complex enough to benefit from named steps.
 
 ---
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -52,6 +52,7 @@ commit messages, and PR titles.
 | cap042 | Build-time network mode for image builds                       | feat | merged | feat/cap042-build-network-mode        | #89 | 2026-03-19 |
 | cap043 | Semantic versioning convention                                 | feat | merged | feat/cap043-semver-convention          | #92 | 2026-03-21 |
 | cap044 | ruff linter/formatter + ty type checker                        | feat | merged | feat/cap044-ruff-ty                   | #91 | 2026-03-21 |
+| cap047 | Documentation rewrite: lifecycle, annotations, compile         | docs | open   | docs/cap047-docs-rewrite              | —   | 2026-03-21 |
 
 ## ID Assignment
 

--- a/docs/concepts/annotations.md
+++ b/docs/concepts/annotations.md
@@ -1,0 +1,166 @@
+# Concepts: Annotations
+
+CUTIP provides two workflow decorators --- `@action` and `@orchestrator` --- that add structured metadata to workflow functions. These decorators are optional: a plain `def main(ctx)` works without them. They exist for introspection, planning, and tooling.
+
+---
+
+## `@action`
+
+Marks a function as a discrete, named step in the workflow. Each action represents one logical operation (start a container, run a health check, seed a database).
+
+```python
+from cutip.workflow.decorators import action
+
+@action(
+    name="Start DB",
+    description="Start postgres and wait for readiness",
+    container="cutip-db",
+    depends_on=["pull_images"],
+)
+def start_db(ctx):
+    ctx.container("cutip-db").start()
+    # ... health check loop
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | `str` | yes | Human-readable name for this action (used in plan output and introspection) |
+| `description` | `str` | no | Longer description of what this action does |
+| `container` | `str` | no | Container name this action operates on (hint for tooling) |
+| `depends_on` | `list[str]` | no | List of action function names that must run before this one |
+
+### What `@action` does at runtime
+
+Nothing. The decorator attaches an `ActionMeta` dataclass to the function and returns a transparent wrapper. The function executes identically whether decorated or not. The metadata is available for introspection:
+
+```python
+from cutip.workflow.decorators import _ACTION_ATTR
+
+meta = getattr(start_db, _ACTION_ATTR)
+# ActionMeta(name="Start DB", description="...", container="cutip-db", depends_on=["pull_images"])
+```
+
+---
+
+## `@orchestrator`
+
+Marks the workflow entry point. This is the function CUTIP calls to run the workflow.
+
+```python
+from cutip.workflow.decorators import orchestrator
+
+@orchestrator
+def main(ctx):
+    start_db(ctx)
+    start_web(ctx)
+```
+
+`@orchestrator` takes no parameters. It marks the function so that introspection tools can identify the entry point without relying on the function being named `main`.
+
+If no `@orchestrator` is present, CUTIP falls back to calling `main(ctx)` by name --- the decorator is not required for execution.
+
+---
+
+## Introspection
+
+CUTIP includes an AST-based introspection module (`cutip.workflow.introspect`) that can extract action metadata and execution order from a workflow file without importing it.
+
+### `get_module_actions(module)`
+
+Returns all `@action`-decorated functions from an imported module:
+
+```python
+from cutip.workflow.introspect import get_module_actions
+
+actions = get_module_actions(workflow_module)
+# {"start_db": ActionMeta(...), "start_web": ActionMeta(...)}
+```
+
+### `get_orchestrator(module)`
+
+Returns the `@orchestrator`-decorated function, or `None`:
+
+```python
+from cutip.workflow.introspect import get_orchestrator
+
+orch = get_orchestrator(workflow_module)
+```
+
+### `extract_action_order(workflow_path)`
+
+Parses the workflow file with Python's `ast` module and returns actions in the order they are called inside the orchestrator body:
+
+```python
+from cutip.workflow.introspect import extract_action_order
+
+order = extract_action_order(Path("cutip/groups/dev/workflow.py"))
+# [ActionMeta(name="Start DB", ...), ActionMeta(name="Start Web", ...)]
+```
+
+This works without importing the module --- it analyzes the source code statically. The introspection walks if/else branches, for/while loops, and try blocks to find all action calls.
+
+---
+
+## When to use decorators
+
+**Use `@action` when:**
+
+- You want `cutip plan` to show named steps with descriptions
+- You are building a multi-step workflow and want the execution graph to be self-documenting
+- You want tooling to understand which container each function operates on
+
+**Use `@orchestrator` when:**
+
+- Your entry point is not named `main`
+- You want introspection to identify the entry point without naming conventions
+
+**Skip decorators when:**
+
+- You have a simple single-container workflow
+- You prefer minimal boilerplate
+- The workflow is straightforward enough that the code is its own documentation
+
+---
+
+## Example: annotated workflow
+
+```python
+from cutip.workflow.decorators import action, orchestrator
+
+@action(name="Pull images", description="Pull all container images")
+def pull_images(ctx):
+    for card in ctx.resolved_cards.values():
+        if hasattr(card, "spec") and hasattr(card.spec, "source"):
+            ctx.runtime.pull_image(card)
+
+@action(
+    name="Start DB",
+    description="Start postgres and wait for readiness",
+    container="cutip-db",
+    depends_on=["pull_images"],
+)
+def start_db(ctx):
+    ctx.container("cutip-db").start()
+    # health check ...
+
+@action(
+    name="Start Web",
+    description="Start the web application",
+    container="cutip-web",
+    depends_on=["start_db"],
+)
+def start_web(ctx):
+    ctx.container("cutip-web").start()
+
+@orchestrator
+def main(ctx):
+    if ctx.runtime is None:
+        return  # plan-safe
+    pull_images(ctx)
+    start_db(ctx)
+    start_web(ctx)
+```
+
+This workflow is functionally identical to one without decorators. The difference is that `cutip plan` and introspection tools can extract the step names, descriptions, container hints, and dependency graph without executing the code.

--- a/docs/concepts/groups.md
+++ b/docs/concepts/groups.md
@@ -57,14 +57,16 @@ cutip run staging
 
 ## The workflow contract
 
-The attached `workflow.py` must export a single function:
+The attached `workflow.py` must export an entry point function:
 
 ```python
 def main(ctx: CutipContext) -> None:
     ...
 ```
 
-CUTIP dynamically imports the file, calls `main(ctx)`, and propagates any exception as a `CutipWorkflowError`.
+CUTIP dynamically imports the file, calls `main(ctx)`, and propagates any exception as a `CutipWorkflowError`. Workflows can use `@action` and `@orchestrator` decorators for self-describing steps --- see [Annotations](annotations.md).
+
+The workflow runs as Phase 2 of the unit lifecycle (pre-build -> orchestration -> post-start). See [Lifecycle](lifecycle.md) for the full execution model.
 
 Full reference: [Workflow Contract](../reference/workflow-contract.md)
 

--- a/docs/concepts/lifecycle.md
+++ b/docs/concepts/lifecycle.md
@@ -1,0 +1,142 @@
+# Concepts: Unit Lifecycle
+
+Every unit in a CUTIP group follows a three-phase lifecycle. Understanding this lifecycle is key to writing workflows that are predictable, debuggable, and safe to re-run.
+
+---
+
+## The three phases
+
+```
+pre_build(ctx)  ──▶  workflow main(ctx)  ──▶  startup(ctx)
+    │                      │                      │
+    │                      │                      │
+ Generate files         Start containers       Post-start
+ Stage build context    Order by behavior       verification
+ Write configs          Health-check loops      Smoke tests
+```
+
+| Phase | Hook | When it runs | Typical use |
+|---|---|---|---|
+| **Pre-build** | `pre_build(ctx)` in `startup.py` | Before image builds, per unit | Generate config files, stage buildtime resources, write secrets into build context |
+| **Orchestration** | `main(ctx)` in `workflow.py` | After all images are built and networks ensured | Start containers in order, run health checks, branch on container state |
+| **Post-start** | `startup(ctx)` in `startup.py` | After `workflow.main()` completes, per unit | Verify services are running, print connection instructions, run smoke tests |
+
+---
+
+## Phase 1: Pre-build
+
+Each unit may define a `pre_build(ctx)` function in its `startup.py`. CUTIP calls this function before building the unit's image.
+
+```python
+# cutip/units/web/startup.py
+
+def pre_build(ctx):
+    """Generate config.yaml into the build context."""
+    import yaml
+
+    config = {
+        "database": {"host": "cutip-db", "port": 5432},
+        "app": {"debug": False, "port": 8080},
+    }
+
+    config_path = ctx.project_root / "resources" / "buildtime" / "config.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.dump(config))
+```
+
+**Why this matters:** In compose, you either commit generated files to the repo, write a Makefile target, or pass everything as environment variables. `pre_build` makes file generation an explicit, auditable step in the container lifecycle.
+
+---
+
+## Phase 2: Orchestration
+
+The `workflow.py` attached to a group is the orchestration layer. CUTIP calls `main(ctx)` after all pre-build hooks have run and images are built.
+
+The orchestrator has full control over container start order. There is no `depends_on` declaration --- ordering is imperative Python:
+
+```python
+# cutip/groups/complex/workflow.py
+from cutip.workflow.decorators import action, orchestrator
+
+@action(name="Start DB", container="cutip-db")
+def start_db(ctx):
+    ctx.container("cutip-db").start()
+
+    import time
+    for attempt in range(1, 31):
+        exit_code, _ = ctx.container("cutip-db").exec_run(
+            ["psql", "-U", "appuser", "-d", "appdb", "-c", "SELECT 1"],
+            environment={"PGPASSWORD": ctx.secrets["db_password"]},
+        )
+        if exit_code == 0:
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError("Postgres did not become ready")
+
+@action(name="Start Web", container="cutip-web", depends_on=["start_db"])
+def start_web(ctx):
+    ctx.container("cutip-web").start()
+
+@orchestrator
+def main(ctx):
+    start_db(ctx)
+    start_web(ctx)
+```
+
+The `@action` and `@orchestrator` decorators are optional --- a plain `def main(ctx)` works identically. The decorators add metadata that CUTIP uses for introspection (see [Annotations](annotations.md)).
+
+---
+
+## Phase 3: Post-start
+
+After `workflow.main()` returns, CUTIP calls `startup(ctx)` in each unit's `startup.py`. This is the place for verification and smoke tests:
+
+```python
+# cutip/units/web/startup.py
+
+def startup(ctx):
+    """Verify the web app is serving."""
+    exit_code, output = ctx.container("cutip-web").exec_run(
+        ["curl", "-sf", "http://localhost:8080/health"]
+    )
+    if exit_code == 0:
+        logger.success("Web app is serving at http://localhost:8080")
+    else:
+        logger.warning(f"Health endpoint returned non-zero: {exit_code}")
+```
+
+**Why this matters:** Post-start hooks run after the full orchestration sequence is complete. They confirm the deployment is healthy, not just that containers started. This is the difference between "the process is running" and "the service is reachable."
+
+---
+
+## Full lifecycle sequence
+
+For a group with two units (`db` and `web`), the complete execution order is:
+
+```
+1. Load paths.yaml + secrets.yaml
+2. Validate all {{ paths.X }} / {{ secrets.X }} refs
+3. Create generated directories
+4. Create host dirs + named volumes
+5. pre_build(ctx) for each unit        ← Phase 1
+6. Build/pull images
+7. Ensure networks
+8. Create containers
+9. workflow.main(ctx)                   ← Phase 2
+10. startup(ctx) for each unit          ← Phase 3
+```
+
+Steps 1--8 are handled by CUTIP's runtime. Steps 5, 9, and 10 are your code.
+
+---
+
+## Lifecycle and `cutip plan`
+
+`cutip plan` runs steps 1--4 (validation and directory setup) and prints what steps 5--10 would do. No containers are created, no images are built, no hooks are called. This makes `cutip plan` safe to run anywhere --- no runtime required.
+
+---
+
+## Idempotency
+
+CUTIP removes stale containers before recreating them on each `cutip run`. The lifecycle is designed to be re-runnable: `pre_build` regenerates files, `main` starts fresh containers, `startup` re-verifies. There is no hidden state between runs.

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -2,14 +2,15 @@
 
 ## Why CUTIP exists
 
-Most container tooling conflates *definition* and *execution*. A `docker-compose.yml` is both a schema and a runtime instruction — there's no clean separation between "what the container looks like" and "what to do with it."
+Most container tooling conflates *definition* and *execution*. A `docker-compose.yml` is both a schema and a runtime instruction --- there is no clean separation between "what the container looks like" and "what to do with it."
 
-CUTIP separates these concerns explicitly:
+CUTIP is an automation tool that separates these concerns explicitly:
 
-- **Cards** — immutable, validated definitions of container resources
-- **Workflow** — arbitrary Python that operates on those definitions at runtime
+- **Cards** --- immutable, validated definitions of container resources
+- **Workflow** --- Python that operates on those definitions at runtime, with optional `@action`/`@orchestrator` annotations for self-describing steps
+- **Lifecycle** --- a three-phase execution model (pre-build, orchestration, post-start) that gives you control over every stage
 
-This means you can validate your entire container graph statically (no daemon, no network) and only contact a runtime when you've verified the graph is correct.
+This means you can validate your entire container graph statically (no daemon, no network) and only contact a runtime when you have verified the graph is correct.
 
 ---
 
@@ -44,9 +45,11 @@ A **Group** collects one or more Units and attaches a Python `workflow.py`. A gr
 
 ### Layer 4: Workflow (Python orchestration)
 
-The workflow is a plain Python file with a single function: `main(ctx: CutipContext)`. CUTIP injects a `CutipContext` that gives the workflow access to all resolved cards, units, the backend handle, and the project root. There is no DSL — just Python.
+The workflow is a Python file with an entry point function: `main(ctx: CutipContext)`. CUTIP injects a `CutipContext` that gives the workflow access to all resolved cards, units, the backend handle, and the project root. There is no DSL --- just Python.
 
-→ [reference/workflow-contract.md](../reference/workflow-contract.md)
+Workflows can optionally use `@action` and `@orchestrator` decorators to make steps self-describing. See [Annotations](annotations.md) for details.
+
+-> [reference/workflow-contract.md](../reference/workflow-contract.md)
 
 ---
 
@@ -60,6 +63,14 @@ Every `cutip run` begins with a full graph validation pass:
 4. **Only then** — the backend is connected and the workflow runs
 
 → [concepts/graph-resolution.md](graph-resolution.md)
+
+---
+
+## Unit lifecycle
+
+Each unit follows a three-phase lifecycle: **pre-build** (generate files and stage build context), **orchestration** (start containers and run health checks), and **post-start** (verify the deployment is healthy). This lifecycle is the core of CUTIP's automation model.
+
+-> [concepts/lifecycle.md](lifecycle.md)
 
 ---
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -167,7 +167,9 @@ Plan for group: dev
 
 ## Next steps
 
-- [Workspace layout](workspace-layout.md) — understand the full directory structure
-- [Concepts: Cards](../concepts/cards.md) — the full card type system
-- [Reference: CLI](../reference/cli.md) — all commands and flags
-- [Guides: Writing workflows](../guides/workflows/writing-workflows.md) — patterns and best practices
+- [Workspace layout](workspace-layout.md) --- understand the full directory structure
+- [Concepts: Cards](../concepts/cards.md) --- the full card type system
+- [Concepts: Lifecycle](../concepts/lifecycle.md) --- the three-phase unit lifecycle (pre-build, orchestration, post-start)
+- [Concepts: Annotations](../concepts/annotations.md) --- `@action` and `@orchestrator` decorators
+- [Reference: CLI](../reference/cli.md) --- all commands and flags
+- [Guides: Writing workflows](../guides/workflows/writing-workflows.md) --- patterns and best practices

--- a/docs/getting-started/why-cutip.md
+++ b/docs/getting-started/why-cutip.md
@@ -1,6 +1,8 @@
 # Why CUTIP?
 
-This page is an honest comparison. If `docker-compose` does what you need, use it — it is simpler, widely understood, and has first-class IDE tooling. CUTIP solves a different class of problems.
+CUTIP is an automation tool for containerized workflows. It handles the full lifecycle --- from generating config files before an image build, through ordering container startups by actual readiness, to verifying services after deployment.
+
+This page is an honest comparison. If `docker-compose` does what you need, use it --- it is simpler, widely understood, and has first-class IDE tooling. CUTIP solves a different class of problems.
 
 ---
 

--- a/docs/guides/workflows/writing-workflows.md
+++ b/docs/guides/workflows/writing-workflows.md
@@ -1,6 +1,6 @@
 # Guide: Writing Workflows
 
-A CUTIP workflow is a plain Python file with a single function. There is no DSL, no base class, no decorator — just:
+A CUTIP workflow is a Python file with a single entry point. There is no DSL, no base class --- just:
 
 ```python
 def main(ctx):
@@ -8,6 +8,8 @@ def main(ctx):
 ```
 
 CUTIP injects a fully-populated `CutipContext` and calls your function. What happens next is entirely up to you.
+
+For larger workflows, you can use `@action` and `@orchestrator` decorators to make steps self-describing --- see [Annotations](../../concepts/annotations.md). For the lifecycle context (pre-build, orchestration, post-start), see [Lifecycle](../../concepts/lifecycle.md).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@
 [![uv](https://img.shields.io/badge/uv-package_manager-6e44ff)](https://github.com/astral-sh/uv)
 [![Runtime](https://img.shields.io/badge/runtime-podman%20%7C%20docker-892ca0)](getting-started/installation.md)
 
-**Container Unit Templates in Python** — a deterministic framework for defining, validating, and orchestrating container environments using structured YAML artifacts and Python workflows.
+**Container Unit Templates in Python** — an automation tool for defining, validating, and orchestrating containerized workflows using structured YAML artifacts and Python.
 
-CUTIP is not a wrapper around `docker-compose`. It is an opinionated engineering layer: every container resource is a versioned, validated artifact; every deployment is a reproducible Python function.
+CUTIP is not a wrapper around `docker-compose`. It is an opinionated automation layer: every container resource is a versioned, validated artifact; every deployment is a reproducible Python function. You define the structure in YAML, write the orchestration in Python, and CUTIP handles the lifecycle --- from pre-build file generation through container startup to post-deployment verification.
 
 ---
 
@@ -25,7 +25,7 @@ NetworkCard ─┘──▶  ContainerCard  ──▶  Unit  ──▶  Group  �
 | **Card** | One atomic container resource (image, network, or container configuration) |
 | **Unit** | One running container instance — a ContainerCard reference |
 | **Group** | A collection of Units + a Python `workflow.py` — the executable artifact |
-| **Workflow** | A plain Python function `main(ctx: CutipContext)` — full control, no magic |
+| **Workflow** | A Python function `main(ctx: CutipContext)` with optional `@action`/`@orchestrator` annotations --- full control, no magic |
 
 Every artifact is a versioned YAML file. Every ref is validated before any backend is contacted.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -220,6 +220,46 @@ Connects directly to the local Podman socket. Socket URL is resolved in priority
 
 ---
 
+## `cutip stop`
+
+Gracefully stop all containers in a group.
+
+```shell
+cutip stop <group> [--backend BACKEND] [--local] [--path PATH]
+```
+
+Stops all containers belonging to the group. Containers are stopped in reverse unit order.
+
+---
+
+## `cutip info`
+
+Display version, workspace status, and backend configuration.
+
+```shell
+cutip info [--path PATH]
+```
+
+---
+
+## `cutip from-compose`
+
+Convert an existing `docker-compose.yaml` into a full CUTIP workspace.
+
+```shell
+cutip from-compose <compose-file> [--output-dir DIR]
+```
+
+Generates ImageCards, ContainerCards, NetworkCards, Units, a Group, and a workflow stub. Sensitive environment variables are automatically extracted as `{{ secrets.<key> }}` references.
+
+---
+
+## `cutip compile` (Planned)
+
+Produce a visual representation of the artifact graph. See [Compile Reference](compile.md).
+
+---
+
 ## Global options
 
 | Option | Description |

--- a/docs/reference/compile.md
+++ b/docs/reference/compile.md
@@ -1,0 +1,129 @@
+# Reference: `cutip compile` (Planned)
+
+> [!NOTE]
+> `cutip compile` is a planned feature. This page documents the intended design and output format. The command is not yet available in the current release.
+
+---
+
+## Purpose
+
+`cutip compile` will analyze a workspace and produce a visual representation of the artifact graph as a Mermaid diagram. This gives teams a single command to generate up-to-date architecture diagrams from their YAML artifacts --- no manual diagramming, no stale documentation.
+
+---
+
+## Planned usage
+
+```shell
+cutip compile [--format mermaid|json] [--output FILE] [--path PATH]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--format / -f` | `mermaid` | Output format: `mermaid` for Mermaid markup, `json` for machine-readable graph |
+| `--output / -o` | stdout | Write output to a file instead of stdout |
+| `--path / -p` | git root / cwd | Override project root |
+
+---
+
+## Planned output: Mermaid
+
+For a workspace with a `complex` group containing `db` and `web` units:
+
+```shell
+cutip compile
+```
+
+Expected output:
+
+```mermaid
+graph LR
+    subgraph Group: complex
+        direction TB
+        subgraph Unit: db
+            IC_db[ImageCard: db<br/>postgres:16]
+            CC_db[ContainerCard: cutip-db]
+            IC_db --> CC_db
+        end
+        subgraph Unit: web
+            IC_web[ImageCard: web<br/>source: build]
+            CC_web[ContainerCard: cutip-web]
+            IC_web --> CC_web
+        end
+        NC_appnet[NetworkCard: app-net<br/>172.20.0.0/24]
+        CC_db --> NC_appnet
+        CC_web --> NC_appnet
+    end
+    WF[workflow.py] --> CC_db
+    WF --> CC_web
+```
+
+This Mermaid output can be:
+
+- Pasted directly into GitHub Markdown (rendered natively)
+- Included in MkDocs documentation (with the `pymdownx.superfences` Mermaid integration)
+- Rendered locally with the [Mermaid CLI](https://github.com/mermaid-js/mermaid-cli)
+
+---
+
+## Planned output: JSON
+
+```shell
+cutip compile --format json
+```
+
+Expected output:
+
+```json
+{
+  "groups": [
+    {
+      "name": "complex",
+      "workflow": "cutip/groups/complex/workflow.py",
+      "units": [
+        {
+          "name": "db",
+          "container_card": "containers/cutip-db",
+          "image_card": "images/db",
+          "network_card": "networks/app-net"
+        },
+        {
+          "name": "web",
+          "container_card": "containers/cutip-web",
+          "image_card": "images/web",
+          "network_card": "networks/app-net"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The JSON format is intended for consumption by CI pipelines, custom visualization tools, or any system that needs a machine-readable view of the workspace graph.
+
+---
+
+## Relationship to `cutip validate` and `cutip plan`
+
+| Command | Purpose | Backend required |
+|---|---|---|
+| `cutip validate` | Check graph integrity (refs, schema, workflow files) | No |
+| `cutip plan` | Show execution steps as a table | No |
+| `cutip compile` | Produce a visual graph of the artifact relationships | No |
+
+All three commands operate on the static artifact graph. None contact a container runtime. `compile` differs from `plan` in that it shows the structural relationships between artifacts (which card references which), while `plan` shows the runtime execution sequence (which operations will run in what order).
+
+---
+
+## Action graph integration
+
+When workflows use `@action` and `@orchestrator` decorators, `cutip compile` will include the action execution graph alongside the artifact graph:
+
+```mermaid
+graph TD
+    subgraph Actions
+        A1[Pull images] --> A2[Start DB]
+        A2 --> A3[Start Web]
+    end
+```
+
+This is extracted via AST analysis (the same introspection used internally by `cutip.workflow.introspect`) and does not require importing or executing the workflow.

--- a/docs/reference/workflow-contract.md
+++ b/docs/reference/workflow-contract.md
@@ -1,8 +1,8 @@
 # Workflow Contract
 
-A CUTIP workflow is a plain Python file (`workflow.py`) containing exactly one function: `main(ctx: CutipContext)`. CUTIP discovers and imports this file dynamically at runtime and calls `main(ctx)`.
+A CUTIP workflow is a Python file (`workflow.py`) with an entry point function `main(ctx: CutipContext)`. CUTIP discovers and imports this file dynamically at runtime and calls `main(ctx)`.
 
-There is no base class to inherit, no decorator to apply, no registration step. If the file exists and exports `main`, it runs.
+There is no base class to inherit, no registration step. If the file exists and exports `main`, it runs. Workflows can optionally use `@action` and `@orchestrator` decorators to add structured metadata for introspection and planning --- see [Annotations](../concepts/annotations.md).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: CUTIP
 site_description: >
-  Container Unit Templates in Python — a deterministic framework for defining,
-  validating, and orchestrating container environments.
+  Container Unit Templates in Python — an automation tool for defining,
+  validating, and orchestrating containerized workflows.
 site_url: https://joshuajerome.github.io/cutip
 repo_url: https://github.com/joshuajerome/cutip
 repo_name: joshuajerome/cutip
@@ -85,10 +85,13 @@ nav:
     - Cards: concepts/cards.md
     - Units: concepts/units.md
     - Groups: concepts/groups.md
+    - Lifecycle: concepts/lifecycle.md
+    - Annotations: concepts/annotations.md
     - Graph Resolution: concepts/graph-resolution.md
 
   - Reference:
     - CLI: reference/cli.md
+    - Compile: reference/compile.md
     - Workflow Contract: reference/workflow-contract.md
     - Exceptions: reference/exceptions.md
     - Cards:


### PR DESCRIPTION
## Summary

- Rewrites documentation to lead with CUTIP's identity as an automation tool for containerized workflows
- Adds new concept pages: lifecycle (prehook/workflow/posthook), annotations (@action/@orchestrator decorators)
- Adds new reference page: cutip compile with Mermaid output documentation
- Updates existing docs pages to reflect current CUTIP architecture and terminology

## Changes

- `docs/concepts/lifecycle.md`: new page documenting the per-unit lifecycle model
- `docs/concepts/annotations.md`: new page documenting all workflow decorators
- `docs/reference/compile.md`: new page documenting cutip compile and Mermaid output
- `docs/index.md`, `docs/concepts/overview.md`, `docs/getting-started/quickstart.md`, etc.: updated to reflect CUTIP identity
- `mkdocs.yml`: updated nav to include new pages

## Test plan

- [ ] `uv run pytest tests/ -v --ignore=tests/e2e` passes
- [ ] `mkdocs build` succeeds (CI docs build check)
- [ ] New pages render correctly in nav structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
