### PR TITLE
[cap060] Upgrade system, cutip diff, stage() separator

### DIFF
--- a/cutip/__init__.py
+++ b/cutip/__init__.py
@@ -1,3 +1,3 @@
 """CUTIP — Container Unit Templates in Python."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.2"

--- a/cutip/cli/commands/diff.py
+++ b/cutip/cli/commands/diff.py
@@ -45,7 +45,9 @@ def diff(
     for f in findings:
         rel = f.file.relative_to(project_root) if f.file else "—"
         sev = "✗" if f.severity == "breaking" else "!"
-        lines.append(f"[{'red' if f.severity == 'breaking' else 'yellow'}]{sev}[/] [{f.migration_id}] {rel}")
+        lines.append(
+            f"[{'red' if f.severity == 'breaking' else 'yellow'}]{sev}[/] [{f.migration_id}] {rel}"
+        )
         if f.detail:
             lines.append(f"    → {f.detail}")
         lines.append("")

--- a/cutip/cli/commands/diff.py
+++ b/cutip/cli/commands/diff.py
@@ -1,0 +1,70 @@
+"""cutip diff — show what migrations would change, or review staged changes."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.syntax import Syntax
+
+from cutip.upgrade.registry import scan_migrations
+from cutip.workspace.scaffold import _find_project_root
+
+console = Console()
+
+
+def diff(
+    path: Path = typer.Option(None, "--path", "-p", show_default=False),
+) -> None:
+    """Show pending migration changes or review already-staged changes.
+
+    Before --apply: shows what each migration would change.
+    After --apply: shows the git-staged diff for cutip/ files.
+    """
+    project_root = path or _find_project_root()
+
+    # Check if there are staged cutip/ changes (post-apply review)
+    staged_diff = _get_staged_diff(project_root)
+    if staged_diff:
+        console.print(
+            Panel("[bold]Staged changes[/bold] (after cutip upgrade --apply)", border_style="green")
+        )
+        console.print(Syntax(staged_diff, "diff", theme="monokai"))
+        return
+
+    # Pre-apply: show what migrations would change
+    findings = scan_migrations(project_root)
+    if not findings:
+        console.print("[green]No pending migrations — nothing to diff.[/green]")
+        raise typer.Exit(0)
+
+    lines: list[str] = []
+    for f in findings:
+        rel = f.file.relative_to(project_root) if f.file else "—"
+        sev = "✗" if f.severity == "breaking" else "!"
+        lines.append(f"[{'red' if f.severity == 'breaking' else 'yellow'}]{sev}[/] [{f.migration_id}] {rel}")
+        if f.detail:
+            lines.append(f"    → {f.detail}")
+        lines.append("")
+
+    console.print(Panel.fit("\n".join(lines), title="cutip diff (dry-run preview)"))
+    console.print("Run [bold]cutip upgrade --apply[/bold] to apply these changes.")
+
+
+def _get_staged_diff(project_root: Path) -> str | None:
+    """Get git staged diff for cutip/ files. Returns None if no staged changes."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--", "cutip/", "cutip.yaml"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except FileNotFoundError:
+        pass
+    return None

--- a/cutip/cli/commands/info.py
+++ b/cutip/cli/commands/info.py
@@ -2,28 +2,54 @@
 
 from __future__ import annotations
 
-from importlib.metadata import version as _pkg_version
-
 import typer
 import yaml
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from cutip.utils.version import installed_version, latest_version
 from cutip.workspace.scaffold import _find_project_root
 
 console = Console()
 app = typer.Typer()
 
 
+def _version_line(project_root) -> str:
+    """Build the version status line: installed vs latest + migration hint."""
+    ver = installed_version()
+    latest = latest_version(cache_dir=project_root / ".cutip" / "cache")
+
+    if latest and latest != ver:
+        return (
+            f"[bold]Version[/bold]: {ver} "
+            f"([yellow]{latest} available[/yellow] — "
+            f"run: [cyan]pip install cutip --upgrade[/cyan])"
+        )
+
+    # Up to date — check if workspace has deprecated patterns
+    from cutip.upgrade.registry import scan_migrations
+
+    findings = scan_migrations(project_root)
+    if findings:
+        n = len(findings)
+        return (
+            f"[bold]Version[/bold]: {ver} [green]up to date[/green] — "
+            f"[yellow]{n} file{'s' if n != 1 else ''} use{'s' if n == 1 else ''} "
+            f"deprecated patterns[/yellow]. Run: [cyan]cutip upgrade[/cyan]"
+        )
+
+    return f"[bold]Version[/bold]: {ver} [green]up to date[/green]"
+
+
 @app.callback(invoke_without_command=True)
 def info() -> None:
     """Show CUTIP version, active workspace, backend info, and discovered artifacts."""
-    ver = _pkg_version("cutip")
-    lines = [f"[bold]Version[/bold]: {ver}"]
+    project_root = _find_project_root()
+
+    lines = [_version_line(project_root)]
 
     # Active workspace
-    project_root = _find_project_root()
     config_path = project_root / "cutip.yaml"
     if config_path.is_file():
         try:

--- a/cutip/cli/commands/upgrade.py
+++ b/cutip/cli/commands/upgrade.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-import re
+import subprocess
 from pathlib import Path
 
 import typer
-import yaml
-from loguru import logger
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 
+from cutip.upgrade.registry import Finding, apply_findings, scan_migrations
 from cutip.workspace.scaffold import _find_project_root
 
 console = Console()
@@ -22,165 +22,45 @@ app = typer.Typer(
 )
 
 
-# ---------------------------------------------------------------------------
-# Migration checks
-# ---------------------------------------------------------------------------
+def _render_findings(findings: list[Finding]) -> None:
+    """Print a summary table of detected migration findings."""
+    table = Table(title="Migration Report", show_lines=True)
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Severity", width=10)
+    table.add_column("Migration", width=20)
+    table.add_column("File", style="cyan")
+    table.add_column("Action")
+
+    for i, f in enumerate(findings, 1):
+        sev = "[red]breaking[/red]" if f.severity == "breaking" else "[yellow]warning[/yellow]"
+        file_str = str(f.file.name) if f.file else "—"
+        table.add_row(str(i), sev, f.migration_id, file_str, f.detail or f.message)
+
+    console.print(table)
 
 
-def _check_vars_yaml(project_root: Path) -> dict | None:
-    """Detect cutip/vars.yaml that should be split into paths.yaml + secrets.yaml."""
-    old = project_root / "cutip" / "vars.yaml"
-    new_paths = project_root / "cutip" / "paths.yaml"
-    if old.exists() and not new_paths.exists():
-        return {
-            "id": "vars-to-paths",
-            "severity": "breaking",
-            "message": (
-                "cutip/vars.yaml was renamed to cutip/paths.yaml in v0.1.8.\n"
-                "  Sensitive values should be moved to cutip/secrets.yaml."
-            ),
-            "old_file": old,
-        }
-    return None
+def _git_stage(files: list[Path], project_root: Path) -> bool:
+    """Stage modified files in git. Returns True if git is available and staging succeeded."""
+    try:
+        # Check if we're in a git repo
+        subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=project_root,
+            capture_output=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
 
+    existing = [str(f) for f in files if f.exists()]
+    deleted = [str(f) for f in files if not f.exists()]
 
-def _check_cutip_yaml_backend(project_root: Path) -> dict | None:
-    """Detect cutip.yaml missing the project.backend field."""
-    config = project_root / "cutip.yaml"
-    if not config.exists():
-        return None
-    data = yaml.safe_load(config.read_text(encoding="utf-8")) or {}
-    project = data.get("project")
-    if project is None:
-        return {
-            "id": "cutip-yaml-project",
-            "severity": "breaking",
-            "message": (
-                "cutip.yaml is missing the 'project' section.\n"
-                "  Expected format:\n"
-                "    apiVersion: cutip/v1\n"
-                "    project:\n"
-                "      name: my-project\n"
-                "      version: 0.1.0\n"
-                "      backend: docker"
-            ),
-        }
-    if not isinstance(project, dict):
-        return None
-    if "backend" not in project:
-        return {
-            "id": "missing-backend",
-            "severity": "warning",
-            "message": (
-                "cutip.yaml is missing project.backend.\n"
-                "  Default is now 'docker' (changed from 'podman' in v0.1.9).\n"
-                "  Add 'backend: podman' if your system only supports Podman."
-            ),
-        }
-    return None
+    if existing:
+        subprocess.run(["git", "add", *existing], cwd=project_root, capture_output=True)
+    if deleted:
+        subprocess.run(["git", "rm", "--cached", *deleted], cwd=project_root, capture_output=True)
 
-
-def _check_startup_ctx_vars(project_root: Path) -> list[dict]:
-    """Detect startup.py files still using ctx.vars (renamed to ctx.paths)."""
-    findings = []
-    units_dir = project_root / "cutip" / "units"
-    if not units_dir.exists():
-        return findings
-
-    for startup in units_dir.rglob("startup.py"):
-        text = startup.read_text(encoding="utf-8")
-        if "ctx.vars" in text:
-            findings.append(
-                {
-                    "id": "ctx-vars-renamed",
-                    "severity": "breaking",
-                    "message": (
-                        f"{startup.relative_to(project_root)}: "
-                        f"ctx.vars was renamed to ctx.paths in v0.1.8.\n"
-                        f"  Replace ctx.vars with ctx.paths."
-                    ),
-                    "file": startup,
-                }
-            )
-    return findings
-
-
-def _check_card_vars_refs(project_root: Path) -> list[dict]:
-    """Detect YAML cards still using {{ vars.X }} (renamed to {{ paths.X }})."""
-    findings = []
-    cards_dir = project_root / "cutip" / "cards"
-    if not cards_dir.exists():
-        return findings
-
-    pattern = re.compile(r"\{\{\s*vars\.\w+\s*\}\}")
-    for yaml_file in cards_dir.rglob("*.yaml"):
-        text = yaml_file.read_text(encoding="utf-8")
-        if pattern.search(text):
-            findings.append(
-                {
-                    "id": "vars-ref-renamed",
-                    "severity": "breaking",
-                    "message": (
-                        f"{yaml_file.relative_to(project_root)}: "
-                        f"{{{{ vars.X }}}} was renamed to {{{{ paths.X }}}} in v0.1.8.\n"
-                        f"  Update all {{{{ vars.X }}}} references to {{{{ paths.X }}}}."
-                    ),
-                    "file": yaml_file,
-                }
-            )
-    return findings
-
-
-# ---------------------------------------------------------------------------
-# Apply logic
-# ---------------------------------------------------------------------------
-
-
-def _apply_vars_to_paths(project_root: Path) -> None:
-    """Rename cutip/vars.yaml → cutip/paths.yaml."""
-    old = project_root / "cutip" / "vars.yaml"
-    new = project_root / "cutip" / "paths.yaml"
-    old.rename(new)
-    logger.info("Renamed: cutip/vars.yaml → cutip/paths.yaml")
-
-
-def _apply_missing_backend(project_root: Path, backend: str) -> None:
-    """Add project.backend to cutip.yaml."""
-    config = project_root / "cutip.yaml"
-    data = yaml.safe_load(config.read_text(encoding="utf-8")) or {}
-    project = data.get("project", {})
-    project["backend"] = backend
-    data["project"] = project
-    config.write_text(
-        yaml.dump(data, default_flow_style=False, sort_keys=False),
-        encoding="utf-8",
-    )
-    logger.info(f"Added project.backend: {backend} to cutip.yaml")
-
-
-def _apply_ctx_vars_rename(file_path: Path) -> None:
-    """Replace ctx.vars with ctx.paths in a startup.py file."""
-    text = file_path.read_text(encoding="utf-8")
-    updated = text.replace("ctx.vars", "ctx.paths")
-    file_path.write_text(updated, encoding="utf-8")
-    logger.info(f"Updated: {file_path} (ctx.vars → ctx.paths)")
-
-
-def _apply_vars_ref_rename(file_path: Path) -> None:
-    """Replace {{ vars.X }} with {{ paths.X }} in a YAML card."""
-    text = file_path.read_text(encoding="utf-8")
-    updated = re.sub(
-        r"\{\{\s*vars\.(\w+)\s*\}\}",
-        r"{{ paths.\1 }}",
-        text,
-    )
-    file_path.write_text(updated, encoding="utf-8")
-    logger.info(f"Updated: {file_path} ({{ vars.X }} → {{ paths.X }})")
-
-
-# ---------------------------------------------------------------------------
-# CLI command
-# ---------------------------------------------------------------------------
+    return True
 
 
 @app.callback()
@@ -189,7 +69,7 @@ def upgrade(
     apply: bool = typer.Option(
         False,
         "--apply",
-        help="Apply all safe migrations automatically.",
+        help="Apply all safe migrations and stage changes in git.",
     ),
     backend: str = typer.Option(
         "podman",
@@ -200,63 +80,64 @@ def upgrade(
 ) -> None:
     """Scan the workspace for outdated patterns and report needed changes.
 
-    Run without --apply to see a dry-run report. Pass --apply to fix automatically.
+    Run without --apply to see a dry-run report.
+    Pass --apply to fix automatically and stage changes in git.
+
+    Upgrade workflow:
+      1. cutip info          — check version + migration status
+      2. pip install cutip --upgrade  — install latest
+      3. cutip upgrade       — dry-run: see what needs changing
+      4. cutip diff          — preview exact changes
+      5. cutip upgrade --apply  — apply and stage
     """
     project_root = path or _find_project_root()
 
-    findings: list[dict] = []
-
-    # Run all checks
-    v = _check_vars_yaml(project_root)
-    if v:
-        findings.append(v)
-
-    b = _check_cutip_yaml_backend(project_root)
-    if b:
-        findings.append(b)
-
-    findings.extend(_check_startup_ctx_vars(project_root))
-    findings.extend(_check_card_vars_refs(project_root))
+    findings = scan_migrations(project_root)
 
     if not findings:
         console.print("[green]Workspace is up to date — no migrations needed.[/green]")
         raise typer.Exit(0)
 
-    # Report
-    breaking = [f for f in findings if f["severity"] == "breaking"]
-    warnings = [f for f in findings if f["severity"] == "warning"]
+    # Always show the report
+    _render_findings(findings)
 
-    lines = []
-    if breaking:
-        lines.append("[bold red]Breaking changes:[/bold red]")
-        for f in breaking:
-            lines.append(f"  [red]✗[/red] {f['message']}")
-    if warnings:
-        lines.append("[bold yellow]Warnings:[/bold yellow]")
-        for f in warnings:
-            lines.append(f"  [yellow]![/yellow] {f['message']}")
-
-    console.print(Panel.fit("\n".join(lines), title="cutip upgrade"))
+    breaking = [f for f in findings if f.severity == "breaking"]
 
     if not apply:
-        console.print("\nRun [bold]cutip upgrade --apply[/bold] to fix automatically.")
+        console.print()
+        console.print("Run [bold]cutip diff[/bold] to preview changes.")
+        console.print("Run [bold]cutip upgrade --apply[/bold] to fix and stage in git.")
         raise typer.Exit(1 if breaking else 0)
 
     # Apply migrations
-    console.print("\n[bold]Applying migrations...[/bold]")
-    for f in findings:
-        fid = f["id"]
-        if fid == "vars-to-paths":
-            _apply_vars_to_paths(project_root)
-        elif fid == "missing-backend":
-            _apply_missing_backend(project_root, backend)
-        elif fid == "ctx-vars-renamed":
-            _apply_ctx_vars_rename(f["file"])
-        elif fid == "vars-ref-renamed":
-            _apply_vars_ref_rename(f["file"])
-        elif fid == "cutip-yaml-project":
-            console.print(
-                f"  [yellow]Skipped:[/yellow] {fid} — requires manual restructuring of cutip.yaml"
-            )
+    console.print()
+    console.print("[bold]Applying migrations...[/bold]")
 
-    console.print("[green]Done. Re-run cutip upgrade to verify.[/green]")
+    modified = apply_findings(findings, project_root, backend=backend)
+
+    if not modified:
+        console.print("[yellow]No changes were applied.[/yellow]")
+        raise typer.Exit(0)
+
+    # Stage in git
+    staged = _git_stage(modified, project_root)
+    if staged:
+        console.print(
+            f"\n[green]Done.[/green] {len(modified)} file(s) modified and staged in git."
+        )
+        console.print("Run [bold]cutip diff[/bold] to review staged changes.")
+    else:
+        console.print(
+            f"\n[green]Done.[/green] {len(modified)} file(s) modified."
+        )
+        console.print("[dim](Not a git repository — changes were not staged.)[/dim]")
+
+    # Verify
+    remaining = scan_migrations(project_root)
+    if remaining:
+        console.print(
+            f"\n[yellow]{len(remaining)} migration(s) still pending "
+            f"(may require manual action).[/yellow]"
+        )
+    else:
+        console.print("\n[green]All migrations applied. Workspace is up to date.[/green]")

--- a/cutip/cli/commands/upgrade.py
+++ b/cutip/cli/commands/upgrade.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
-from rich.panel import Panel
 from rich.table import Table
 
 from cutip.upgrade.registry import Finding, apply_findings, scan_migrations
@@ -122,14 +121,10 @@ def upgrade(
     # Stage in git
     staged = _git_stage(modified, project_root)
     if staged:
-        console.print(
-            f"\n[green]Done.[/green] {len(modified)} file(s) modified and staged in git."
-        )
+        console.print(f"\n[green]Done.[/green] {len(modified)} file(s) modified and staged in git.")
         console.print("Run [bold]cutip diff[/bold] to review staged changes.")
     else:
-        console.print(
-            f"\n[green]Done.[/green] {len(modified)} file(s) modified."
-        )
+        console.print(f"\n[green]Done.[/green] {len(modified)} file(s) modified.")
         console.print("[dim](Not a git repository — changes were not staged.)[/dim]")
 
     # Verify

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -10,6 +10,7 @@ import typer
 
 from cutip.cli.commands.compile import compile_cmd
 from cutip.cli.commands.compose import from_compose
+from cutip.cli.commands.diff import diff
 from cutip.cli.commands.create import app as create_app
 from cutip.cli.commands.desktop import desktop
 from cutip.cli.commands.export_cmd import export_group
@@ -62,14 +63,12 @@ def _backend_status() -> str:
 
 
 _EPILOG = (
-    "[bold]Getting Started[/bold]: "
-    "cutip init · cutip from-compose FILE · cutip validate · cutip preview GROUP · cutip run GROUP\n\n"
-    "[bold]Updating[/bold]: "
-    "pip install --upgrade cutip · cutip upgrade --apply\n\n"
-    "[bold]AI Issues[/bold] (requires cutip\\[ai]): "
-    "pip install cutip\\[ai] · export ANTHROPIC_API_KEY=... · cutip issue diagnose\n\n"
-    "[bold]GitHub[/bold]: "
-    "gh auth login (required for cutip issue push)\n\n"
+    "[bold]Common Workflows[/bold]\n\n"
+    "  [bold]New project[/bold]:   cutip init → cutip validate → cutip run GROUP\n"
+    "  [bold]Upgrade[/bold]:       cutip info → pip install cutip --upgrade → cutip upgrade → cutip diff → cutip upgrade --apply\n"
+    "  [bold]Inspect[/bold]:       cutip info → cutip group ls → cutip tree → cutip show group GROUP\n"
+    "  [bold]Run[/bold]:           cutip status → cutip validate → cutip run GROUP\n"
+    "  [bold]AI Issues[/bold]:     cutip issue diagnose → cutip issue fix → cutip issue push\n\n"
     "[bold]Docs[/bold]: https://joshuajerome.github.io/cutip"
 )
 
@@ -265,6 +264,7 @@ app.command("import", rich_help_panel=_MG)(import_group)
 _CF = "Configuration"
 app.add_typer(secrets_app, name="secrets", rich_help_panel=_CF)
 app.add_typer(upgrade_app, name="upgrade", rich_help_panel=_CF)
+app.command("diff", rich_help_panel=_CF)(diff)
 
 # ── AI & Issues ──────────────────────────────────────────────────────────────
 _AI = "AI & Issues"

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -10,9 +10,9 @@ import typer
 
 from cutip.cli.commands.compile import compile_cmd
 from cutip.cli.commands.compose import from_compose
-from cutip.cli.commands.diff import diff
 from cutip.cli.commands.create import app as create_app
 from cutip.cli.commands.desktop import desktop
+from cutip.cli.commands.diff import diff
 from cutip.cli.commands.export_cmd import export_group
 from cutip.cli.commands.import_cmd import import_group
 from cutip.cli.commands.info import app as info_app

--- a/cutip/upgrade/__init__.py
+++ b/cutip/upgrade/__init__.py
@@ -1,0 +1,1 @@
+"""cutip.upgrade — workspace migration detection and application."""

--- a/cutip/upgrade/registry.py
+++ b/cutip/upgrade/registry.py
@@ -11,13 +11,12 @@ Each migration is a class with:
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
 import yaml
 from loguru import logger
-
 
 # ---------------------------------------------------------------------------
 # Finding — a single detected issue
@@ -64,7 +63,9 @@ class VarsToPathsMigration:
     id = "vars-to-paths"
     introduced = "0.1.8"
     severity = "breaking"
-    description = "cutip/vars.yaml was renamed to cutip/paths.yaml; secrets go in cutip/secrets.yaml"
+    description = (
+        "cutip/vars.yaml was renamed to cutip/paths.yaml; secrets go in cutip/secrets.yaml"
+    )
 
     def detect(self, project_root: Path) -> list[Finding]:
         old = project_root / "cutip" / "vars.yaml"
@@ -75,8 +76,8 @@ class VarsToPathsMigration:
                     migration_id=self.id,
                     severity=self.severity,
                     message=(
-                        f"cutip/vars.yaml should be renamed to cutip/paths.yaml.\n"
-                        f"  Sensitive values should be moved to cutip/secrets.yaml."
+                        "cutip/vars.yaml should be renamed to cutip/paths.yaml.\n"
+                        "  Sensitive values should be moved to cutip/secrets.yaml."
                     ),
                     file=old,
                     detail="Rename cutip/vars.yaml → cutip/paths.yaml",
@@ -98,7 +99,9 @@ class MissingBackendMigration:
     id = "missing-backend"
     introduced = "0.1.9"
     severity = "warning"
-    description = "cutip.yaml project.backend field required (default changed from podman to docker)"
+    description = (
+        "cutip.yaml project.backend field required (default changed from podman to docker)"
+    )
 
     def detect(self, project_root: Path) -> list[Finding]:
         config = project_root / "cutip.yaml"
@@ -138,7 +141,9 @@ class MissingBackendMigration:
 
     def apply(self, finding: Finding, project_root: Path, **kwargs: object) -> list[Path]:
         if finding.migration_id == "cutip-yaml-project":
-            logger.warning("Skipped: cutip-yaml-project requires manual restructuring of cutip.yaml")
+            logger.warning(
+                "Skipped: cutip-yaml-project requires manual restructuring of cutip.yaml"
+            )
             return []
         backend = kwargs.get("backend", "podman")
         config = project_root / "cutip.yaml"
@@ -298,7 +303,6 @@ class StartupToHooksMigration:
             return []
 
         import ast
-        import textwrap
 
         text = finding.file.read_text(encoding="utf-8")
         tree = ast.parse(text)
@@ -376,8 +380,7 @@ class StartupToHooksMigration:
                 remaining.append("")
                 finding.file.write_text("\n".join(remaining), encoding="utf-8")
                 logger.info(
-                    f"Updated: {finding.file.relative_to(project_root)} "
-                    f"(removed {old_name}())"
+                    f"Updated: {finding.file.relative_to(project_root)} (removed {old_name}())"
                 )
                 modified.append(finding.file)
 
@@ -425,7 +428,9 @@ def apply_findings(
         migration = get_migration(finding.migration_id)
         if migration is None:
             # Sub-findings like "cutip-yaml-project" are handled by their parent migration
-            parent_id = finding.migration_id.rsplit("-", 1)[0] if "-" in finding.migration_id else None
+            parent_id = (
+                finding.migration_id.rsplit("-", 1)[0] if "-" in finding.migration_id else None
+            )
             if parent_id:
                 migration = get_migration(parent_id)
         if migration:

--- a/cutip/upgrade/registry.py
+++ b/cutip/upgrade/registry.py
@@ -1,0 +1,437 @@
+"""Migration registry — extensible scan/detect/apply framework for workspace upgrades.
+
+Each migration is a class with:
+  - id:          unique identifier (e.g. "vars-to-paths")
+  - introduced:  version that introduced the breaking change (e.g. "0.1.8")
+  - severity:    "breaking" or "warning"
+  - detect():    returns list of Finding dicts if the migration applies
+  - apply():     applies the fix for a single finding
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+import yaml
+from loguru import logger
+
+
+# ---------------------------------------------------------------------------
+# Finding — a single detected issue
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    """A single migration finding."""
+
+    migration_id: str
+    severity: str  # "breaking" or "warning"
+    message: str
+    file: Path | None = None
+    detail: str = ""  # human-readable description of what --apply would do
+
+
+# ---------------------------------------------------------------------------
+# Migration protocol
+# ---------------------------------------------------------------------------
+
+
+class Migration(Protocol):
+    id: str
+    introduced: str
+    severity: str
+    description: str
+
+    def detect(self, project_root: Path) -> list[Finding]: ...
+
+    def apply(self, finding: Finding, project_root: Path, **kwargs: object) -> Path | list[Path]:
+        """Apply fix for a single finding. Return list of modified file paths."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Concrete migrations
+# ---------------------------------------------------------------------------
+
+
+class VarsToPathsMigration:
+    """vars.yaml → paths.yaml + secrets.yaml split (v0.1.8)."""
+
+    id = "vars-to-paths"
+    introduced = "0.1.8"
+    severity = "breaking"
+    description = "cutip/vars.yaml was renamed to cutip/paths.yaml; secrets go in cutip/secrets.yaml"
+
+    def detect(self, project_root: Path) -> list[Finding]:
+        old = project_root / "cutip" / "vars.yaml"
+        new_paths = project_root / "cutip" / "paths.yaml"
+        if old.exists() and not new_paths.exists():
+            return [
+                Finding(
+                    migration_id=self.id,
+                    severity=self.severity,
+                    message=(
+                        f"cutip/vars.yaml should be renamed to cutip/paths.yaml.\n"
+                        f"  Sensitive values should be moved to cutip/secrets.yaml."
+                    ),
+                    file=old,
+                    detail="Rename cutip/vars.yaml → cutip/paths.yaml",
+                )
+            ]
+        return []
+
+    def apply(self, finding: Finding, project_root: Path, **kwargs: object) -> list[Path]:
+        old = project_root / "cutip" / "vars.yaml"
+        new = project_root / "cutip" / "paths.yaml"
+        old.rename(new)
+        logger.info("Renamed: cutip/vars.yaml → cutip/paths.yaml")
+        return [new]
+
+
+class MissingBackendMigration:
+    """cutip.yaml missing project.backend field (v0.1.9)."""
+
+    id = "missing-backend"
+    introduced = "0.1.9"
+    severity = "warning"
+    description = "cutip.yaml project.backend field required (default changed from podman to docker)"
+
+    def detect(self, project_root: Path) -> list[Finding]:
+        config = project_root / "cutip.yaml"
+        if not config.exists():
+            return []
+        data = yaml.safe_load(config.read_text(encoding="utf-8")) or {}
+        project = data.get("project")
+        if project is None:
+            return [
+                Finding(
+                    migration_id="cutip-yaml-project",
+                    severity="breaking",
+                    message=(
+                        "cutip.yaml is missing the 'project' section.\n"
+                        "  Expected: apiVersion: cutip/v1 / project: / name: ... / backend: docker"
+                    ),
+                    file=config,
+                    detail="Add project section to cutip.yaml (requires manual restructuring)",
+                )
+            ]
+        if not isinstance(project, dict):
+            return []
+        if "backend" not in project:
+            return [
+                Finding(
+                    migration_id=self.id,
+                    severity=self.severity,
+                    message=(
+                        "cutip.yaml is missing project.backend.\n"
+                        "  Default is now 'docker' (changed from 'podman' in v0.1.9)."
+                    ),
+                    file=config,
+                    detail="Add project.backend to cutip.yaml",
+                )
+            ]
+        return []
+
+    def apply(self, finding: Finding, project_root: Path, **kwargs: object) -> list[Path]:
+        if finding.migration_id == "cutip-yaml-project":
+            logger.warning("Skipped: cutip-yaml-project requires manual restructuring of cutip.yaml")
+            return []
+        backend = kwargs.get("backend", "podman")
+        config = project_root / "cutip.yaml"
+        data = yaml.safe_load(config.read_text(encoding="utf-8")) or {}
+        project = data.get("project", {})
+        project["backend"] = backend
+        data["project"] = project
+        config.write_text(
+            yaml.dump(data, default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )
+        logger.info(f"Added project.backend: {backend} to cutip.yaml")
+        return [config]
+
+
+class CtxVarsRenamedMigration:
+    """ctx.vars → ctx.paths in startup.py files (v0.1.8)."""
+
+    id = "ctx-vars-renamed"
+    introduced = "0.1.8"
+    severity = "breaking"
+    description = "ctx.vars was renamed to ctx.paths in startup.py files"
+
+    def detect(self, project_root: Path) -> list[Finding]:
+        findings: list[Finding] = []
+        units_dir = project_root / "cutip" / "units"
+        if not units_dir.exists():
+            return findings
+        for startup in units_dir.rglob("startup.py"):
+            text = startup.read_text(encoding="utf-8")
+            if "ctx.vars" in text:
+                findings.append(
+                    Finding(
+                        migration_id=self.id,
+                        severity=self.severity,
+                        message=(
+                            f"{startup.relative_to(project_root)}: "
+                            f"ctx.vars was renamed to ctx.paths in v0.1.8."
+                        ),
+                        file=startup,
+                        detail="Replace ctx.vars → ctx.paths",
+                    )
+                )
+        return findings
+
+    def apply(self, finding: Finding, project_root: Path, **kwargs: object) -> list[Path]:
+        if finding.file is None:
+            return []
+        text = finding.file.read_text(encoding="utf-8")
+        updated = text.replace("ctx.vars", "ctx.paths")
+        finding.file.write_text(updated, encoding="utf-8")
+        logger.info(f"Updated: {finding.file} (ctx.vars → ctx.paths)")
+        return [finding.file]
+
+
+class CardVarsRefsMigration:
+    """{{ vars.X }} → {{ paths.X }} in YAML cards (v0.1.8)."""
+
+    id = "card-vars-refs"
+    introduced = "0.1.8"
+    severity = "breaking"
+    description = "{{ vars.X }} template refs renamed to {{ paths.X }}"
+
+    _pattern = re.compile(r"\{\{\s*vars\.\w+\s*\}\}")
+
+    def detect(self, project_root: Path) -> list[Finding]:
+        findings: list[Finding] = []
+        cards_dir = project_root / "cutip" / "cards"
+        if not cards_dir.exists():
+            return findings
+        for yaml_file in cards_dir.rglob("*.yaml"):
+            text = yaml_file.read_text(encoding="utf-8")
+            if self._pattern.search(text):
+                findings.append(
+                    Finding(
+                        migration_id=self.id,
+                        severity=self.severity,
+                        message=(
+                            f"{yaml_file.relative_to(project_root)}: "
+                            f"{{{{ vars.X }}}} should be {{{{ paths.X }}}}."
+                        ),
+                        file=yaml_file,
+                        detail="Replace {{ vars.X }} → {{ paths.X }}",
+                    )
+                )
+        return findings
+
+    def apply(self, finding: Finding, project_root: Path, **kwargs: object) -> list[Path]:
+        if finding.file is None:
+            return []
+        text = finding.file.read_text(encoding="utf-8")
+        updated = re.sub(r"\{\{\s*vars\.(\w+)\s*\}\}", r"{{ paths.\1 }}", text)
+        finding.file.write_text(updated, encoding="utf-8")
+        logger.info(f"Updated: {finding.file} ({{{{ vars.X }}}} → {{{{ paths.X }}}})")
+        return [finding.file]
+
+
+class StartupToHooksMigration:
+    """startup.py with pre_build/startup → prehook.py/posthook.py (v0.2.0)."""
+
+    id = "startup-to-hooks"
+    introduced = "0.2.0"
+    severity = "warning"
+    description = "startup.py pre_build()/startup() should migrate to prehook.py/posthook.py"
+
+    def detect(self, project_root: Path) -> list[Finding]:
+        findings: list[Finding] = []
+        units_dir = project_root / "cutip" / "units"
+        if not units_dir.exists():
+            return findings
+
+        for startup in units_dir.rglob("startup.py"):
+            unit_dir = startup.parent
+            text = startup.read_text(encoding="utf-8")
+
+            has_pre_build = "def pre_build(" in text
+            has_startup = "def startup(" in text
+            has_prehook = (unit_dir / "prehook.py").is_file()
+            has_posthook = (unit_dir / "posthook.py").is_file()
+
+            if has_pre_build and not has_prehook:
+                findings.append(
+                    Finding(
+                        migration_id=self.id,
+                        severity=self.severity,
+                        message=(
+                            f"{startup.relative_to(project_root)}: "
+                            f"pre_build() should move to prehook.py (startup.py is deprecated)."
+                        ),
+                        file=startup,
+                        detail="Extract pre_build() → prehook.py with main(ctx) entry point",
+                    )
+                )
+
+            if has_startup and not has_posthook:
+                findings.append(
+                    Finding(
+                        migration_id=self.id,
+                        severity=self.severity,
+                        message=(
+                            f"{startup.relative_to(project_root)}: "
+                            f"startup() should move to posthook.py (startup.py is deprecated)."
+                        ),
+                        file=startup,
+                        detail="Extract startup() → posthook.py with main(ctx) entry point",
+                    )
+                )
+
+        return findings
+
+    def apply(self, finding: Finding, project_root: Path, **kwargs: object) -> list[Path]:
+        """Extract pre_build/startup from startup.py into prehook.py/posthook.py.
+
+        Preserves imports and helper functions. The new file gets main(ctx) as entry point.
+        """
+        if finding.file is None:
+            return []
+
+        import ast
+        import textwrap
+
+        text = finding.file.read_text(encoding="utf-8")
+        tree = ast.parse(text)
+
+        # Determine which function to extract
+        if "pre_build() should move" in finding.message:
+            old_name = "pre_build"
+            new_file = finding.file.parent / "prehook.py"
+        else:
+            old_name = "startup"
+            new_file = finding.file.parent / "posthook.py"
+
+        if new_file.exists():
+            logger.warning(f"Skipped: {new_file} already exists")
+            return []
+
+        # Collect imports (all lines before first function def)
+        imports: list[str] = []
+        func_body: str | None = None
+
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                imports.append(ast.get_source_segment(text, node) or "")
+            elif isinstance(node, ast.FunctionDef) and node.name == old_name:
+                func_body = ast.get_source_segment(text, node)
+
+        if func_body is None:
+            logger.warning(f"Could not extract {old_name}() from {finding.file}")
+            return []
+
+        # Build the new file: imports + renamed function
+        new_func = func_body.replace(f"def {old_name}(", "def main(", 1)
+
+        parts = []
+        if imports:
+            parts.append("\n".join(imports))
+            parts.append("")
+        parts.append("")
+        parts.append(new_func)
+        parts.append("")
+
+        new_file.write_text("\n".join(parts), encoding="utf-8")
+        logger.info(f"Created: {new_file.relative_to(project_root)} (from {old_name}())")
+
+        modified = [new_file]
+
+        # Remove the extracted function from startup.py if the other function still exists
+        other_name = "startup" if old_name == "pre_build" else "pre_build"
+        has_other = any(
+            isinstance(n, ast.FunctionDef) and n.name == other_name
+            for n in ast.iter_child_nodes(tree)
+        )
+
+        if not has_other:
+            # startup.py only had this one function — it can be deleted
+            finding.file.unlink()
+            logger.info(f"Removed: {finding.file.relative_to(project_root)} (fully migrated)")
+            modified.append(finding.file)
+        else:
+            # Remove the extracted function from startup.py, keep the rest
+            lines = text.split("\n")
+            func_start = None
+            func_end = None
+            for node in ast.iter_child_nodes(tree):
+                if isinstance(node, ast.FunctionDef) and node.name == old_name:
+                    func_start = node.lineno - 1  # 0-indexed
+                    func_end = node.end_lineno  # exclusive
+                    break
+
+            if func_start is not None and func_end is not None:
+                remaining = lines[:func_start] + lines[func_end:]
+                # Remove trailing blank lines from the cut
+                while remaining and remaining[-1].strip() == "":
+                    remaining.pop()
+                remaining.append("")
+                finding.file.write_text("\n".join(remaining), encoding="utf-8")
+                logger.info(
+                    f"Updated: {finding.file.relative_to(project_root)} "
+                    f"(removed {old_name}())"
+                )
+                modified.append(finding.file)
+
+        return modified
+
+
+# ---------------------------------------------------------------------------
+# Registry — ordered list of all migrations
+# ---------------------------------------------------------------------------
+
+
+_MIGRATIONS: list[Migration] = [
+    VarsToPathsMigration(),
+    MissingBackendMigration(),
+    CtxVarsRenamedMigration(),
+    CardVarsRefsMigration(),
+    StartupToHooksMigration(),
+]
+
+
+def scan_migrations(project_root: Path) -> list[Finding]:
+    """Run all migration detectors against a workspace. Returns all findings."""
+    findings: list[Finding] = []
+    for migration in _MIGRATIONS:
+        findings.extend(migration.detect(project_root))
+    return findings
+
+
+def get_migration(migration_id: str) -> Migration | None:
+    """Look up a migration by ID."""
+    for m in _MIGRATIONS:
+        if m.id == migration_id:
+            return m
+    return None
+
+
+def apply_findings(
+    findings: list[Finding],
+    project_root: Path,
+    **kwargs: object,
+) -> list[Path]:
+    """Apply all findings. Returns list of all modified file paths."""
+    modified: list[Path] = []
+    for finding in findings:
+        migration = get_migration(finding.migration_id)
+        if migration is None:
+            # Sub-findings like "cutip-yaml-project" are handled by their parent migration
+            parent_id = finding.migration_id.rsplit("-", 1)[0] if "-" in finding.migration_id else None
+            if parent_id:
+                migration = get_migration(parent_id)
+        if migration:
+            result = migration.apply(finding, project_root, **kwargs)
+            if isinstance(result, list):
+                modified.extend(result)
+            elif isinstance(result, Path):
+                modified.append(result)
+    return modified

--- a/cutip/utils/version.py
+++ b/cutip/utils/version.py
@@ -1,0 +1,60 @@
+"""Version utilities — installed version + PyPI latest check."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+_PYPI_URL = "https://pypi.org/pypi/cutip/json"
+_CACHE_TTL = 3600  # 1 hour
+
+
+def installed_version() -> str:
+    """Return the locally installed cutip version."""
+    return _pkg_version("cutip")
+
+
+def latest_version(cache_dir: Path | None = None) -> str | None:
+    """Check PyPI for the latest cutip version (cached for 1 hour).
+
+    Returns the version string, or None if the check fails (offline, timeout, etc.).
+    """
+    if cache_dir is None:
+        cache_dir = Path(".cutip") / "cache"
+
+    cache_file = cache_dir / "version_check.json"
+
+    # Read cache
+    if cache_file.exists():
+        try:
+            data = json.loads(cache_file.read_text(encoding="utf-8"))
+            if time.time() - data.get("ts", 0) < _CACHE_TTL:
+                return data.get("version")
+        except Exception:
+            pass
+
+    # Fetch from PyPI
+    try:
+        req = urllib.request.Request(_PYPI_URL, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read())
+        ver = payload.get("info", {}).get("version")
+    except Exception:
+        return None
+
+    # Write cache
+    if ver:
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_file.write_text(
+                json.dumps({"version": ver, "ts": time.time()}),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
+
+    return ver

--- a/cutip/workflow/__init__.py
+++ b/cutip/workflow/__init__.py
@@ -2,23 +2,27 @@
 
 Public API::
 
-    from cutip.workflow import action, orchestrator, ActionMeta, extract_action_order
+    from cutip.workflow import action, orchestrator, stage, ActionMeta, StageMeta
 """
 
-from cutip.workflow.decorators import ActionMeta, action, orchestrator
+from cutip.workflow.decorators import ActionMeta, StageMeta, action, orchestrator, stage
 from cutip.workflow.introspect import (
     extract_action_order,
     extract_action_order_from_module,
+    extract_staged_action_order,
     get_module_actions,
     get_orchestrator,
 )
 
 __all__ = [
     "ActionMeta",
+    "StageMeta",
     "action",
     "extract_action_order",
     "extract_action_order_from_module",
+    "extract_staged_action_order",
     "get_module_actions",
     "get_orchestrator",
     "orchestrator",
+    "stage",
 ]

--- a/cutip/workflow/decorators.py
+++ b/cutip/workflow/decorators.py
@@ -15,6 +15,45 @@ _CLEANUP_ATTR = "_cutip_cleanup_meta"
 _CONFIG_ATTR = "_cutip_config_meta"
 
 
+# ---------------------------------------------------------------------------
+# Stage separator
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StageMeta:
+    """Metadata for a stage boundary in the orchestrator."""
+
+    title: str | None = None
+    description: str | None = None
+
+
+def stage(title: str | None = None, description: str | None = None) -> None:
+    """Workflow stage separator. No-op at runtime.
+
+    Parsed by the AST introspector to group actions into named stages
+    for cutip-desktop DAG visualization.
+
+    With no arguments, Desktop labels stages numerically (Stage 1, Stage 2, ...).
+    With title/description, Desktop shows the stage header and detail panel.
+
+    Usage::
+
+        @orchestrator
+        def main(ctx):
+            stage("Pre-op Validation", description="Verify SSH, K8s resources, and file integrity")
+            validate_ssh(ctx, sesh)
+            check_deploy(ctx, sesh, ns, deploy)
+
+            stage("Operations")
+            enable_keycloak(ctx, sesh, script)
+            patch_handler(ctx, sesh, ns, deploy, patch)
+
+            stage()  # Desktop shows "Stage 3"
+            verify_pod(ctx, sesh, ns, deploy)
+    """
+
+
 @dataclass(frozen=True)
 class ActionMeta:
     """Metadata attached to an ``@action``-decorated function."""

--- a/cutip/workflow/introspect.py
+++ b/cutip/workflow/introspect.py
@@ -170,14 +170,10 @@ def extract_staged_action_order(workflow_path: Path) -> list[StageGroup]:
         return [StageGroup(stage=StageMeta(), actions=[action_funcs[n] for n in all_actions])]
 
     # Number untitled stages
-    stage_counter = 0
-    for group in groups:
-        stage_counter += 1
+    for i, group in enumerate(groups):
         if group.stage.title is None:
-            # Replace with numbered stage — need to create new frozen instance
-            numbered = StageMeta(title=f"Stage {stage_counter}", description=group.stage.description)
-            # Since StageGroup is frozen, rebuild it
-            groups[groups.index(group)] = StageGroup(stage=numbered, actions=group.actions)
+            numbered = StageMeta(title=f"Stage {i + 1}", description=group.stage.description)
+            groups[i] = StageGroup(stage=numbered, actions=group.actions)
 
     return groups
 
@@ -271,9 +267,9 @@ def _extract_stage_call(stmt: ast.stmt) -> StageMeta | None:
 
     # Match stage(...) or workflow.stage(...)
     is_stage = False
-    if isinstance(func, ast.Name) and func.id == "stage":
-        is_stage = True
-    elif isinstance(func, ast.Attribute) and func.attr == "stage":
+    if (isinstance(func, ast.Name) and func.id == "stage") or (
+        isinstance(func, ast.Attribute) and func.attr == "stage"
+    ):
         is_stage = True
 
     if not is_stage:
@@ -291,9 +287,17 @@ def _extract_stage_call(stmt: ast.stmt) -> StageMeta | None:
 
     # Keyword arguments
     for kw in call.keywords:
-        if kw.arg == "title" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+        if (
+            kw.arg == "title"
+            and isinstance(kw.value, ast.Constant)
+            and isinstance(kw.value.value, str)
+        ):
             title = kw.value.value
-        elif kw.arg == "description" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+        elif (
+            kw.arg == "description"
+            and isinstance(kw.value, ast.Constant)
+            and isinstance(kw.value.value, str)
+        ):
             description = kw.value.value
 
     return StageMeta(title=title, description=description)

--- a/cutip/workflow/introspect.py
+++ b/cutip/workflow/introspect.py
@@ -16,6 +16,7 @@ from cutip.workflow.decorators import (
     ConfigMeta,
     HealthcheckMeta,
     HookMeta,
+    StageMeta,
 )
 
 
@@ -102,6 +103,200 @@ def extract_action_order_from_module(module: ModuleType) -> list[ActionMeta]:
     # No file available — fall back to runtime introspection
     actions = get_module_actions(module)
     return list(actions.values())
+
+
+@dataclass(frozen=True)
+class StageGroup:
+    """A group of actions belonging to a named stage."""
+
+    stage: StageMeta
+    actions: list[ActionMeta] = field(default_factory=list)
+
+
+def extract_staged_action_order(workflow_path: Path) -> list[StageGroup]:
+    """Extract actions grouped by stage() separators from a workflow file.
+
+    Returns a list of StageGroup objects. Each group contains a StageMeta
+    (with optional title/description) and the actions that follow that stage()
+    call until the next stage() or end of orchestrator body.
+
+    Actions before any stage() call are placed in an implicit first group
+    with no title (Desktop may render these outside any stage lane, or as
+    setup/teardown).
+
+    If no stage() calls are found, returns a single StageGroup containing
+    all actions.
+    """
+    source = workflow_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(workflow_path))
+
+    # Find action-decorated functions
+    action_funcs: dict[str, ActionMeta] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for deco in node.decorator_list:
+            if _is_action_decorator(deco):
+                meta = _extract_meta_from_decorator(deco)
+                if meta is not None:
+                    action_funcs[node.name] = meta
+                break
+
+    if not action_funcs:
+        return []
+
+    # Find orchestrator body
+    orch_body = _find_orchestrator_body(tree)
+    if orch_body is None:
+        return [StageGroup(stage=StageMeta(), actions=list(action_funcs.values()))]
+
+    # Walk body collecting stage boundaries and action calls
+    groups: list[StageGroup] = []
+    current_stage = StageMeta()
+    current_actions: list[ActionMeta] = []
+
+    current_stage, current_actions = _collect_staged_items(
+        orch_body, action_funcs, groups, current_stage, current_actions
+    )
+
+    # Flush remaining actions
+    if current_actions:
+        groups.append(StageGroup(stage=current_stage, actions=list(current_actions)))
+
+    # If no stages were found, return single group with all actions
+    if not groups:
+        all_actions: list[str] = []
+        _collect_action_calls(orch_body, action_funcs, all_actions)
+        return [StageGroup(stage=StageMeta(), actions=[action_funcs[n] for n in all_actions])]
+
+    # Number untitled stages
+    stage_counter = 0
+    for group in groups:
+        stage_counter += 1
+        if group.stage.title is None:
+            # Replace with numbered stage — need to create new frozen instance
+            numbered = StageMeta(title=f"Stage {stage_counter}", description=group.stage.description)
+            # Since StageGroup is frozen, rebuild it
+            groups[groups.index(group)] = StageGroup(stage=numbered, actions=group.actions)
+
+    return groups
+
+
+def _collect_staged_items(
+    stmts: list[ast.stmt],
+    action_funcs: dict[str, ActionMeta],
+    groups: list[StageGroup],
+    current_stage: StageMeta,
+    current_actions: list[ActionMeta],
+) -> tuple[StageMeta, list[ActionMeta]]:
+    """Walk statements collecting stage() boundaries and action calls."""
+    for stmt in stmts:
+        # Check for stage() call
+        stage_meta = _extract_stage_call(stmt)
+        if stage_meta is not None:
+            # Flush current group if it has actions
+            if current_actions:
+                groups.append(StageGroup(stage=current_stage, actions=list(current_actions)))
+                current_actions.clear()
+            current_stage = stage_meta
+            continue
+
+        # Check for action call
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            func = stmt.value.func
+            if isinstance(func, ast.Name) and func.id in action_funcs:
+                current_actions.append(action_funcs[func.id])
+                continue
+
+        # Assignment with action call
+        if isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+            value = stmt.value
+            if isinstance(value, ast.Call):
+                func = value.func
+                if isinstance(func, ast.Name) and func.id in action_funcs:
+                    current_actions.append(action_funcs[func.id])
+                    continue
+
+        # Recurse into with blocks (ssh.session, etc.)
+        if isinstance(stmt, ast.With):
+            current_stage, current_actions = _collect_staged_items_with_state(
+                stmt.body, action_funcs, groups, current_stage, current_actions
+            )
+            continue
+
+        # Recurse into if/for/while/try
+        if isinstance(stmt, ast.If):
+            current_stage, current_actions = _collect_staged_items_with_state(
+                stmt.body, action_funcs, groups, current_stage, current_actions
+            )
+            current_stage, current_actions = _collect_staged_items_with_state(
+                stmt.orelse, action_funcs, groups, current_stage, current_actions
+            )
+        elif isinstance(stmt, (ast.For, ast.While)):
+            current_stage, current_actions = _collect_staged_items_with_state(
+                stmt.body, action_funcs, groups, current_stage, current_actions
+            )
+        elif isinstance(stmt, ast.Try):
+            current_stage, current_actions = _collect_staged_items_with_state(
+                stmt.body, action_funcs, groups, current_stage, current_actions
+            )
+            for handler in stmt.handlers:
+                current_stage, current_actions = _collect_staged_items_with_state(
+                    handler.body, action_funcs, groups, current_stage, current_actions
+                )
+
+    return current_stage, current_actions
+
+
+def _collect_staged_items_with_state(
+    stmts: list[ast.stmt],
+    action_funcs: dict[str, ActionMeta],
+    groups: list[StageGroup],
+    current_stage: StageMeta,
+    current_actions: list[ActionMeta],
+) -> tuple[StageMeta, list[ActionMeta]]:
+    """Wrapper that threads mutable state through recursive calls."""
+    return _collect_staged_items(stmts, action_funcs, groups, current_stage, current_actions)
+
+
+def _extract_stage_call(stmt: ast.stmt) -> StageMeta | None:
+    """Check if a statement is a stage() call and extract its metadata."""
+    if not isinstance(stmt, ast.Expr):
+        return None
+    if not isinstance(stmt.value, ast.Call):
+        return None
+
+    call = stmt.value
+    func = call.func
+
+    # Match stage(...) or workflow.stage(...)
+    is_stage = False
+    if isinstance(func, ast.Name) and func.id == "stage":
+        is_stage = True
+    elif isinstance(func, ast.Attribute) and func.attr == "stage":
+        is_stage = True
+
+    if not is_stage:
+        return None
+
+    # Extract title and description
+    title: str | None = None
+    description: str | None = None
+
+    # Positional: first arg is title
+    if call.args:
+        first = call.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            title = first.value
+
+    # Keyword arguments
+    for kw in call.keywords:
+        if kw.arg == "title" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            title = kw.value.value
+        elif kw.arg == "description" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            description = kw.value.value
+
+    return StageMeta(title=title, description=description)
 
 
 def _is_action_decorator(deco: ast.expr) -> bool:

--- a/tests/test_stage_parsing.py
+++ b/tests/test_stage_parsing.py
@@ -3,7 +3,6 @@
 import textwrap
 from pathlib import Path
 
-from cutip.workflow.decorators import StageMeta
 from cutip.workflow.introspect import extract_staged_action_order
 
 
@@ -14,7 +13,9 @@ def _write_workflow(tmp_path: Path, code: str) -> Path:
 
 
 def test_no_stages_returns_single_group(tmp_path):
-    path = _write_workflow(tmp_path, """\
+    path = _write_workflow(
+        tmp_path,
+        """\
         from cutip.workflow import action, orchestrator
 
         @action(name="A")
@@ -27,7 +28,8 @@ def test_no_stages_returns_single_group(tmp_path):
         def main(ctx):
             a(ctx)
             b(ctx)
-    """)
+    """,
+    )
     groups = extract_staged_action_order(path)
     assert len(groups) == 1
     assert len(groups[0].actions) == 2
@@ -36,7 +38,9 @@ def test_no_stages_returns_single_group(tmp_path):
 
 
 def test_titled_stages_group_actions(tmp_path):
-    path = _write_workflow(tmp_path, """\
+    path = _write_workflow(
+        tmp_path,
+        """\
         from cutip.workflow import action, orchestrator, stage
 
         @action(name="Check SSH")
@@ -62,7 +66,8 @@ def test_titled_stages_group_actions(tmp_path):
 
             stage("Post-check")
             verify(ctx)
-    """)
+    """,
+    )
     groups = extract_staged_action_order(path)
     assert len(groups) == 3
 
@@ -81,7 +86,9 @@ def test_titled_stages_group_actions(tmp_path):
 
 
 def test_untitled_stages_get_numbered(tmp_path):
-    path = _write_workflow(tmp_path, """\
+    path = _write_workflow(
+        tmp_path,
+        """\
         from cutip.workflow import action, orchestrator, stage
 
         @action(name="A")
@@ -97,7 +104,8 @@ def test_untitled_stages_get_numbered(tmp_path):
 
             stage()
             b(ctx)
-    """)
+    """,
+    )
     groups = extract_staged_action_order(path)
     assert len(groups) == 2
     assert groups[0].stage.title == "Stage 1"
@@ -105,7 +113,9 @@ def test_untitled_stages_get_numbered(tmp_path):
 
 
 def test_mixed_titled_and_untitled(tmp_path):
-    path = _write_workflow(tmp_path, """\
+    path = _write_workflow(
+        tmp_path,
+        """\
         from cutip.workflow import action, orchestrator, stage
 
         @action(name="A")
@@ -127,7 +137,8 @@ def test_mixed_titled_and_untitled(tmp_path):
 
             stage()
             c(ctx)
-    """)
+    """,
+    )
     groups = extract_staged_action_order(path)
     assert len(groups) == 3
     assert groups[0].stage.title == "Stage 1"
@@ -136,7 +147,9 @@ def test_mixed_titled_and_untitled(tmp_path):
 
 
 def test_stage_with_description(tmp_path):
-    path = _write_workflow(tmp_path, """\
+    path = _write_workflow(
+        tmp_path,
+        """\
         from cutip.workflow import action, orchestrator, stage
 
         @action(name="A")
@@ -146,7 +159,8 @@ def test_stage_with_description(tmp_path):
         def main(ctx):
             stage("Setup", description="Initialize all resources")
             a(ctx)
-    """)
+    """,
+    )
     groups = extract_staged_action_order(path)
     assert len(groups) == 1
     assert groups[0].stage.title == "Setup"
@@ -155,7 +169,9 @@ def test_stage_with_description(tmp_path):
 
 def test_stages_inside_with_block(tmp_path):
     """Stages inside a `with` block (like ssh.session) should be detected."""
-    path = _write_workflow(tmp_path, """\
+    path = _write_workflow(
+        tmp_path,
+        """\
         from cutip.workflow import action, orchestrator, stage
 
         @action(name="Check")
@@ -172,7 +188,8 @@ def test_stages_inside_with_block(tmp_path):
 
                 stage("Execute")
                 deploy(ctx)
-    """)
+    """,
+    )
     groups = extract_staged_action_order(path)
     assert len(groups) == 2
     assert groups[0].stage.title == "Validate"
@@ -183,7 +200,9 @@ def test_stages_inside_with_block(tmp_path):
 
 def test_actions_before_first_stage(tmp_path):
     """Actions before the first stage() go into an implicit group."""
-    path = _write_workflow(tmp_path, """\
+    path = _write_workflow(
+        tmp_path,
+        """\
         from cutip.workflow import action, orchestrator, stage
 
         @action(name="Init")
@@ -198,7 +217,8 @@ def test_actions_before_first_stage(tmp_path):
 
             stage("Main Work")
             work(ctx)
-    """)
+    """,
+    )
     groups = extract_staged_action_order(path)
     assert len(groups) == 2
     # First group has the pre-stage action, numbered
@@ -208,12 +228,15 @@ def test_actions_before_first_stage(tmp_path):
 
 
 def test_no_actions_returns_empty(tmp_path):
-    path = _write_workflow(tmp_path, """\
+    path = _write_workflow(
+        tmp_path,
+        """\
         from cutip.workflow import orchestrator
 
         @orchestrator
         def main(ctx):
             pass
-    """)
+    """,
+    )
     groups = extract_staged_action_order(path)
     assert len(groups) == 0

--- a/tests/test_stage_parsing.py
+++ b/tests/test_stage_parsing.py
@@ -1,0 +1,219 @@
+"""Tests for stage() boundary detection in AST parser."""
+
+import textwrap
+from pathlib import Path
+
+from cutip.workflow.decorators import StageMeta
+from cutip.workflow.introspect import extract_staged_action_order
+
+
+def _write_workflow(tmp_path: Path, code: str) -> Path:
+    p = tmp_path / "workflow.py"
+    p.write_text(textwrap.dedent(code), encoding="utf-8")
+    return p
+
+
+def test_no_stages_returns_single_group(tmp_path):
+    path = _write_workflow(tmp_path, """\
+        from cutip.workflow import action, orchestrator
+
+        @action(name="A")
+        def a(ctx): pass
+
+        @action(name="B")
+        def b(ctx): pass
+
+        @orchestrator
+        def main(ctx):
+            a(ctx)
+            b(ctx)
+    """)
+    groups = extract_staged_action_order(path)
+    assert len(groups) == 1
+    assert len(groups[0].actions) == 2
+    assert groups[0].actions[0].name == "A"
+    assert groups[0].actions[1].name == "B"
+
+
+def test_titled_stages_group_actions(tmp_path):
+    path = _write_workflow(tmp_path, """\
+        from cutip.workflow import action, orchestrator, stage
+
+        @action(name="Check SSH")
+        def check_ssh(ctx): pass
+
+        @action(name="Check DB")
+        def check_db(ctx): pass
+
+        @action(name="Deploy")
+        def deploy(ctx): pass
+
+        @action(name="Verify")
+        def verify(ctx): pass
+
+        @orchestrator
+        def main(ctx):
+            stage("Validation")
+            check_ssh(ctx)
+            check_db(ctx)
+
+            stage("Operations")
+            deploy(ctx)
+
+            stage("Post-check")
+            verify(ctx)
+    """)
+    groups = extract_staged_action_order(path)
+    assert len(groups) == 3
+
+    assert groups[0].stage.title == "Validation"
+    assert len(groups[0].actions) == 2
+    assert groups[0].actions[0].name == "Check SSH"
+    assert groups[0].actions[1].name == "Check DB"
+
+    assert groups[1].stage.title == "Operations"
+    assert len(groups[1].actions) == 1
+    assert groups[1].actions[0].name == "Deploy"
+
+    assert groups[2].stage.title == "Post-check"
+    assert len(groups[2].actions) == 1
+    assert groups[2].actions[0].name == "Verify"
+
+
+def test_untitled_stages_get_numbered(tmp_path):
+    path = _write_workflow(tmp_path, """\
+        from cutip.workflow import action, orchestrator, stage
+
+        @action(name="A")
+        def a(ctx): pass
+
+        @action(name="B")
+        def b(ctx): pass
+
+        @orchestrator
+        def main(ctx):
+            stage()
+            a(ctx)
+
+            stage()
+            b(ctx)
+    """)
+    groups = extract_staged_action_order(path)
+    assert len(groups) == 2
+    assert groups[0].stage.title == "Stage 1"
+    assert groups[1].stage.title == "Stage 2"
+
+
+def test_mixed_titled_and_untitled(tmp_path):
+    path = _write_workflow(tmp_path, """\
+        from cutip.workflow import action, orchestrator, stage
+
+        @action(name="A")
+        def a(ctx): pass
+
+        @action(name="B")
+        def b(ctx): pass
+
+        @action(name="C")
+        def c(ctx): pass
+
+        @orchestrator
+        def main(ctx):
+            stage()
+            a(ctx)
+
+            stage("Operations")
+            b(ctx)
+
+            stage()
+            c(ctx)
+    """)
+    groups = extract_staged_action_order(path)
+    assert len(groups) == 3
+    assert groups[0].stage.title == "Stage 1"
+    assert groups[1].stage.title == "Operations"
+    assert groups[2].stage.title == "Stage 3"
+
+
+def test_stage_with_description(tmp_path):
+    path = _write_workflow(tmp_path, """\
+        from cutip.workflow import action, orchestrator, stage
+
+        @action(name="A")
+        def a(ctx): pass
+
+        @orchestrator
+        def main(ctx):
+            stage("Setup", description="Initialize all resources")
+            a(ctx)
+    """)
+    groups = extract_staged_action_order(path)
+    assert len(groups) == 1
+    assert groups[0].stage.title == "Setup"
+    assert groups[0].stage.description == "Initialize all resources"
+
+
+def test_stages_inside_with_block(tmp_path):
+    """Stages inside a `with` block (like ssh.session) should be detected."""
+    path = _write_workflow(tmp_path, """\
+        from cutip.workflow import action, orchestrator, stage
+
+        @action(name="Check")
+        def check(ctx): pass
+
+        @action(name="Deploy")
+        def deploy(ctx): pass
+
+        @orchestrator
+        def main(ctx):
+            with some_context() as conn:
+                stage("Validate")
+                check(ctx)
+
+                stage("Execute")
+                deploy(ctx)
+    """)
+    groups = extract_staged_action_order(path)
+    assert len(groups) == 2
+    assert groups[0].stage.title == "Validate"
+    assert groups[0].actions[0].name == "Check"
+    assert groups[1].stage.title == "Execute"
+    assert groups[1].actions[0].name == "Deploy"
+
+
+def test_actions_before_first_stage(tmp_path):
+    """Actions before the first stage() go into an implicit group."""
+    path = _write_workflow(tmp_path, """\
+        from cutip.workflow import action, orchestrator, stage
+
+        @action(name="Init")
+        def init(ctx): pass
+
+        @action(name="Work")
+        def work(ctx): pass
+
+        @orchestrator
+        def main(ctx):
+            init(ctx)
+
+            stage("Main Work")
+            work(ctx)
+    """)
+    groups = extract_staged_action_order(path)
+    assert len(groups) == 2
+    # First group has the pre-stage action, numbered
+    assert groups[0].actions[0].name == "Init"
+    assert groups[1].stage.title == "Main Work"
+    assert groups[1].actions[0].name == "Work"
+
+
+def test_no_actions_returns_empty(tmp_path):
+    path = _write_workflow(tmp_path, """\
+        from cutip.workflow import orchestrator
+
+        @orchestrator
+        def main(ctx):
+            pass
+    """)
+    groups = extract_staged_action_order(path)
+    assert len(groups) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "0.1.15"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## Summary

- Adds `cutip info` PyPI version check with cached lookups
- Adds `cutip upgrade` with extensible migration registry (5 migrations), dry-run table, `--apply` with git staging
- Adds `cutip diff` command for previewing pending or staged migration changes
- Adds `stage()` workflow separator for cutip-desktop DAG pipeline lanes
- Adds `extract_staged_action_order()` AST parser that groups actions by stage boundaries
- Documents common command workflows in `cutip --help` epilog
- Fixes `__version__` from 0.1.0 to 0.2.2

## Changes

- `cutip/cli/commands/info.py`: PyPI version check + migration count hint
- `cutip/cli/commands/upgrade.py`: Extensible migration registry, table output, git staging
- `cutip/cli/commands/diff.py`: New command — preview or review staged changes
- `cutip/cli/main.py`: Registered `diff`, updated epilog with command workflows
- `cutip/upgrade/registry.py`: 5 migration classes (vars-to-paths, missing-backend, ctx-vars, card-vars-refs, startup-to-hooks)
- `cutip/utils/version.py`: PyPI version check with 1hr cache
- `cutip/workflow/decorators.py`: `stage()` function + `StageMeta` dataclass
- `cutip/workflow/introspect.py`: `extract_staged_action_order()` + `StageGroup` dataclass
- `cutip/workflow/__init__.py`: Exports stage, StageMeta, extract_staged_action_order
- `tests/test_stage_parsing.py`: 8 tests for stage boundary detection

## Test plan

- [x] `uv run pytest tests/ -v --ignore=tests/e2e` passes (65/65)
- [x] `cutip info` shows version status against real consumer projects
- [x] `cutip upgrade` dry-run detects startup.py → prehook/posthook migrations
- [x] `cutip diff` shows pending changes before apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)