### PR TITLE
strip backcompat + cutip cmd shorthand — v2.6.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -13,7 +13,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.5.1"
+VERSION = "2.6.0"
 console = Console()
 
 
@@ -27,13 +27,6 @@ def _resolve_project(project_arg: str | None) -> Path:
     """
     if project_arg:
         path = Path(project_arg)
-        if path.is_dir():
-            # User passed a directory — look for config.yaml inside (backward compat)
-            candidate = path / "config.yaml"
-            if candidate.exists():
-                return candidate
-            console.print(f"[red]Error:[/red] No config.yaml found in {path}")
-            sys.exit(1)
         if not path.suffix:
             path = path.with_suffix(".yaml")
         if not path.exists():
@@ -46,10 +39,6 @@ def _resolve_project(project_arg: str | None) -> Path:
 
     search_dir = Path.cwd()
     while True:
-        # Check for config.yaml (backward compat)
-        if (search_dir / "config.yaml").exists():
-            return search_dir / "config.yaml"
-
         # Check for *.yaml with project: field
         projects = []
         for f in sorted(search_dir.glob("*.yaml")):
@@ -95,10 +84,6 @@ def _resolve_workflow(project_path: Path, config: dict) -> Path:
     if not workflow_name:
         # Default: <stem>.workflow.py
         workflow_name = f"{project_path.stem}.workflow.py"
-        # Fallback: workflow.py (backward compat)
-        candidate = project_path.parent / workflow_name
-        if not candidate.exists():
-            workflow_name = "workflow.py"
 
     return project_path.parent / workflow_name
 
@@ -112,12 +97,8 @@ def _load_config(project_path: Path) -> dict:
 
 
 def _resolve_host(config: dict) -> str:
-    """Resolve host from config, with backward compat for 'backend'."""
-    host = config.get("host")
-    if host:
-        return host
-    backend = config.get("backend", "local")
-    return "container" if backend in ("docker", "podman") else backend
+    """Resolve host from config."""
+    return config.get("host", "local")
 
 
 # ── Commands ────────────────────────────────────────────────────────────────
@@ -141,10 +122,10 @@ def cmd_validate(args):
     table.add_column("Value")
 
     table.add_row("Project", result["project"])
-    host = result.get("host", result.get("backend", "local"))
+    host = result.get("host", "local")
     table.add_row("Host", host)
     if host == "container":
-        rt = result.get("container_runtime", result.get("container.rt", "auto"))
+        rt = result.get("container_runtime", "auto")
         table.add_row("Runtime", rt)
     table.add_row("Workflow", result.get("workflow", "workflow.py"))
     table.add_row("Vars", str(result["vars_count"]))
@@ -193,10 +174,10 @@ def cmd_tree(args):
     config = json.loads(config_json)
     tree = Tree(f"[bold]{config['project']}[/bold]")
 
-    host = config.get("host") or ("container" if config.get("backend") in ("docker", "podman") else config.get("backend", "local"))
+    host = config.get("host") or "local"
     tree.add(f"host: [cyan]{host}[/cyan]")
     if host == "container":
-        rt = config.get("container.rt", config.get("container_runtime", "auto"))
+        rt = config.get("container.rt", "auto")
         tree.add(f"container.rt: [cyan]{rt}[/cyan]")
 
     workflow = config.get("workflow", f"{project_path.stem}.workflow.py")
@@ -238,7 +219,7 @@ def cmd_tree(args):
         for name in config["networks"]:
             networks_branch.add(f"[cyan]{name}[/cyan]")
 
-    excluded = {"project", "host", "container.rt", "container_runtime", "backend",
+    excluded = {"project", "host", "container.rt",
                 "workflow", "vars", "secrets", "connections",
                 "image", "container", "containers", "network", "networks"}
     extra = {k for k in config if k not in excluded}
@@ -942,6 +923,18 @@ def cmd_cmd(args):
 
     cmd_name = args.get("cmd_name")
 
+    # Normalize: a command can be either a string shorthand or a dict.
+    #   commands:
+    #     git_branch: "git branch"                    # string shorthand
+    #     deploy:                                      # dict form
+    #       run: "ansible-playbook deploy.yml"
+    #       args: "<env>"
+    #       help: "Deploy to <env>"
+    def _normalize(cmd_def):
+        if isinstance(cmd_def, str):
+            return {"run": cmd_def, "args": "", "help": ""}
+        return cmd_def
+
     # No command name — list all available commands
     if not cmd_name:
         if not commands:
@@ -949,8 +942,9 @@ def cmd_cmd(args):
             return
         console.print(f"[bold]Available commands:[/bold]\n")
         for name, cmd_def in commands.items():
-            cmd_args = cmd_def.get("args", "")
-            cmd_help = cmd_def.get("help", "")
+            cd = _normalize(cmd_def)
+            cmd_args = cd.get("args", "")
+            cmd_help = cd.get("help", "")
             console.print(f"  [cyan]{name}[/cyan]  {cmd_args}  [dim]{cmd_help}[/dim]")
         console.print(f"\n  Usage: cutip cmd [project.yaml] <command> [args...]")
         return
@@ -962,7 +956,7 @@ def cmd_cmd(args):
             console.print(f"Available: {', '.join(commands)}")
         sys.exit(1)
 
-    cmd_def = commands[cmd_name]
+    cmd_def = _normalize(commands[cmd_name])
     run_template = cmd_def.get("run", "")
     cmd_args_desc = cmd_def.get("args", "")
     cmd_help = cmd_def.get("help", "")

--- a/cutip/workflow/engine.py
+++ b/cutip/workflow/engine.py
@@ -85,25 +85,8 @@ class WorkflowContext:
 
     @property
     def data(self) -> dict[str, Any]:
-        """Workflow data — freeform config from data: section.
-
-        Falls back to full config for backward compat (projects without data: section).
-        """
-        d = self.config.get("data")
-        if d is not None:
-            return d
-        # Backward compat: return config minus cutip schema keys
-        return {k: v for k, v in self.config.items()
-                if k not in ("project", "host", "container.rt", "container_runtime",
-                             "backend", "workflow", "vars", "secrets", "data",
-                             "image", "container", "containers", "network", "networks")}
-
-    @property
-    def backend(self) -> str:
-        """Backward compat."""
-        if self.host == "container":
-            return self.container_runtime
-        return self.host
+        """Workflow data — freeform config from data: section."""
+        return self.config.get("data", {})
 
     @property
     def ssh(self) -> Any:
@@ -182,17 +165,8 @@ class WorkflowContext:
 
     @classmethod
     def from_config(cls, config: dict, hosts: dict | None = None) -> WorkflowContext:
-        # Resolve host
-        host = config.get("host")
-        if not host:
-            backend = config.get("backend", "local")
-            host = "container" if backend in ("docker", "podman") else backend
-
-        # Resolve container runtime
-        runtime = config.get("container.rt", config.get("container_runtime"))
-        if not runtime:
-            backend = config.get("backend", "")
-            runtime = backend if backend in ("docker", "podman") else "auto"
+        host = config.get("host", "local")
+        runtime = config.get("container.rt", "auto")
 
         return cls(
             config=config,

--- a/cutip/workflow/validate.py
+++ b/cutip/workflow/validate.py
@@ -28,16 +28,14 @@ def validate_project(
         errors.append("Missing 'project' field")
 
     # 2. Host type
-    host = config.get("host", config.get("backend", "local"))
-    if host in ("docker", "podman"):
-        host = "container"
+    host = config.get("host", "local")
     valid_hosts = ("local", "container", "remote")
     if host not in valid_hosts:
         errors.append(f"Invalid host: '{host}' (must be one of: {', '.join(valid_hosts)})")
 
     # 3. Container runtime
     if host == "container":
-        rt = config.get("container.rt", config.get("container_runtime", "auto"))
+        rt = config.get("container.rt", "auto")
         valid_rts = ("auto", "podman", "docker")
         if rt not in valid_rts:
             errors.append(f"Invalid container.rt: '{rt}' (must be one of: {', '.join(valid_rts)})")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.5.1"
+version = "2.6.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -65,13 +65,9 @@ pub fn show(section: &str, path: Option<&str>) -> PyResult<String> {
             }
         }
         other => {
-            if let Some(value) = config.extra.get(other) {
-                serde_yaml::to_string(value)
-            } else {
-                return Err(PyRuntimeError::new_err(format!(
-                    "Unknown section: '{other}'. Available: data, vars, secrets, container, containers, network, networks"
-                )));
-            }
+            return Err(PyRuntimeError::new_err(format!(
+                "Unknown section: '{other}'. Available: data, vars, secrets, container, containers, network, networks"
+            )));
         }
     }
     .map_err(|e| PyRuntimeError::new_err(format!("YAML error: {e}")))?;

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -10,7 +10,7 @@ use crate::config::resolve;
 /// Validate config.yaml and return results as a dict.
 ///
 /// Returns: {
-///   "project", "backend", "workflow",
+///   "project", "host", "container_runtime", "workflow",
 ///   "vars_count", "secrets_count", "containers_count", "networks_count",
 ///   "empty_secrets": [...], "warnings": [...],
 ///   "workflow_exists": bool, "valid": bool
@@ -44,10 +44,8 @@ pub fn validate(py: Python<'_>, path: Option<&str>) -> PyResult<PyObject> {
     let dict = PyDict::new(py);
     dict.set_item("path", config_path.to_string_lossy().to_string())?;
     dict.set_item("project", &config.project)?;
-    dict.set_item("host", config.resolved_host())?;
-    dict.set_item("container_runtime", config.resolved_runtime())?;
-    // backward compat
-    dict.set_item("backend", config.resolved_host())?;
+    dict.set_item("host", config.host.as_deref().unwrap_or("local"))?;
+    dict.set_item("container_runtime", config.container_rt.as_deref().unwrap_or("auto"))?;
     dict.set_item("workflow", &config.workflow)?;
     dict.set_item("vars_count", config.vars.len())?;
     dict.set_item("secrets_count", config.secrets.len())?;

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -64,14 +64,6 @@ pub struct Config {
     #[serde(default, rename = "container.rt")]
     pub container_rt: Option<String>,
 
-    /// Legacy container_runtime field.
-    #[serde(default)]
-    pub container_runtime: Option<String>,
-
-    /// Legacy backend field — maps to host + container_rt for backward compat.
-    #[serde(default)]
-    pub backend: Option<String>,
-
     /// Workflow file path (default: "workflow.py").
     #[serde(default = "default_workflow")]
     pub workflow: String,
@@ -107,10 +99,6 @@ pub struct Config {
     /// Workflow data — freeform key-value pairs accessed as ctx.data in workflows.
     #[serde(default)]
     pub data: HashMap<String, serde_yaml::Value>,
-
-    /// Extra config sections not in a known field — passed through for backward compat.
-    #[serde(flatten)]
-    pub extra: HashMap<String, serde_yaml::Value>,
 }
 
 /// Image build/pull configuration.
@@ -229,37 +217,6 @@ pub struct NetworkConfig {
     /// Gateway IP.
     #[serde(default)]
     pub gateway: Option<String>,
-}
-
-impl Config {
-    /// Resolved host type — prefers `host`, falls back to `backend` for backward compat.
-    pub fn resolved_host(&self) -> String {
-        if let Some(ref h) = self.host {
-            return h.clone();
-        }
-        // Map legacy backend values
-        match self.backend.as_deref() {
-            Some("local") => "local".to_string(),
-            Some("docker") | Some("podman") => "container".to_string(),
-            Some(other) => other.to_string(),
-            None => "local".to_string(),
-        }
-    }
-
-    /// Resolved container runtime — prefers `container.rt`, falls back to `container_runtime` or `backend`.
-    pub fn resolved_runtime(&self) -> String {
-        if let Some(ref rt) = self.container_rt {
-            return rt.clone();
-        }
-        if let Some(ref rt) = self.container_runtime {
-            return rt.clone();
-        }
-        match self.backend.as_deref() {
-            Some("docker") => "docker".to_string(),
-            Some("podman") => "podman".to_string(),
-            _ => "auto".to_string(),
-        }
-    }
 }
 
 fn default_workflow() -> String { "workflow.py".to_string() }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -33,11 +33,6 @@ class TestWorkflowContext:
         assert ctx.host == "container"
         assert ctx.container_runtime == "podman"
 
-    def test_from_config_legacy_backend(self):
-        ctx = WorkflowContext.from_config({"project": "test", "backend": "podman"})
-        assert ctx.host == "container"
-        assert ctx.backend == "podman"
-
     def test_from_config_vars_and_secrets(self):
         ctx = WorkflowContext.from_config({
             "project": "test",
@@ -79,17 +74,6 @@ class TestWorkflowContext:
             "data": {"kubernetes": {"namespace": "prod"}},
         })
         assert ctx.data["kubernetes"]["namespace"] == "prod"
-
-    def test_data_fallback_to_config(self):
-        """Projects without data: section fall back to extra config keys."""
-        ctx = WorkflowContext.from_config({
-            "project": "test",
-            "host": "local",
-            "kubernetes": {"namespace": "prod"},
-        })
-        assert ctx.data["kubernetes"]["namespace"] == "prod"
-        assert "project" not in ctx.data
-        assert "host" not in ctx.data
 
     def test_close_connections(self):
         ctx = WorkflowContext.from_config({"project": "test"})

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -111,11 +111,3 @@ class TestValidateProject:
         cred_errors = [e for e in errors if "missing" in e.lower() and "SSH" in e]
         assert cred_errors == []
 
-    def test_legacy_backend_mapped(self, tmp_path):
-        """backend: podman should be treated as host: container."""
-        errors, warnings = validate_project(
-            tmp_path / "test.yaml",
-            {"project": "test", "backend": "podman"},
-        )
-        host_errors = [e for e in errors if "Invalid host" in e]
-        assert host_errors == []

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.4.2"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

**Breaking** — removes legacy field handling that has no consumer in cutip-projects.

### Removed (backcompat strip — ~107 LOC)
- Config.backend and Config.container_runtime Rust fields
- host: docker / host: podman aliases for host: container
- Config.extra catch-all flatten map (use data: instead)
- resolved_host() / resolved_runtime() methods
- config.yaml directory + cwd walk-up fallbacks in CLI
- workflow.py filename fallback (must be <stem>.workflow.py)
- WorkflowContext.backend property
- Three legacy tests

### Added
- cutip cmd accepts string shorthand: \`commands: { hello: "echo hi" }\`

## Test plan
- [x] cargo check clean
- [x] maturin develop builds
- [x] pytest 73/73 passed
- [ ] Release CI publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)