### PR TITLE
[cap057] fix: validate orchestrator.py alongside workflow.py

### DIFF
--- a/cutip/validation/graph.py
+++ b/cutip/validation/graph.py
@@ -104,11 +104,19 @@ class GraphValidator:
                 group_dir = None
 
             if group_dir is not None:
+                # Resolution order matches WorkflowLoader: orchestrator → workflow
+                orchestrator_path = group_dir / group.spec.orchestrator
                 workflow_path = group_dir / group.spec.workflow
-                if not workflow_path.is_file():
-                    result.add(
-                        f"[WorkflowPath] {group_name}: workflow file not found: '{workflow_path}'"
-                    )
-                    logger.warning(f"  ✗ {group_name}: workflow not found: '{workflow_path}'")
-                else:
+                if orchestrator_path.is_file():
+                    logger.info(f"  ✓ {group_name}: {group.spec.orchestrator}")
+                elif workflow_path.is_file():
                     logger.info(f"  ✓ {group_name}: {group.spec.workflow}")
+                else:
+                    result.add(
+                        f"[WorkflowPath] {group_name}: neither orchestrator "
+                        f"'{group.spec.orchestrator}' nor workflow "
+                        f"'{group.spec.workflow}' found in {group_dir}"
+                    )
+                    logger.warning(
+                        f"  ✗ {group_name}: no orchestrator or workflow found in {group_dir}"
+                    )


### PR DESCRIPTION
## Summary

- `GraphValidator` now checks `orchestrator.py` first, then `workflow.py`, matching `WorkflowLoader` resolution order
- Groups with only an orchestrator (e.g. hello-world scaffold) no longer fail validation

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (57/57)
- [ ] `cutip validate` passes on hello-world scaffold (orchestrator.py only, no group-level workflow.py)
- [ ] `cutip validate` still passes on legacy projects with workflow.py only

🤖 Generated with [Claude Code](https://claude.com/claude-code)