### PR TITLE
[cap062] validate paths/secrets, cutip ping, compile→graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
             -o /tmp/react-nginx.yaml
           mkdir -p /tmp/fc-react-nginx
           uv run cutip from-compose /tmp/react-nginx.yaml --output-dir /tmp/fc-react-nginx
-          uv run cutip validate --path /tmp/fc-react-nginx
+          uv run cutip validate --graph-only --path /tmp/fc-react-nginx
 
       - name: "from-compose · fastapi"
         run: |
@@ -207,7 +207,7 @@ jobs:
             -o /tmp/fastapi.yaml
           mkdir -p /tmp/fc-fastapi
           uv run cutip from-compose /tmp/fastapi.yaml --output-dir /tmp/fc-fastapi
-          uv run cutip validate --path /tmp/fc-fastapi
+          uv run cutip validate --graph-only --path /tmp/fc-fastapi
 
       - name: "from-compose · nginx-flask-mongo"
         run: |
@@ -215,7 +215,7 @@ jobs:
             -o /tmp/nginx-flask-mongo.yaml
           mkdir -p /tmp/fc-nginx-flask-mongo
           uv run cutip from-compose /tmp/nginx-flask-mongo.yaml --output-dir /tmp/fc-nginx-flask-mongo
-          uv run cutip validate --path /tmp/fc-nginx-flask-mongo
+          uv run cutip validate --graph-only --path /tmp/fc-nginx-flask-mongo
 
       - name: "from-compose · prometheus-grafana"
         run: |
@@ -223,7 +223,7 @@ jobs:
             -o /tmp/prometheus-grafana.yaml
           mkdir -p /tmp/fc-prometheus-grafana
           uv run cutip from-compose /tmp/prometheus-grafana.yaml --output-dir /tmp/fc-prometheus-grafana
-          uv run cutip validate --path /tmp/fc-prometheus-grafana
+          uv run cutip validate --graph-only --path /tmp/fc-prometheus-grafana
 
       - name: "from-compose · angular"
         run: |
@@ -231,7 +231,7 @@ jobs:
             -o /tmp/angular.yaml
           mkdir -p /tmp/fc-angular
           uv run cutip from-compose /tmp/angular.yaml --output-dir /tmp/fc-angular
-          uv run cutip validate --path /tmp/fc-angular
+          uv run cutip validate --graph-only --path /tmp/fc-angular
 
   # ── E2E · Docker · Ubuntu ──────────────────────────────────────────────────
   e2e-docker-ubuntu:
@@ -271,7 +271,7 @@ jobs:
             -o /tmp/react-nginx.yaml
           mkdir -p /tmp/fc-react-nginx
           uv run cutip from-compose /tmp/react-nginx.yaml --output-dir /tmp/fc-react-nginx
-          uv run cutip validate --path /tmp/fc-react-nginx
+          uv run cutip validate --graph-only --path /tmp/fc-react-nginx
 
       - name: "from-compose · fastapi"
         run: |
@@ -279,7 +279,7 @@ jobs:
             -o /tmp/fastapi.yaml
           mkdir -p /tmp/fc-fastapi
           uv run cutip from-compose /tmp/fastapi.yaml --output-dir /tmp/fc-fastapi
-          uv run cutip validate --path /tmp/fc-fastapi
+          uv run cutip validate --graph-only --path /tmp/fc-fastapi
 
       - name: "from-compose · nginx-flask-mongo"
         run: |
@@ -287,7 +287,7 @@ jobs:
             -o /tmp/nginx-flask-mongo.yaml
           mkdir -p /tmp/fc-nginx-flask-mongo
           uv run cutip from-compose /tmp/nginx-flask-mongo.yaml --output-dir /tmp/fc-nginx-flask-mongo
-          uv run cutip validate --path /tmp/fc-nginx-flask-mongo
+          uv run cutip validate --graph-only --path /tmp/fc-nginx-flask-mongo
 
       - name: "from-compose · prometheus-grafana"
         run: |
@@ -295,7 +295,7 @@ jobs:
             -o /tmp/prometheus-grafana.yaml
           mkdir -p /tmp/fc-prometheus-grafana
           uv run cutip from-compose /tmp/prometheus-grafana.yaml --output-dir /tmp/fc-prometheus-grafana
-          uv run cutip validate --path /tmp/fc-prometheus-grafana
+          uv run cutip validate --graph-only --path /tmp/fc-prometheus-grafana
 
       - name: "from-compose · angular"
         run: |
@@ -303,7 +303,7 @@ jobs:
             -o /tmp/angular.yaml
           mkdir -p /tmp/fc-angular
           uv run cutip from-compose /tmp/angular.yaml --output-dir /tmp/fc-angular
-          uv run cutip validate --path /tmp/fc-angular
+          uv run cutip validate --graph-only --path /tmp/fc-angular
 
   # ── E2E · Windows ───────────────────────────────────────────────────────────
   e2e-podman-windows:
@@ -364,7 +364,7 @@ jobs:
             -OutFile "$env:TEMP\react-nginx.yaml"
           New-Item -ItemType Directory -Force "$env:TEMP\fc-react-nginx" | Out-Null
           uv run cutip from-compose "$env:TEMP\react-nginx.yaml" --output-dir "$env:TEMP\fc-react-nginx"
-          uv run cutip validate --path "$env:TEMP\fc-react-nginx"
+          uv run cutip validate --graph-only --path "$env:TEMP\fc-react-nginx"
 
       - name: "from-compose · fastapi (Windows)"
         shell: pwsh
@@ -373,7 +373,7 @@ jobs:
             -OutFile "$env:TEMP\fastapi.yaml"
           New-Item -ItemType Directory -Force "$env:TEMP\fc-fastapi" | Out-Null
           uv run cutip from-compose "$env:TEMP\fastapi.yaml" --output-dir "$env:TEMP\fc-fastapi"
-          uv run cutip validate --path "$env:TEMP\fc-fastapi"
+          uv run cutip validate --graph-only --path "$env:TEMP\fc-fastapi"
 
       - name: "from-compose · nginx-flask-mongo (Windows)"
         shell: pwsh
@@ -382,7 +382,7 @@ jobs:
             -OutFile "$env:TEMP\nginx-flask-mongo.yaml"
           New-Item -ItemType Directory -Force "$env:TEMP\fc-nginx-flask-mongo" | Out-Null
           uv run cutip from-compose "$env:TEMP\nginx-flask-mongo.yaml" --output-dir "$env:TEMP\fc-nginx-flask-mongo"
-          uv run cutip validate --path "$env:TEMP\fc-nginx-flask-mongo"
+          uv run cutip validate --graph-only --path "$env:TEMP\fc-nginx-flask-mongo"
 
       - name: "from-compose · prometheus-grafana (Windows)"
         shell: pwsh
@@ -391,7 +391,7 @@ jobs:
             -OutFile "$env:TEMP\prometheus-grafana.yaml"
           New-Item -ItemType Directory -Force "$env:TEMP\fc-prometheus-grafana" | Out-Null
           uv run cutip from-compose "$env:TEMP\prometheus-grafana.yaml" --output-dir "$env:TEMP\fc-prometheus-grafana"
-          uv run cutip validate --path "$env:TEMP\fc-prometheus-grafana"
+          uv run cutip validate --graph-only --path "$env:TEMP\fc-prometheus-grafana"
 
       - name: "from-compose · angular (Windows)"
         shell: pwsh
@@ -400,7 +400,7 @@ jobs:
             -OutFile "$env:TEMP\angular.yaml"
           New-Item -ItemType Directory -Force "$env:TEMP\fc-angular" | Out-Null
           uv run cutip from-compose "$env:TEMP\angular.yaml" --output-dir "$env:TEMP\fc-angular"
-          uv run cutip validate --path "$env:TEMP\fc-angular"
+          uv run cutip validate --graph-only --path "$env:TEMP\fc-angular"
 
   # ── Install & Validate · macOS ──────────────────────────────────────────────
   install-validate-macos:

--- a/cutip/cli/commands/ping.py
+++ b/cutip/cli/commands/ping.py
@@ -1,0 +1,85 @@
+"""cutip ping — test backend connectivity."""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+
+def ping(
+    backend: str = typer.Option(
+        None,
+        "--backend",
+        "-b",
+        help="Backend to test (docker or podman). Auto-detected if omitted.",
+    ),
+) -> None:
+    """Test connection to the container runtime engine.
+
+    Pings the Docker or Podman API and prints the runtime version.
+    Use this as a quick pre-flight check before cutip run.
+
+    Pre-run workflow:
+      cutip ping → cutip validate → cutip run GROUP
+    """
+    if backend is None:
+        try:
+            from cutip.cli.commands.run import _load_project_backend
+            from cutip.workspace.scaffold import _find_project_root
+
+            backend = _load_project_backend(_find_project_root())
+        except Exception:
+            backend = "docker"
+
+    console.print(f"Pinging [bold]{backend}[/bold]...")
+
+    try:
+        if backend == "podman":
+            from podman import PodmanClient
+
+            from cutip.backends.podman.connection import local_socket_url
+
+            url = local_socket_url()
+            client = PodmanClient(base_url=url)
+            client.ping()
+            ver = client.version()
+            version_str = ver.get("Version", "unknown")
+            client.close()
+            console.print(f"[green]Podman {version_str} — running[/green]")
+
+        else:
+            import docker
+
+            client = docker.from_env()
+            client.ping()
+            info = client.version()
+            version_str = info.get("Version", "unknown")
+            client.close()
+            console.print(f"[green]Docker {version_str} — running[/green]")
+
+    except Exception as e:
+        console.print(f"[red]{backend} is not reachable: {e}[/red]")
+        console.print()
+
+        # Platform-specific start hints
+        import platform
+
+        hints = {
+            "podman": {
+                "Darwin": "podman machine start",
+                "Windows": "podman machine start",
+                "Linux": "systemctl --user start podman.socket",
+            },
+            "docker": {
+                "Darwin": "open -a Docker",
+                "Windows": "Start Docker Desktop",
+                "Linux": "sudo systemctl start docker",
+            },
+        }
+        hint = hints.get(backend, {}).get(platform.system())
+        if hint:
+            console.print(f"Try: [cyan]{hint}[/cyan]")
+
+        raise typer.Exit(1)

--- a/cutip/cli/commands/validate.py
+++ b/cutip/cli/commands/validate.py
@@ -1,8 +1,11 @@
+"""cutip validate — static validation of the CUTIP workspace graph + configuration."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import typer
+import yaml
 from rich.console import Console
 
 from cutip.utils.logging import setup_logging
@@ -14,6 +17,61 @@ console = Console()
 app = typer.Typer()
 
 
+def _validate_paths_secrets(project_root: Path) -> list[str]:
+    """Check that all required paths and secrets are non-empty."""
+    errors: list[str] = []
+
+    # paths.yaml
+    paths_file = project_root / "cutip" / "paths.yaml"
+    if paths_file.exists():
+        data = yaml.safe_load(paths_file.read_text(encoding="utf-8")) or {}
+        if isinstance(data, dict):
+            req = data.get(
+                "required", data if "required" not in data and "generated" not in data else {}
+            )
+            if isinstance(req, dict):
+                for key, val in req.items():
+                    if val is None or not str(val).strip():
+                        errors.append(f"paths.yaml: required key '{key}' is empty")
+
+    # secrets.yaml
+    secrets_file = project_root / "cutip" / "secrets.yaml"
+    if secrets_file.exists():
+        data = yaml.safe_load(secrets_file.read_text(encoding="utf-8")) or {}
+        if isinstance(data, dict):
+            req = data.get("required", data if "required" not in data else {})
+            if isinstance(req, dict):
+                for key, val in req.items():
+                    if val is None or not str(val).strip():
+                        errors.append(f"secrets.yaml: required key '{key}' is empty")
+
+    return errors
+
+
+def _validate_config(project_root: Path) -> list[str]:
+    """Check that config.yaml exists if referenced in cutip.yaml."""
+    errors: list[str] = []
+
+    cutip_yaml = project_root / "cutip.yaml"
+    if not cutip_yaml.exists():
+        return errors
+
+    data = yaml.safe_load(cutip_yaml.read_text(encoding="utf-8")) or {}
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return errors
+
+    config_path_str = project.get("config")
+    if not config_path_str:
+        return errors
+
+    config_path = project_root / config_path_str
+    if not config_path.is_file():
+        errors.append(f"config: '{config_path_str}' referenced in cutip.yaml but file not found")
+
+    return errors
+
+
 @app.callback(invoke_without_command=True)
 def validate(
     path: Path = typer.Option(
@@ -23,8 +81,20 @@ def validate(
         help="Project root. Defaults to nearest cutip.yaml, git root, or cwd.",
         show_default=False,
     ),
+    graph_only: bool = typer.Option(
+        False,
+        "--graph-only",
+        help="Only validate the artifact graph (skip paths/secrets/config checks).",
+    ),
 ) -> None:
-    """Validate the CUTIP configuration graph."""
+    """Validate the CUTIP workspace: artifact graph + static configuration.
+
+    Checks:
+      1. Artifact graph — all refs resolve (unit → container → image → network)
+      2. paths.yaml — all required keys are non-empty
+      3. secrets.yaml — all required keys are non-empty
+      4. config.yaml — exists if referenced in cutip.yaml
+    """
     setup_logging()
     project_root = path or _find_project_root()
     discovery = WorkspaceDiscovery(project_root)
@@ -35,13 +105,29 @@ def validate(
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)
 
+    all_errors: list[str] = []
+
+    # 1. Graph validation
     validator = GraphValidator(registry, project_root=project_root)
     result = validator.validate()
-
-    if result.ok:
-        console.print("[bold green]Validation OK[/bold green]")
-    else:
+    if not result.ok:
         for error in result.errors:
+            all_errors.append(f"[graph] {error}")
+
+    # 2-4. Config validation (unless --graph-only)
+    if not graph_only:
+        path_errors = _validate_paths_secrets(project_root)
+        for e in path_errors:
+            all_errors.append(f"[config] {e}")
+
+        config_errors = _validate_config(project_root)
+        for e in config_errors:
+            all_errors.append(f"[config] {e}")
+
+    if all_errors:
+        for error in all_errors:
             console.print(f"[red]{error}[/red]")
-        console.print(f"\n[bold red]{len(result.errors)} error(s) found.[/bold red]")
+        console.print(f"\n[bold red]{len(all_errors)} error(s) found.[/bold red]")
         raise typer.Exit(1)
+
+    console.print("[bold green]Validation OK[/bold green]")

--- a/cutip/cli/main.py
+++ b/cutip/cli/main.py
@@ -20,6 +20,7 @@ from cutip.cli.commands.info import app as info_app
 from cutip.cli.commands.init import app as init_app
 from cutip.cli.commands.issue import issue_app
 from cutip.cli.commands.ls import card_app, group_app, unit_app
+from cutip.cli.commands.ping import ping
 from cutip.cli.commands.plan import preview
 from cutip.cli.commands.rm import app as rm_app
 from cutip.cli.commands.run import run
@@ -63,15 +64,31 @@ def _backend_status() -> str:
     return "[bold]Backends[/bold]: " + ", ".join(parts)
 
 
-_EPILOG = (
-    "[bold]Common Workflows[/bold]\n\n"
-    "  [bold]New project[/bold]:   cutip init → cutip validate → cutip run GROUP\n"
-    "  [bold]Adopt[/bold]:         cutip adopt CONTAINER → cutip validate → cutip run GROUP\n"
-    "  [bold]Upgrade[/bold]:       cutip info → pip install cutip --upgrade → cutip upgrade → cutip diff → cutip upgrade --apply\n"
-    "  [bold]Inspect[/bold]:       cutip info → cutip group ls → cutip tree → cutip show group GROUP\n"
-    "  [bold]Run[/bold]:           cutip status → cutip validate → cutip run GROUP\n"
-    "  [bold]AI Issues[/bold]:     cutip issue diagnose → cutip issue fix → cutip issue push\n\n"
-    "[bold]Docs[/bold]: https://joshuajerome.github.io/cutip"
+_EPILOG = "\n".join(
+    [
+        "[bold]Common Workflows[/bold]",
+        "",
+        "  [bold]New project[/bold]",
+        "    cutip init → cutip validate → cutip run GROUP",
+        "",
+        "  [bold]Adopt[/bold]",
+        "    cutip adopt CONTAINER → cutip validate → cutip run GROUP",
+        "",
+        "  [bold]Upgrade[/bold]",
+        "    cutip info → pip install cutip --upgrade",
+        "    cutip upgrade → cutip diff → cutip upgrade --apply",
+        "",
+        "  [bold]Inspect[/bold]",
+        "    cutip info → cutip group ls → cutip tree",
+        "",
+        "  [bold]Run[/bold]",
+        "    cutip ping → cutip validate → cutip run GROUP",
+        "",
+        "  [bold]AI Issues[/bold]",
+        "    cutip issue diagnose → cutip issue fix → cutip issue push",
+        "",
+        "[bold]Docs[/bold]: https://joshuajerome.github.io/cutip",
+    ]
 )
 
 app = typer.Typer(
@@ -245,8 +262,10 @@ app.command("desktop", rich_help_panel=_WF)(desktop)
 app.add_typer(info_app, name="info", rich_help_panel=_WF)
 app.add_typer(create_app, name="create", rich_help_panel=_WF)
 
-app.command("compile", rich_help_panel=_WF)(compile_cmd)
+app.command("graph", rich_help_panel=_WF)(compile_cmd)
+app.command("compile", hidden=True)(compile_cmd)  # backward-compat alias
 app.command("status", rich_help_panel=_WF)(status)
+app.command("ping", rich_help_panel=_WF)(ping)
 
 # ── Inspect ──────────────────────────────────────────────────────────────────
 _IN = "Inspect"


### PR DESCRIPTION
## Summary

- `cutip validate` extended: checks paths.yaml/secrets.yaml required keys + config.yaml existence
- `cutip ping`: tests Docker/Podman API connectivity, prints runtime version
- `cutip graph`: renamed from compile (compile kept as hidden backward-compat alias)
- CLI epilog reformatted as multi-line blocks for readability

## Test plan

- [x] 84/84 tests pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)