### PR TITLE
[cap048] feat: CLI command renames + new commands

### DIFF
--- a/cutip/cli/commands/create.py
+++ b/cutip/cli/commands/create.py
@@ -1,0 +1,141 @@
+"""``cutip create`` — scaffold individual CUTIP artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from cutip.workspace.scaffold import _find_project_root
+
+console = Console()
+app = typer.Typer(help="Create CUTIP artifacts (cards, units, groups).")
+
+
+@app.command("card")
+def create_card(
+    name: str = typer.Argument(..., help="Card name"),
+    kind: str = typer.Option(
+        "container", "--kind", "-k", help="Card kind: image, container, or network"
+    ),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Create a new card YAML stub."""
+    project_root = path or _find_project_root()
+    card_dir = project_root / "cutip" / "cards" / name
+    card_dir.mkdir(parents=True, exist_ok=True)
+
+    if kind == "image":
+        out = card_dir / f"{name}.image.yaml"
+        out.write_text(
+            f'apiVersion: cutip/v1\nkind: ImageCard\nname: {name}\nspec:\n  source: pull\n  image: "alpine:3.20"\n',
+            encoding="utf-8",
+        )
+    elif kind == "network":
+        out = card_dir / f"{name}.network.yaml"
+        out.write_text(
+            f"apiVersion: cutip/v1\nkind: NetworkCard\nname: {name}\nspec:\n  subnet: 172.20.0.0/16\n",
+            encoding="utf-8",
+        )
+    else:
+        # container (default) — also create image card
+        img_out = card_dir / f"{name}.image.yaml"
+        if not img_out.exists():
+            img_out.write_text(
+                f'apiVersion: cutip/v1\nkind: ImageCard\nname: {name}\nspec:\n  source: pull\n  image: "alpine:3.20"\n',
+                encoding="utf-8",
+            )
+        out = card_dir / f"{name}.container.yaml"
+        out.write_text(
+            f"apiVersion: cutip/v1\nkind: ContainerCard\nname: {name}\nspec:\n"
+            f"  imageRef:\n    ref: images/{name}\n  command:\n    - tail\n    - -f\n    - /dev/null\n",
+            encoding="utf-8",
+        )
+
+    console.print(f"[green]Created {kind} card:[/green] {out.relative_to(project_root)}")
+
+
+@app.command("unit")
+def create_unit(
+    name: str = typer.Argument(..., help="Unit name"),
+    container: str = typer.Option(
+        None, "--container", "-c", help="Container ref (e.g. containers/myapp)"
+    ),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Create a new unit with YAML stub and optional hook files."""
+    project_root = path or _find_project_root()
+    unit_dir = project_root / "cutip" / "units" / name
+    unit_dir.mkdir(parents=True, exist_ok=True)
+
+    container_ref = container or f"containers/{name}"
+
+    yaml_out = unit_dir / f"{name}.unit.yaml"
+    yaml_out.write_text(
+        f"apiVersion: cutip/v1\nkind: Unit\nname: {name}\nspec:\n  containerRef:\n    ref: {container_ref}\n",
+        encoding="utf-8",
+    )
+
+    # Create empty hook stubs
+    for hook_file in ("prehook.py", "workflow.py", "posthook.py"):
+        hook_path = unit_dir / hook_file
+        if not hook_path.exists():
+            hook_path.write_text(
+                f'"""CUTIP {hook_file.replace(".py", "")} for unit: {name}."""\n',
+                encoding="utf-8",
+            )
+
+    console.print(f"[green]Created unit:[/green] {unit_dir.relative_to(project_root)}/")
+    console.print(f"  {name}.unit.yaml, prehook.py, workflow.py, posthook.py")
+
+
+@app.command("group")
+def create_group(
+    name: str = typer.Argument(..., help="Group name"),
+    units: str = typer.Option(None, "--units", "-u", help="Comma-separated unit names"),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Create a new group with YAML stub and orchestrator."""
+    project_root = path or _find_project_root()
+    group_dir = project_root / "cutip" / "groups" / name
+    group_dir.mkdir(parents=True, exist_ok=True)
+
+    unit_list = [u.strip() for u in units.split(",")] if units else []
+    unit_yaml = (
+        "\n".join(f"    - ref: units/{u}" for u in unit_list)
+        if unit_list
+        else "    - ref: units/example"
+    )
+
+    yaml_out = group_dir / "group.yaml"
+    yaml_out.write_text(
+        f"apiVersion: cutip/v1\nkind: Group\nname: {name}\nspec:\n  units:\n{unit_yaml}\n  workflow: workflow.py\n",
+        encoding="utf-8",
+    )
+
+    # Create orchestrator stub
+    orch_out = group_dir / "orchestrator.py"
+    if not orch_out.exists():
+        orch_out.write_text(
+            f'"""CUTIP orchestrator for group: {name}."""\n\n'
+            "from cutip.workflow.decorators import orchestrator\n\n\n"
+            "@orchestrator\ndef main(ctx):\n"
+            '    """Sequence unit workflows."""\n'
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+    # Create workflow.py stub
+    wf_out = group_dir / "workflow.py"
+    if not wf_out.exists():
+        wf_out.write_text(
+            f'"""CUTIP workflow for group: {name}."""\n\n\n'
+            "def main(ctx):\n"
+            '    """Start containers and orchestrate."""\n'
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+    console.print(f"[green]Created group:[/green] {group_dir.relative_to(project_root)}/")
+    console.print("  group.yaml, orchestrator.py, workflow.py")

--- a/cutip/cli/commands/info.py
+++ b/cutip/cli/commands/info.py
@@ -8,6 +8,7 @@ import typer
 import yaml
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 
 from cutip.workspace.scaffold import _find_project_root
 
@@ -17,7 +18,7 @@ app = typer.Typer()
 
 @app.callback(invoke_without_command=True)
 def info() -> None:
-    """Show CUTIP version, active workspace, and backend info."""
+    """Show CUTIP version, active workspace, backend info, and discovered artifacts."""
     ver = _pkg_version("cutip")
     lines = [f"[bold]Version[/bold]: {ver}"]
 
@@ -43,10 +44,10 @@ def info() -> None:
 
     # Available backends
     available = []
-    for name, mod in [("docker", "docker"), ("podman", "podman")]:
+    for be_name, mod in [("docker", "docker"), ("podman", "podman")]:
         try:
             __import__(mod)
-            available.append(name)
+            available.append(be_name)
         except ImportError:
             pass
 
@@ -55,6 +56,25 @@ def info() -> None:
     else:
         lines.append("[bold]Available backends[/bold]: [yellow]none installed[/yellow]")
 
+    # Discover artifacts
+    cutip_dir = project_root / "cutip"
+    if cutip_dir.is_dir():
+        try:
+            from cutip.workspace.discovery import WorkspaceDiscovery
+
+            registry = WorkspaceDiscovery(project_root).discover()
+            lines.append("")
+            lines.append(
+                f"[bold]Artifacts[/bold]: "
+                f"{len(registry.groups)} group(s), "
+                f"{len(registry.units)} unit(s), "
+                f"{len(registry.cards)} card(s)"
+            )
+            if registry.groups:
+                lines.append(f"[bold]Groups[/bold]: {', '.join(sorted(registry.groups.keys()))}")
+        except Exception:
+            pass
+
     console.print(
         Panel.fit(
             "\n".join(lines),
@@ -62,3 +82,35 @@ def info() -> None:
             border_style="blue",
         )
     )
+
+    # Per-unit hook status table
+    if cutip_dir.is_dir():
+        try:
+            from cutip.workspace.discovery import WorkspaceDiscovery
+
+            registry = WorkspaceDiscovery(project_root).discover()
+            if registry.units:
+                table = Table(title="Unit Hook Status", show_lines=True)
+                table.add_column("Unit", style="bold")
+                table.add_column("prehook.py")
+                table.add_column("workflow.py")
+                table.add_column("posthook.py")
+                table.add_column("startup.py", style="dim")
+
+                for unit_name in sorted(registry.units):
+                    unit_source = registry.source_of(f"units/{unit_name}")
+                    if unit_source:
+                        unit_dir = unit_source.parent
+                    else:
+                        unit_dir = cutip_dir / "units" / unit_name
+
+                    row = [unit_name]
+                    for hook_file in ("prehook.py", "workflow.py", "posthook.py", "startup.py"):
+                        exists = (unit_dir / hook_file).is_file()
+                        row.append("[green]yes[/green]" if exists else "[dim]—[/dim]")
+                    table.add_row(*row)
+
+                console.print()
+                console.print(table)
+        except Exception:
+            pass

--- a/cutip/cli/commands/plan.py
+++ b/cutip/cli/commands/plan.py
@@ -19,8 +19,8 @@ from cutip.workspace.scaffold import _find_project_root
 console = Console()
 
 
-def plan(
-    group_name: str = typer.Argument(..., help="Name of the group to plan"),
+def preview(
+    group_name: str = typer.Argument(..., help="Name of the group to preview"),
     path: Path = typer.Option(None, "--path", "-p", show_default=False),
 ) -> None:
     """Dry-run: show what cutip run would execute for a group."""

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -9,12 +9,13 @@ from pathlib import Path
 import typer
 
 from cutip.cli.commands.compose import from_compose
+from cutip.cli.commands.create import app as create_app
 from cutip.cli.commands.desktop import desktop
 from cutip.cli.commands.info import app as info_app
 from cutip.cli.commands.init import app as init_app
 from cutip.cli.commands.issue import issue_app
 from cutip.cli.commands.ls import card_app, group_app, unit_app
-from cutip.cli.commands.plan import plan
+from cutip.cli.commands.plan import preview
 from cutip.cli.commands.run import run
 from cutip.cli.commands.secrets import secrets_app
 from cutip.cli.commands.show import app as show_app
@@ -57,7 +58,7 @@ def _backend_status() -> str:
 
 _EPILOG = (
     "[bold]Getting Started[/bold]: "
-    "cutip init · cutip from-compose FILE · cutip validate · cutip run GROUP\n\n"
+    "cutip init · cutip from-compose FILE · cutip validate · cutip preview GROUP · cutip run GROUP\n\n"
     "[bold]Updating[/bold]: "
     "pip install --upgrade cutip · cutip upgrade --apply\n\n"
     "[bold]AI Issues[/bold] (requires cutip\\[ai]): "
@@ -229,11 +230,13 @@ _WF = "Workflow"
 app.add_typer(init_app, name="init", rich_help_panel=_WF)
 app.command("run", rich_help_panel=_WF)(run)
 app.command("stop", rich_help_panel=_WF)(stop)
-app.command("plan", rich_help_panel=_WF)(plan)
+app.command("preview", rich_help_panel=_WF)(preview)
+app.command("plan", hidden=True)(preview)  # backward-compat alias
 app.command("from-compose", rich_help_panel=_WF)(from_compose)
 app.command("desktop", rich_help_panel=_WF)(desktop)
 
 app.add_typer(info_app, name="info", rich_help_panel=_WF)
+app.add_typer(create_app, name="create", rich_help_panel=_WF)
 
 # ── Inspect ──────────────────────────────────────────────────────────────────
 _IN = "Inspect"


### PR DESCRIPTION
## Summary

- Renames `cutip plan` to `cutip preview` (keeps `plan` as a hidden backward-compatible alias)
- Enhances `cutip info` to show discovered artifact counts (groups, units, cards), group names, and a per-unit hook status table (prehook.py, workflow.py, posthook.py, startup.py)
- Adds `cutip create` subcommands (`card`, `unit`, `group`) that generate YAML stubs and hook file stubs in the correct directory structure

## Changes

- `cutip/cli/commands/plan.py`: Renamed `plan()` function to `preview()`
- `cutip/cli/main.py`: Updated import, registered `preview` as visible + `plan` as hidden alias, added `create` app, updated epilog
- `cutip/cli/commands/info.py`: Added workspace discovery for artifact counts, group listing, and per-unit hook status table
- `cutip/cli/commands/create.py`: New file with `create card`, `create unit`, `create group` subcommands

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57/57)
- [ ] `cutip preview <group>` works identically to old `cutip plan`
- [ ] `cutip plan <group>` still works (hidden alias)
- [ ] `cutip info` shows artifact counts and hook status table in a workspace
- [ ] `cutip create card myapp --kind container` creates card stubs
- [ ] `cutip create unit myapp` creates unit YAML + hook stubs
- [ ] `cutip create group mygroup --units db,web` creates group YAML + orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
