### PR TITLE
[cap054] feat: add cutip export/import for portable group archives

### DIFF
--- a/cutip/cli/commands/export_cmd.py
+++ b/cutip/cli/commands/export_cmd.py
@@ -1,0 +1,47 @@
+"""``cutip export`` — package a group and its dependencies into a portable archive."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from cutip.cli.commands.rm import _collect_group_files
+from cutip.resolver.refs import RefResolver
+from cutip.workspace.discovery import WorkspaceDiscovery
+from cutip.workspace.scaffold import _find_project_root
+
+console = Console()
+
+
+def export_group(
+    group_name: str = typer.Argument(..., help="Group name to export"),
+    output: Path = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output archive path (default: ./<group>.cutip.tar.gz)",
+    ),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Export a group and all its artifacts into a portable .tar.gz archive."""
+    project_root = path or _find_project_root()
+    registry = WorkspaceDiscovery(project_root).discover()
+    resolver = RefResolver(registry)
+
+    files = _collect_group_files(group_name, project_root, registry, resolver)
+    if not files:
+        console.print(f"[yellow]No files found for group '{group_name}'.[/yellow]")
+        raise typer.Exit(0)
+
+    archive_path = output or Path(f"{group_name}.cutip.tar.gz")
+
+    with tarfile.open(archive_path, "w:gz") as tar:
+        for f in files:
+            arcname = str(f.relative_to(project_root))
+            tar.add(f, arcname=arcname)
+
+    console.print(f"[green]Exported {len(files)} files to {archive_path}[/green]")
+    console.print("[dim]Import with: cutip import <archive>[/dim]")

--- a/cutip/cli/commands/import_cmd.py
+++ b/cutip/cli/commands/import_cmd.py
@@ -1,0 +1,85 @@
+"""``cutip import`` — import a group archive into the current workspace."""
+
+from __future__ import annotations
+
+import tarfile
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+
+import typer
+from rich.console import Console
+
+from cutip.utils.exceptions import CutipError
+from cutip.workspace.scaffold import _find_project_root
+
+console = Console()
+
+
+def _is_url(value: str) -> bool:
+    """Check if a string looks like a URL."""
+    parsed = urlparse(value)
+    return parsed.scheme in ("http", "https")
+
+
+def _download(url: str, dest: Path) -> None:
+    """Download a URL to a local path."""
+    from urllib.request import urlretrieve
+
+    try:
+        urlretrieve(url, dest)
+    except Exception as exc:
+        raise CutipError(f"Failed to download '{url}': {exc}") from exc
+
+
+def import_group(
+    source: str = typer.Argument(..., help="Path or URL to a .cutip.tar.gz archive"),
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Import a group archive into the current workspace."""
+    project_root = path or _find_project_root()
+
+    if _is_url(source):
+        console.print(f"[dim]Downloading {source}...[/dim]")
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        _download(source, tmp_path)
+        archive_path = tmp_path
+    else:
+        archive_path = Path(source)
+
+    if not archive_path.is_file():
+        console.print(f"[red]Archive not found: {archive_path}[/red]")
+        raise typer.Exit(1)
+
+    if not tarfile.is_tarfile(archive_path):
+        console.print(f"[red]Not a valid tar archive: {archive_path}[/red]")
+        raise typer.Exit(1)
+
+    imported: list[str] = []
+    with tarfile.open(archive_path, "r:gz") as tar:
+        # Security: reject absolute paths and path traversal
+        for member in tar.getmembers():
+            if member.name.startswith("/") or ".." in member.name:
+                console.print(f"[red]Refusing to extract unsafe path: {member.name}[/red]")
+                raise typer.Exit(1)
+
+        for member in tar.getmembers():
+            if member.isfile():
+                tar.extract(member, path=project_root)
+                imported.append(member.name)
+
+    console.print(f"[green]Imported {len(imported)} files into {project_root}[/green]")
+    for name in imported[:20]:
+        console.print(f"  {name}")
+    if len(imported) > 20:
+        console.print(f"  ... and {len(imported) - 20} more")
+
+    # Run validation
+    try:
+        from cutip.workspace.discovery import WorkspaceDiscovery
+
+        WorkspaceDiscovery(project_root).discover()
+        console.print("[green]Workspace validation passed.[/green]")
+    except Exception as exc:
+        console.print(f"[yellow]Warning: validation issue after import: {exc}[/yellow]")

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -12,6 +12,8 @@ from cutip.cli.commands.compile import compile_cmd
 from cutip.cli.commands.compose import from_compose
 from cutip.cli.commands.create import app as create_app
 from cutip.cli.commands.desktop import desktop
+from cutip.cli.commands.export_cmd import export_group
+from cutip.cli.commands.import_cmd import import_group
 from cutip.cli.commands.info import app as info_app
 from cutip.cli.commands.init import app as init_app
 from cutip.cli.commands.issue import issue_app
@@ -254,6 +256,8 @@ app.add_typer(card_app, name="card", rich_help_panel=_IN)
 # ── Manage ────────────────────────────────────────────────────────────────────
 _MG = "Manage"
 app.add_typer(rm_app, name="rm", rich_help_panel=_MG)
+app.command("export", rich_help_panel=_MG)(export_group)
+app.command("import", rich_help_panel=_MG)(import_group)
 
 # ── Configuration ────────────────────────────────────────────────────────────
 _CF = "Configuration"


### PR DESCRIPTION
## Summary

- Adds `cutip export <group>` — packages group + units + cards into a portable `.cutip.tar.gz` archive
- Adds `cutip import <path-or-url>` — extracts archive into workspace with path traversal protection
- URL support: downloads remote archives to temp before extracting
- Post-import validation check

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57/57)
- [ ] `cutip export <group>` creates valid .tar.gz with correct directory structure
- [ ] `cutip import <archive>` extracts files to correct locations
- [ ] Path traversal (../) in archives is rejected
- [ ] URL download + import works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)