### PR TITLE
v2.6.1 (CI fix re-trigger)

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -13,7 +13,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.6.0"
+VERSION = "2.6.1"
 console = Console()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.6.0"
+version = "2.6.1"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Bumps to 2.6.1 to re-run release CI with the just-merged Python 3.13 pin + E2E cleanup. No code changes since 2.6.0.