### PR TITLE
fix CI: ruff via uvx + remove broken smoke-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,9 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install dev dependencies
-        run: uv sync
-
+      # ruff isn't a project dev dep — run via uvx (ephemeral tool env)
       - name: Ruff check
-        run: uv run ruff check .
+        run: uvx ruff check .
 
   # ── Ruff Format ────────────────────────────────────────────────────────────
   ruff-format:
@@ -88,11 +86,8 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install dev dependencies
-        run: uv sync
-
       - name: Ruff format check
-        run: uv run ruff format --check .
+        run: uvx ruff format --check .
 
   # ── Type Check ─────────────────────────────────────────────────────────────
   ty-check:
@@ -134,28 +129,9 @@ jobs:
       - name: Run unit tests
         run: uv run pytest tests/ --ignore=tests/e2e -v --tb=short
 
-  # ── Smoke Test ──────────────────────────────────────────────────────────────
-  smoke-test:
-    name: Smoke Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
-
-      - name: Build wheel
-        run: uv build --wheel
-
-      - name: Smoke-test wheel install
-        run: |
-          uv venv .wheel-test --python 3.13
-          uv pip install --python .wheel-test/bin/python dist/cutip-*.whl
-          .wheel-test/bin/python -c "import cutip; print('cutip import OK')"
-          .wheel-test/bin/cutip --help
+  # NOTE: smoke-test removed. Without Rust toolchain, uv build --wheel
+  # produces an invalid no-platform-tag wheel that uv pip install rejects.
+  # Real per-platform validation happens in release.yml's build-wheels matrix.
 
   # ── Install & Validate · macOS ──────────────────────────────────────────────
   install-validate-macos:


### PR DESCRIPTION
Follow-up: CI workflow ruff steps couldn't find ruff binary (not in dev deps). Run via uvx instead. Also drop ci.yml's smoke-test (same broken pattern as the release.yml one already removed).