### PR TITLE
[cap052] feat: group orchestrator.py + ctx.run_unit()

### DIFF
--- a/cutip/context/workflow.py
+++ b/cutip/context/workflow.py
@@ -61,87 +61,157 @@ class CutipContext:
             )
         return self.runtime.containers.get(name)
 
+    def run_unit(self, unit_name: str) -> None:
+        """Execute a unit's workflow.py (if it exists).
+
+        Called from an orchestrator to run a specific unit's workflow::
+
+            @orchestrator
+            def main(ctx):
+                ctx.run_unit("db")
+                ctx.run_unit("web")
+
+        If the unit has no workflow.py, just starts the container.
+        """
+        from loguru import logger
+
+        unit = self.resolved_units.get(unit_name)
+        if unit is None:
+            raise CutipWorkflowError(f"Unit '{unit_name}' not found in resolved units")
+
+        unit_source = self.registry.source_of(f"units/{unit_name}")
+        if unit_source is not None:
+            unit_dir = unit_source.parent
+        else:
+            unit_dir = self.project_root / "cutip" / "units" / unit_name
+
+        workflow_path = unit_dir / "workflow.py"
+        if workflow_path.is_file():
+            logger.info(f"Running workflow for unit '{unit_name}' ...")
+            module = _load_module_from_path(f"cutip._unit_workflow_{unit_name}", workflow_path)
+            fn = getattr(module, "main", None)
+            if fn is not None:
+                try:
+                    fn(self)
+                except Exception as exc:
+                    raise CutipWorkflowError(
+                        f"Error in unit workflow '{workflow_path}': {exc}"
+                    ) from exc
+                return
+
+        # No workflow.py — just start the container
+        from cutip.models.cards.container import ContainerCard
+
+        container_ref = unit.spec.containerRef.ref
+        card = self.resolved_cards.get(container_ref)
+        if isinstance(card, ContainerCard) and self.runtime is not None:
+            logger.info(f"Starting container '{card.metadata.name}' (no unit workflow)")
+            self.runtime.containers.get(card.metadata.name).start()
+
+
+def _load_module_from_path(module_name: str, file_path: Path) -> ModuleType:
+    """Import a Python file by path, returning the loaded module."""
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise CutipWorkflowError(f"Could not create module spec from '{file_path}'")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+
+    try:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    except Exception as exc:
+        raise CutipWorkflowError(f"Error loading '{file_path}': {exc}") from exc
+
+    return module
+
 
 class WorkflowLoader:
-    """Dynamically imports a group's workflow.py and calls main(ctx).
+    """Loads and executes a group's orchestrator or workflow.
 
-    ``main(ctx)`` is the group-level orchestration hook — it is responsible
-    for starting containers (via ``ctx.container(name).start()``) and
-    coordinating across units.  It is optional; if absent, CUTIP logs a
-    debug message and continues.
-
-    Unit-specific pre-build and post-start logic belongs in each unit's
-    ``startup.py``, not here.
+    Resolution order:
+    1. ``orchestrator.py`` in the group directory (new convention)
+    2. ``workflow.py`` in the group directory (backward compatible)
+    3. If neither has a ``main()`` or ``@orchestrator``, run unit workflows
+       in group.yaml declaration order (zero-config default)
     """
 
     def __init__(self, project_root: Path) -> None:
         self.project_root = project_root
         self._module_cache: dict[str, tuple[ModuleType, Path]] = {}
 
-    def _load_module(self, group: Group, registry: CutipRegistry) -> tuple[ModuleType, Path]:
-        """Import the workflow module (cached per group name)."""
+    def _group_dir(self, group: Group, registry: CutipRegistry) -> Path:
+        group_source = registry.source_of(f"groups/{group.name}")
+        if group_source is not None:
+            return group_source.parent
+        return self.project_root / "cutip" / "groups" / group.name
+
+    def _load_module(self, group: Group, registry: CutipRegistry) -> tuple[ModuleType, Path] | None:
+        """Import orchestrator.py or workflow.py (cached per group name)."""
         if group.name in self._module_cache:
             return self._module_cache[group.name]
 
-        group_source = registry.source_of(f"groups/{group.name}")
-        if group_source is not None:
-            group_dir = group_source.parent
-        else:
-            group_dir = self.project_root / "cutip" / "groups" / group.name
+        group_dir = self._group_dir(group, registry)
 
-        workflow_path = group_dir / group.spec.workflow
-        if not workflow_path.is_file():
-            raise CutipWorkflowError(f"Workflow file not found: '{workflow_path}'")
+        # Try orchestrator.py first, then workflow.py
+        for filename in (group.spec.orchestrator, group.spec.workflow):
+            candidate = group_dir / filename
+            if candidate.is_file():
+                module_name = f"cutip._workflow_{group.name}"
+                module = _load_module_from_path(module_name, candidate)
+                self._module_cache[group.name] = (module, candidate)
+                return module, candidate
 
-        module_name = f"cutip._workflow_{group.name}"
-        spec = importlib.util.spec_from_file_location(module_name, workflow_path)
-        if spec is None or spec.loader is None:
-            raise CutipWorkflowError(f"Could not create module spec from '{workflow_path}'")
-
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-
-        try:
-            spec.loader.exec_module(module)  # type: ignore[union-attr]
-        except Exception as exc:
-            raise CutipWorkflowError(f"Error loading workflow '{workflow_path}': {exc}") from exc
-
-        self._module_cache[group.name] = (module, workflow_path)
-        return module, workflow_path
+        return None
 
     def run(self, group: Group, ctx: CutipContext, registry: CutipRegistry) -> None:
-        """Import the workflow module and call main(ctx)."""
-        module, workflow_path = self._load_module(group, registry)
+        """Import the orchestrator/workflow module and call main(ctx)."""
+        result = self._load_module(group, registry)
 
-        if not hasattr(module, "main"):
-            # Fallback: check for @orchestrator-decorated function
-            from cutip.workflow.decorators import _ORCHESTRATOR_ATTR
-
-            orch = next(
-                (
-                    fn
-                    for fn in vars(module).values()
-                    if callable(fn) and getattr(fn, _ORCHESTRATOR_ATTR, False)
-                ),
-                None,
-            )
-            if orch is not None:
-                try:
-                    orch(ctx)
-                except Exception as exc:
-                    raise CutipWorkflowError(
-                        f"Error executing workflow '{workflow_path}': {exc}"
-                    ) from exc
-                return
-
-            from loguru import logger as _logger
-
-            _logger.debug(
-                f"Workflow '{workflow_path}' has no main() — skipping group-level execution."
-            )
+        if result is None:
+            # No orchestrator or workflow — run unit workflows in declaration order
+            self._run_units_default(group, ctx)
             return
 
-        try:
-            module.main(ctx)
-        except Exception as exc:
-            raise CutipWorkflowError(f"Error executing workflow '{workflow_path}': {exc}") from exc
+        module, workflow_path = result
+
+        if hasattr(module, "main"):
+            try:
+                module.main(ctx)
+            except Exception as exc:
+                raise CutipWorkflowError(
+                    f"Error executing workflow '{workflow_path}': {exc}"
+                ) from exc
+            return
+
+        # Check for @orchestrator-decorated function
+        from cutip.workflow.decorators import _ORCHESTRATOR_ATTR
+
+        orch = next(
+            (
+                fn
+                for fn in vars(module).values()
+                if callable(fn) and getattr(fn, _ORCHESTRATOR_ATTR, False)
+            ),
+            None,
+        )
+        if orch is not None:
+            try:
+                orch(ctx)
+            except Exception as exc:
+                raise CutipWorkflowError(
+                    f"Error executing workflow '{workflow_path}': {exc}"
+                ) from exc
+            return
+
+        # File exists but has no entry point — fall back to default unit execution
+        self._run_units_default(group, ctx)
+
+    def _run_units_default(self, group: Group, ctx: CutipContext) -> None:
+        """Run unit workflows in group.yaml declaration order (zero-config default)."""
+        from loguru import logger as _logger
+
+        _logger.debug(f"No orchestrator found for group '{group.name}' — running units in order.")
+        for unit_ref in group.spec.units:
+            unit_name = unit_ref.ref.split("/")[-1]
+            ctx.run_unit(unit_name)

--- a/cutip/models/group.py
+++ b/cutip/models/group.py
@@ -10,7 +10,8 @@ from cutip.models.cards.container import Ref
 
 class GroupSpec(BaseModel):
     units: list[Ref]
-    workflow: str
+    workflow: str = "workflow.py"
+    orchestrator: str = "orchestrator.py"
 
 
 class Group(CutipBaseModel):


### PR DESCRIPTION
## Summary

- Adds `orchestrator` field to `GroupSpec` (defaults to `orchestrator.py`, falls back to `workflow.py`)
- Adds `ctx.run_unit(name)` to `CutipContext` — loads `units/<name>/workflow.py` and calls `main(ctx)`, or just starts the container if no workflow exists
- Updates `WorkflowLoader` resolution order: `orchestrator.py` → `workflow.py` → run unit workflows in declaration order (zero-config default)
- Backward compatible: existing `workflow.py` with `main(ctx)` or `@orchestrator` still works unchanged

## Changes

- `cutip/models/group.py`: Added `orchestrator: str = "orchestrator.py"` to `GroupSpec`, made `workflow` default to `"workflow.py"`
- `cutip/context/workflow.py`: Added `ctx.run_unit()` method, extracted `_load_module_from_path()` helper, rewrote `WorkflowLoader` with orchestrator-first resolution and `_run_units_default()` fallback

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57/57)
- [ ] Existing consumer projects with `workflow.py` still work
- [ ] `orchestrator.py` is discovered and executed when present
- [ ] Groups without orchestrator or workflow auto-run unit workflows in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)
