### PR TITLE
fix CI: ruff lint + format

### DIFF
--- a/.github/scripts/analyze-doc-coverage.py
+++ b/.github/scripts/analyze-doc-coverage.py
@@ -79,7 +79,10 @@ def main() -> None:
         sys.exit(1)
 
     changed_block = _changed_files_block()
-    if "no Python files changed" in changed_block or "no changed files list" in changed_block:
+    if (
+        "no Python files changed" in changed_block
+        or "no changed files list" in changed_block
+    ):
         print("[analyze-doc-coverage] No Python files changed — skipping.")
         return
 

--- a/.github/scripts/fix-issue.py
+++ b/.github/scripts/fix-issue.py
@@ -167,7 +167,9 @@ Example response structure:
     try:
         file_changes: dict[str, str] = json.loads(json_part.strip())
     except json.JSONDecodeError as exc:
-        print(f"ERROR: Could not parse Claude's response as JSON: {exc}", file=sys.stderr)
+        print(
+            f"ERROR: Could not parse Claude's response as JSON: {exc}", file=sys.stderr
+        )
         print(f"--- Raw response ---\n{response_text}\n---", file=sys.stderr)
         sys.exit(1)
 

--- a/.github/scripts/scan-doc-vulnerabilities.py
+++ b/.github/scripts/scan-doc-vulnerabilities.py
@@ -71,7 +71,9 @@ def main() -> int:
     out.write_text(response)
 
     if "VERDICT: FAIL" in response:
-        print("\n[scan-doc-vulnerabilities] HIGH-severity findings — resolve before merging.")
+        print(
+            "\n[scan-doc-vulnerabilities] HIGH-severity findings — resolve before merging."
+        )
         return 1
 
     print("\n[scan-doc-vulnerabilities] No HIGH-severity issues found.")

--- a/.github/scripts/scan-outdated-docs.py
+++ b/.github/scripts/scan-outdated-docs.py
@@ -86,7 +86,9 @@ def main() -> int:
     )
 
     client = anthropic.Anthropic(api_key=api_key)
-    print("[scan-outdated-docs] Calling Claude to audit documentation for stale content...")
+    print(
+        "[scan-outdated-docs] Calling Claude to audit documentation for stale content..."
+    )
 
     message = client.messages.create(
         model="claude-sonnet-4-6",

--- a/.github/scripts/update-readme.py
+++ b/.github/scripts/update-readme.py
@@ -46,7 +46,9 @@ def _cli_help() -> str:
 def _version() -> str:
     if not PYPROJECT_PATH.exists():
         return "(unknown)"
-    match = re.search(r'^version\s*=\s*"([^"]+)"', PYPROJECT_PATH.read_text(), re.MULTILINE)
+    match = re.search(
+        r'^version\s*=\s*"([^"]+)"', PYPROJECT_PATH.read_text(), re.MULTILINE
+    )
     return match.group(1) if match else "(unknown)"
 
 
@@ -82,7 +84,9 @@ def main() -> int:
     drift_report = parts[0].strip()
     updated_sections = parts[1].strip() if len(parts) == 2 else ""
 
-    has_changes = bool(updated_sections) and "No updates required" not in updated_sections
+    has_changes = (
+        bool(updated_sections) and "No updates required" not in updated_sections
+    )
 
     print("\n## Drift Report\n")
     print(drift_report)

--- a/cutip/__main__.py
+++ b/cutip/__main__.py
@@ -1,4 +1,5 @@
 """python -m cutip entry point."""
+
 from cutip.cli import main
 
 main()

--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -19,6 +19,7 @@ console = Console()
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
+
 def _resolve_project(project_arg: str | None) -> Path:
     """Resolve a project YAML file path.
 
@@ -70,7 +71,7 @@ def _resolve_project(project_arg: str | None) -> Path:
             name = data.get("project", p.stem)
             host = data.get("host", "local")
             console.print(f"  {p}  — {name} (host: {host})")
-        console.print(f"\nUsage: cutip run <project.yaml>")
+        console.print("\nUsage: cutip run <project.yaml>")
         sys.exit(0)
 
     console.print("[red]Error:[/red] No project YAML found in current directory")
@@ -91,6 +92,7 @@ def _resolve_workflow(project_path: Path, config: dict) -> Path:
 def _load_config(project_path: Path) -> dict:
     """Load and return project config as a dict."""
     import yaml
+
     with open(project_path) as f:
         config = yaml.safe_load(f) or {}
     return config
@@ -102,6 +104,7 @@ def _resolve_host(config: dict) -> str:
 
 
 # ── Commands ────────────────────────────────────────────────────────────────
+
 
 def cmd_validate(args):
     """Validate a project YAML file."""
@@ -117,7 +120,9 @@ def cmd_validate(args):
         print(json.dumps(result, indent=2))
         return
 
-    table = Table(title="Validation", box=box.ROUNDED, show_header=False, title_style="bold")
+    table = Table(
+        title="Validation", box=box.ROUNDED, show_header=False, title_style="bold"
+    )
     table.add_column("Field", style="cyan")
     table.add_column("Value")
 
@@ -131,7 +136,10 @@ def cmd_validate(args):
     table.add_row("Vars", str(result["vars_count"]))
 
     if result["empty_secrets"]:
-        table.add_row("Secrets", f"{result['secrets_count']} ([yellow]{len(result['empty_secrets'])} empty[/yellow])")
+        table.add_row(
+            "Secrets",
+            f"{result['secrets_count']} ([yellow]{len(result['empty_secrets'])} empty[/yellow])",
+        )
     else:
         table.add_row("Secrets", f"{result['secrets_count']}, all set")
 
@@ -219,9 +227,20 @@ def cmd_tree(args):
         for name in config["networks"]:
             networks_branch.add(f"[cyan]{name}[/cyan]")
 
-    excluded = {"project", "host", "container.rt",
-                "workflow", "vars", "secrets", "connections",
-                "image", "container", "containers", "network", "networks"}
+    excluded = {
+        "project",
+        "host",
+        "container.rt",
+        "workflow",
+        "vars",
+        "secrets",
+        "connections",
+        "image",
+        "container",
+        "containers",
+        "network",
+        "networks",
+    }
     extra = {k for k in config if k not in excluded}
     if extra:
         tree.add(f"config: [dim]{', '.join(sorted(extra))}[/dim]")
@@ -263,7 +282,6 @@ def _show_summary(args):
     project_path = _resolve_project(args.get("project"))
     config = _load_config(project_path)
     host = _resolve_host(config)
-    project = config.get("project", project_path.stem)
     workflow_path = _resolve_workflow(project_path, config)
 
     # Print tree
@@ -273,12 +291,14 @@ def _show_summary(args):
     # Steps
     console.print("[bold]Steps:[/bold]")
     console.print(f"  1. Read [cyan]{project_path}[/cyan]")
-    console.print(f"  2. Validate config")
+    console.print("  2. Validate config")
 
     empty_vars = [k for k, v in (config.get("vars") or {}).items() if not v]
     step = 3
     if empty_vars:
-        console.print(f"  {step}. Prompt for empty vars: [yellow]{', '.join(empty_vars)}[/yellow]")
+        console.print(
+            f"  {step}. Prompt for empty vars: [yellow]{', '.join(empty_vars)}[/yellow]"
+        )
         step += 1
 
     if host == "local":
@@ -294,6 +314,7 @@ def _show_summary(args):
     # Workflow actions
     if workflow_path.exists():
         from cutip.workflow.introspect import extract_staged_action_order
+
         groups = extract_staged_action_order(workflow_path)
         if groups:
             console.print()
@@ -325,6 +346,7 @@ def _show_workflow(args):
         sys.exit(1)
 
     from cutip.workflow.introspect import extract_staged_action_order
+
     groups = extract_staged_action_order(workflow_path)
 
     if not groups:
@@ -399,10 +421,11 @@ def cmd_plan(args):
         sys.exit(1)
 
     from cutip.workflow.introspect import extract_staged_action_order
+
     groups = extract_staged_action_order(workflow_path)
 
     if not groups:
-        console.print(f"\n  [dim]No @action-decorated functions found[/dim]")
+        console.print("\n  [dim]No @action-decorated functions found[/dim]")
         return
 
     console.print()
@@ -430,7 +453,9 @@ def cmd_plan(args):
             console.print(f"    {action_num}. {a.name}{suffix}")
         console.print()
 
-    console.print(f"  [dim]{action_num} action(s) across {len(groups)} stage(s)[/dim]\n")
+    console.print(
+        f"  [dim]{action_num} action(s) across {len(groups)} stage(s)[/dim]\n"
+    )
 
 
 def cmd_run(args):
@@ -465,7 +490,6 @@ def cmd_run(args):
         console.print()
 
     # Load hosts file (for remote connections)
-    import yaml
     hosts = None
     hosts_path_arg = args.get("hosts")
     if hosts_path_arg:
@@ -480,9 +504,12 @@ def cmd_run(args):
     # Pre-run validation
     workflow_path = _resolve_workflow(project_path, config)
     from cutip.workflow.validate import validate_project
-    errors, warnings = validate_project(project_path, config, hosts=hosts, workflow_path=workflow_path)
+
+    errors, warnings = validate_project(
+        project_path, config, hosts=hosts, workflow_path=workflow_path
+    )
     if errors:
-        console.print(f"\n[red]Validation failed:[/red]")
+        console.print("\n[red]Validation failed:[/red]")
         for err in errors:
             console.print(f"  [red]✗[/red] {err}")
         sys.exit(1)
@@ -504,7 +531,6 @@ def cmd_run(args):
     spec.loader.exec_module(module)
 
     # Check if workflow uses @action/@orchestrator decorators → use engine
-    from cutip.workflow.engine import WorkflowEngine, ActionFailed
     from cutip.workflow.decorators import _ACTION_ATTR
 
     has_actions = any(
@@ -520,7 +546,9 @@ def cmd_run(args):
     elif hasattr(module, "main"):
         module.main(config)
     else:
-        console.print("[red]Error:[/red] workflow has no @action functions, run_standalone(), or main()")
+        console.print(
+            "[red]Error:[/red] workflow has no @action functions, run_standalone(), or main()"
+        )
         sys.exit(1)
 
 
@@ -552,7 +580,10 @@ def _run_with_engine(module, config, project_path, hosts=None):
             if event.attempt > 1:
                 label += f" [dim](attempt {event.attempt})[/dim]"
             console.print(label)
-            _log(f"  [start] {event.action}" + (f" (attempt {event.attempt})" if event.attempt > 1 else ""))
+            _log(
+                f"  [start] {event.action}"
+                + (f" (attempt {event.attempt})" if event.attempt > 1 else "")
+            )
         elif event.event == "action_completed":
             console.print(f"  [green]✓[/green] {event.action}")
             _log(f"  [done] {event.action}")
@@ -571,7 +602,7 @@ def _run_with_engine(module, config, project_path, hosts=None):
     engine = WorkflowEngine(module, config, on_event=on_event, hosts=hosts)
 
     try:
-        ctx = engine.run()
+        engine.run()
         console.print(f"\n[green]✓ {project} complete[/green]")
         _log(f"\n[OK] {project} complete")
     except ActionFailed as e:
@@ -664,7 +695,7 @@ def greet(ctx):
     console.print(f"  {yaml_path}")
     console.print(f"  {workflow_path}")
     console.print()
-    console.print(f"  [bold]Next:[/bold]")
+    console.print("  [bold]Next:[/bold]")
     console.print(f"    cutip show {yaml_path}")
     console.print(f"    cutip run {yaml_path}")
 
@@ -708,13 +739,15 @@ def cmd_verify(args):
             table.add_row(name, "[dim]· not found[/dim]")
 
     try:
-        import rsty
+        import rsty  # noqa: F401  (importability probe)
+
         table.add_row("rsty", "[green]✓[/green] installed")
     except ImportError:
         table.add_row("rsty", "[red]✗ not installed[/red] (pip install rsty)")
 
     try:
-        from cutip._core import validate
+        from cutip._core import validate  # noqa: F401  (importability probe)
+
         table.add_row("cutip core", "[green]✓[/green] loaded")
     except ImportError:
         table.add_row("cutip core", "[red]✗ not loaded[/red]")
@@ -725,6 +758,7 @@ def cmd_verify(args):
 def _yaml_read(path: Path) -> dict:
     """Read a YAML file, return dict (empty dict if missing or null)."""
     import yaml
+
     if not path.exists():
         return {}
     with open(path) as f:
@@ -734,15 +768,20 @@ def _yaml_read(path: Path) -> dict:
 def _yaml_write(path: Path, data: dict) -> None:
     """Write a dict to a YAML file, preserving key order."""
     import yaml
+
     with open(path, "w") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+        yaml.dump(
+            data, f, default_flow_style=False, sort_keys=False, allow_unicode=True
+        )
 
 
 def cmd_vars(args):
     """Manage project variables."""
     subcmd = args.get("subcmd")
     if not subcmd or subcmd == "help":
-        console.print("[bold]cutip vars[/bold] <list|get|set> [project.yaml] [key=value ...]")
+        console.print(
+            "[bold]cutip vars[/bold] <list|get|set> [project.yaml] [key=value ...]"
+        )
         console.print("  list   Show all vars and their values")
         console.print("  get    Get a single var value")
         console.print("  set    Set one or more vars")
@@ -777,13 +816,17 @@ def cmd_vars(args):
     elif subcmd == "set":
         pairs = args.get("pairs", [])
         if not pairs:
-            console.print("[red]Usage:[/red] cutip vars set [project.yaml] key=value ...")
+            console.print(
+                "[red]Usage:[/red] cutip vars set [project.yaml] key=value ..."
+            )
             sys.exit(1)
         if "vars" not in config or config["vars"] is None:
             config["vars"] = {}
         for pair in pairs:
             if "=" not in pair:
-                console.print(f"[red]Error:[/red] invalid format '{pair}', expected key=value")
+                console.print(
+                    f"[red]Error:[/red] invalid format '{pair}', expected key=value"
+                )
                 sys.exit(1)
             k, v = pair.split("=", 1)
             config["vars"][k] = v
@@ -795,7 +838,9 @@ def cmd_secrets(args):
     """Manage project secrets."""
     subcmd = args.get("subcmd")
     if not subcmd or subcmd == "help":
-        console.print("[bold]cutip secrets[/bold] <list|get|set> [project.yaml] [key=value ...]")
+        console.print(
+            "[bold]cutip secrets[/bold] <list|get|set> [project.yaml] [key=value ...]"
+        )
         console.print("  list   Show all secret keys (values masked)")
         console.print("  get    Get a single secret value")
         console.print("  set    Set one or more secrets")
@@ -830,13 +875,17 @@ def cmd_secrets(args):
     elif subcmd == "set":
         pairs = args.get("pairs", [])
         if not pairs:
-            console.print("[red]Usage:[/red] cutip secrets set [project.yaml] key=value ...")
+            console.print(
+                "[red]Usage:[/red] cutip secrets set [project.yaml] key=value ..."
+            )
             sys.exit(1)
         if "secrets" not in config or config["secrets"] is None:
             config["secrets"] = {}
         for pair in pairs:
             if "=" not in pair:
-                console.print(f"[red]Error:[/red] invalid format '{pair}', expected key=value")
+                console.print(
+                    f"[red]Error:[/red] invalid format '{pair}', expected key=value"
+                )
                 sys.exit(1)
             k, v = pair.split("=", 1)
             config["secrets"][k] = v
@@ -862,7 +911,9 @@ def cmd_hosts(args):
     """Manage project hosts file."""
     subcmd = args.get("subcmd")
     if not subcmd or subcmd == "help":
-        console.print("[bold]cutip hosts[/bold] <list|get|set> [project.yaml] [key=value ...]")
+        console.print(
+            "[bold]cutip hosts[/bold] <list|get|set> [project.yaml] [key=value ...]"
+        )
         console.print("  list   Show all host entries (passwords masked)")
         console.print("  get    Get a single host value")
         console.print("  set    Set one or more host values")
@@ -892,17 +943,23 @@ def cmd_hosts(args):
         if key in hosts:
             console.print(hosts[key] or "")
         else:
-            console.print(f"[red]Error:[/red] key '{key}' not found in {hosts_path.name}")
+            console.print(
+                f"[red]Error:[/red] key '{key}' not found in {hosts_path.name}"
+            )
             sys.exit(1)
 
     elif subcmd == "set":
         pairs = args.get("pairs", [])
         if not pairs:
-            console.print("[red]Usage:[/red] cutip hosts set [project.yaml] key=value ...")
+            console.print(
+                "[red]Usage:[/red] cutip hosts set [project.yaml] key=value ..."
+            )
             sys.exit(1)
         for pair in pairs:
             if "=" not in pair:
-                console.print(f"[red]Error:[/red] invalid format '{pair}', expected key=value")
+                console.print(
+                    f"[red]Error:[/red] invalid format '{pair}', expected key=value"
+                )
                 sys.exit(1)
             k, v = pair.split("=", 1)
             hosts[k] = v
@@ -940,13 +997,13 @@ def cmd_cmd(args):
         if not commands:
             console.print("[dim]No commands defined in project[/dim]")
             return
-        console.print(f"[bold]Available commands:[/bold]\n")
+        console.print("[bold]Available commands:[/bold]\n")
         for name, cmd_def in commands.items():
             cd = _normalize(cmd_def)
             cmd_args = cd.get("args", "")
             cmd_help = cd.get("help", "")
             console.print(f"  [cyan]{name}[/cyan]  {cmd_args}  [dim]{cmd_help}[/dim]")
-        console.print(f"\n  Usage: cutip cmd [project.yaml] <command> [args...]")
+        console.print("\n  Usage: cutip cmd [project.yaml] <command> [args...]")
         return
 
     # Command name given but not defined
@@ -1015,30 +1072,32 @@ def main():
     args = sys.argv[1:]
 
     if not args or args[0] in ("-h", "--help", "help"):
-        console.print(Panel(
-            "[bold]cutip[/bold] — workflow automation framework\n\n"
-            "[bold]Commands:[/bold]\n"
-            "  init       Scaffold a new project\n"
-            "  validate   Validate project config\n"
-            "  show       Project summary or config section\n"
-            "  plan       Show execution plan (dry run)\n"
-            "  run        Execute workflow\n"
-            "  cmd        Run a project-defined command\n"
-            "  tree       Print config structure\n"
-            "  vars       Manage project variables (list/get/set)\n"
-            "  secrets    Manage project secrets (list/get/set)\n"
-            "  hosts      Manage connection credentials (list/get/set)\n"
-            "  verify     Check prerequisites\n\n"
-            "[bold]Usage:[/bold]\n"
-            "  cutip init myproject\n"
-            "  cutip run myproject.yaml\n"
-            "  cutip vars set gui.yaml greeting=hello\n"
-            "  cutip hosts set gui.yaml vm.host=10.0.0.1\n"
-            "  cutip cmd gui.yaml generate sheets/my.xlsx\n"
-            "  cutip validate myproject.yaml",
-            title=f"cutip v{VERSION}",
-            box=box.ROUNDED,
-        ))
+        console.print(
+            Panel(
+                "[bold]cutip[/bold] — workflow automation framework\n\n"
+                "[bold]Commands:[/bold]\n"
+                "  init       Scaffold a new project\n"
+                "  validate   Validate project config\n"
+                "  show       Project summary or config section\n"
+                "  plan       Show execution plan (dry run)\n"
+                "  run        Execute workflow\n"
+                "  cmd        Run a project-defined command\n"
+                "  tree       Print config structure\n"
+                "  vars       Manage project variables (list/get/set)\n"
+                "  secrets    Manage project secrets (list/get/set)\n"
+                "  hosts      Manage connection credentials (list/get/set)\n"
+                "  verify     Check prerequisites\n\n"
+                "[bold]Usage:[/bold]\n"
+                "  cutip init myproject\n"
+                "  cutip run myproject.yaml\n"
+                "  cutip vars set gui.yaml greeting=hello\n"
+                "  cutip hosts set gui.yaml vm.host=10.0.0.1\n"
+                "  cutip cmd gui.yaml generate sheets/my.xlsx\n"
+                "  cutip validate myproject.yaml",
+                title=f"cutip v{VERSION}",
+                box=box.ROUNDED,
+            )
+        )
         return
 
     if args[0] in ("--version", "version"):
@@ -1065,7 +1124,9 @@ def main():
                 parsed["cmd_name"] = None
                 COMMANDS[command](parsed)
                 return
-            elif arg.endswith(".yaml") or (not cmd_name and Path(arg).exists() and arg.endswith(".yaml")):
+            elif arg.endswith(".yaml") or (
+                not cmd_name and Path(arg).exists() and arg.endswith(".yaml")
+            ):
                 parsed["project"] = arg
             elif cmd_name is None and not arg.startswith("-"):
                 cmd_name = arg

--- a/cutip/workflow/engine.py
+++ b/cutip/workflow/engine.py
@@ -22,17 +22,16 @@ from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Any
 
-from cutip.workflow.decorators import ActionMeta, StageMeta, _ACTION_ATTR
+from cutip.workflow.decorators import ActionMeta, _ACTION_ATTR
 from cutip.workflow import decorators as _decorators_module
 from cutip.workflow.introspect import (
     StageGroup,
-    extract_staged_action_order,
-    get_module_actions,
     get_orchestrator,
 )
 
 
 # ── Events ──────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class ActionEvent:
@@ -50,6 +49,7 @@ EventCallback = Callable[[ActionEvent], None]
 
 
 # ── Context ─────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class WorkflowContext:
@@ -109,7 +109,10 @@ class WorkflowContext:
             )
 
         from rsty._core import ssh_connect
-        self._ssh = ssh_connect(host=host, username=username, password=password, port=port)
+
+        self._ssh = ssh_connect(
+            host=host, username=username, password=password, port=port
+        )
         self.ssh_host = host
         return self._ssh
 
@@ -135,6 +138,7 @@ class WorkflowContext:
         ssh_session = self.ssh  # triggers SSH connection if not already established
 
         from rsty._core import kubectl_connect
+
         self._kubectl = kubectl_connect(ssh_session, namespace=ns)
         return self._kubectl
 
@@ -149,6 +153,7 @@ class WorkflowContext:
             return self._container
 
         from rsty._core import container_connect
+
         self._container = container_connect()
         return self._container
 
@@ -179,6 +184,7 @@ class WorkflowContext:
 
 
 # ── Engine ──────────────────────────────────────────────────────────────────
+
 
 class ActionFailed(Exception):
     """Raised when an action fails after all retries."""
@@ -263,6 +269,7 @@ class WorkflowEngine:
             def make_wrapper(fn_name: str, fn: Callable, m: ActionMeta):
                 def wrapper(*args, **kwargs):
                     return self._execute_action(m)
+
                 return wrapper
 
             setattr(self.module, func_name, make_wrapper(func_name, func, meta))
@@ -272,17 +279,21 @@ class WorkflowEngine:
 
         def _runtime_stage(title=None, description=None, parallel=False):
             if self._current_stage is not None:
-                self.on_event(ActionEvent(
-                    event="stage_completed",
-                    action=self._current_stage,
-                ))
+                self.on_event(
+                    ActionEvent(
+                        event="stage_completed",
+                        action=self._current_stage,
+                    )
+                )
             stage_title = title or "Stage"
             self._current_stage = stage_title
-            self.on_event(ActionEvent(
-                event="stage_started",
-                action=stage_title,
-                detail=description or "",
-            ))
+            self.on_event(
+                ActionEvent(
+                    event="stage_started",
+                    action=stage_title,
+                    detail=description or "",
+                )
+            )
 
         _decorators_module.stage = _runtime_stage
 
@@ -295,10 +306,12 @@ class WorkflowEngine:
         """Restore original @action functions and stage()."""
         # Emit final stage_completed
         if self._current_stage is not None:
-            self.on_event(ActionEvent(
-                event="stage_completed",
-                action=self._current_stage,
-            ))
+            self.on_event(
+                ActionEvent(
+                    event="stage_completed",
+                    action=self._current_stage,
+                )
+            )
 
         for func_name, original in self._originals.items():
             setattr(self.module, func_name, original)
@@ -311,21 +324,25 @@ class WorkflowEngine:
             stage = group.stage
             stage_title = stage.title or "Stage"
 
-            self.on_event(ActionEvent(
-                event="stage_started",
-                action=stage_title,
-                detail=stage.description or "",
-            ))
+            self.on_event(
+                ActionEvent(
+                    event="stage_started",
+                    action=stage_title,
+                    detail=stage.description or "",
+                )
+            )
 
             if stage.parallel:
                 self._run_parallel(group.actions, stage_title)
             else:
                 self._run_sequential(group.actions, stage_title)
 
-            self.on_event(ActionEvent(
-                event="stage_completed",
-                action=stage_title,
-            ))
+            self.on_event(
+                ActionEvent(
+                    event="stage_completed",
+                    action=stage_title,
+                )
+            )
 
     def _run_sequential(self, actions: list[ActionMeta], stage_title: str) -> None:
         """Execute actions one at a time, in order."""
@@ -361,7 +378,9 @@ class WorkflowEngine:
         # Find the callable
         func_name = self._name_to_func.get(meta.name)
         if func_name is None or func_name not in self._actions:
-            raise ActionFailed(meta.name, RuntimeError(f"Action '{meta.name}' not found"))
+            raise ActionFailed(
+                meta.name, RuntimeError(f"Action '{meta.name}' not found")
+            )
         func, runtime_meta = self._actions[func_name]
 
         # Runtime meta is authoritative — it has the actual decorator params
@@ -375,24 +394,27 @@ class WorkflowEngine:
             except Exception:
                 should_run = False
             if not should_run:
-                self.on_event(ActionEvent(
-                    event="action_skipped",
-                    action=meta.name,
-                    detail="when condition returned False",
-                ))
+                self.on_event(
+                    ActionEvent(
+                        event="action_skipped",
+                        action=meta.name,
+                        detail="when condition returned False",
+                    )
+                )
                 return None
 
         # Execute with retry/timeout
-        last_error: Exception | None = None
         max_attempts = meta.retry + 1
         current_delay = meta.delay
 
         for attempt in range(1, max_attempts + 1):
-            self.on_event(ActionEvent(
-                event="action_started",
-                action=meta.name,
-                attempt=attempt,
-            ))
+            self.on_event(
+                ActionEvent(
+                    event="action_started",
+                    action=meta.name,
+                    attempt=attempt,
+                )
+            )
 
             try:
                 if meta.timeout is not None:
@@ -402,38 +424,42 @@ class WorkflowEngine:
 
                 # Success
                 self.ctx.results[meta.name] = result
-                self.on_event(ActionEvent(
-                    event="action_completed",
-                    action=meta.name,
-                    attempt=attempt,
-                    result=result,
-                ))
+                self.on_event(
+                    ActionEvent(
+                        event="action_completed",
+                        action=meta.name,
+                        attempt=attempt,
+                        result=result,
+                    )
+                )
                 return result
 
             except Exception as e:
-                last_error = e
-
                 # Check if this error type should stop retries immediately
                 if attempt < max_attempts and not self._is_fatal(e):
-                    self.on_event(ActionEvent(
-                        event="action_retrying",
-                        action=meta.name,
-                        attempt=attempt,
-                        detail=f"Retrying in {current_delay}s ({attempt}/{max_attempts}): {e}",
-                        error=e,
-                    ))
+                    self.on_event(
+                        ActionEvent(
+                            event="action_retrying",
+                            action=meta.name,
+                            attempt=attempt,
+                            detail=f"Retrying in {current_delay}s ({attempt}/{max_attempts}): {e}",
+                            error=e,
+                        )
+                    )
                     if current_delay > 0:
                         time.sleep(current_delay)
                     current_delay *= meta.backoff
                     continue
 
                 # All retries exhausted
-                self.on_event(ActionEvent(
-                    event="action_failed",
-                    action=meta.name,
-                    attempt=attempt,
-                    error=e,
-                ))
+                self.on_event(
+                    ActionEvent(
+                        event="action_failed",
+                        action=meta.name,
+                        attempt=attempt,
+                        error=e,
+                    )
+                )
 
                 # Try on_fail action
                 if meta.on_fail:
@@ -455,6 +481,7 @@ class WorkflowEngine:
         """
         try:
             from rsty.errors import AuthError, ValidationError
+
             return isinstance(error, (AuthError, ValidationError))
         except ImportError:
             pass
@@ -478,6 +505,7 @@ class WorkflowEngine:
         )
 
         if use_signal:
+
             def _alarm_handler(signum, frame):
                 raise TimeoutError(f"Action timed out after {timeout}s")
 
@@ -489,7 +517,10 @@ class WorkflowEngine:
                 signal.alarm(0)
                 signal.signal(signal.SIGALRM, old_handler)
         else:
-            from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+            from concurrent.futures import (
+                ThreadPoolExecutor,
+                TimeoutError as FutureTimeout,
+            )
 
             with ThreadPoolExecutor(max_workers=1) as executor:
                 future = executor.submit(func, self.ctx)
@@ -505,23 +536,29 @@ class WorkflowEngine:
             return
 
         func, meta = self._actions[func_name]
-        self.on_event(ActionEvent(
-            event="action_started",
-            action=on_fail_name,
-            detail=f"on_fail triggered by: {original_error}",
-        ))
+        self.on_event(
+            ActionEvent(
+                event="action_started",
+                action=on_fail_name,
+                detail=f"on_fail triggered by: {original_error}",
+            )
+        )
 
         try:
             result = func(self.ctx)
             self.ctx.results[on_fail_name] = result
-            self.on_event(ActionEvent(
-                event="action_completed",
-                action=on_fail_name,
-                result=result,
-            ))
+            self.on_event(
+                ActionEvent(
+                    event="action_completed",
+                    action=on_fail_name,
+                    result=result,
+                )
+            )
         except Exception as e:
-            self.on_event(ActionEvent(
-                event="action_failed",
-                action=on_fail_name,
-                error=e,
-            ))
+            self.on_event(
+                ActionEvent(
+                    event="action_failed",
+                    action=on_fail_name,
+                    error=e,
+                )
+            )

--- a/cutip/workflow/introspect.py
+++ b/cutip/workflow/introspect.py
@@ -163,12 +163,18 @@ def extract_staged_action_order(workflow_path: Path) -> list[StageGroup]:
     if not groups:
         all_actions: list[str] = []
         _collect_action_calls(orch_body, action_funcs, all_actions)
-        return [StageGroup(stage=StageMeta(), actions=[action_funcs[n] for n in all_actions])]
+        return [
+            StageGroup(
+                stage=StageMeta(), actions=[action_funcs[n] for n in all_actions]
+            )
+        ]
 
     # Number untitled stages
     for i, group in enumerate(groups):
         if group.stage.title is None:
-            numbered = StageMeta(title=f"Stage {i + 1}", description=group.stage.description)
+            numbered = StageMeta(
+                title=f"Stage {i + 1}", description=group.stage.description
+            )
             groups[i] = StageGroup(stage=numbered, actions=group.actions)
 
     return groups
@@ -188,7 +194,9 @@ def _collect_staged_items(
         if stage_meta is not None:
             # Flush current group if it has actions
             if current_actions:
-                groups.append(StageGroup(stage=current_stage, actions=list(current_actions)))
+                groups.append(
+                    StageGroup(stage=current_stage, actions=list(current_actions))
+                )
                 current_actions.clear()
             current_stage = stage_meta
             continue
@@ -248,7 +256,9 @@ def _collect_staged_items_with_state(
     current_actions: list[ActionMeta],
 ) -> tuple[StageMeta, list[ActionMeta]]:
     """Wrapper that threads mutable state through recursive calls."""
-    return _collect_staged_items(stmts, action_funcs, groups, current_stage, current_actions)
+    return _collect_staged_items(
+        stmts, action_funcs, groups, current_stage, current_actions
+    )
 
 
 def _extract_stage_call(stmt: ast.stmt) -> StageMeta | None:
@@ -361,7 +371,9 @@ def _extract_meta_from_decorator(deco: ast.Call) -> ActionMeta | None:
         delay=_float_kwarg(kwargs, "delay", 0.0),
         backoff=_float_kwarg(kwargs, "backoff", 1.0),
         timeout=_float_kwarg_optional(kwargs, "timeout"),
-        on_fail=kwargs.get("on_fail") if isinstance(kwargs.get("on_fail"), str) else None,
+        on_fail=kwargs.get("on_fail")
+        if isinstance(kwargs.get("on_fail"), str)
+        else None,
         continue_on_fail=bool(kwargs.get("continue_on_fail", False)),
         # `when` is a callable — can't be parsed from AST, only available at runtime
     )
@@ -420,7 +432,11 @@ def _check_call(
 ) -> None:
     """If *call* targets a known action function, append to *call_order*."""
     func = call.func
-    if isinstance(func, ast.Name) and func.id in action_funcs and func.id not in call_order:
+    if (
+        isinstance(func, ast.Name)
+        and func.id in action_funcs
+        and func.id not in call_order
+    ):
         call_order.append(func.id)
 
 

--- a/cutip/workflow/validate.py
+++ b/cutip/workflow/validate.py
@@ -31,14 +31,18 @@ def validate_project(
     host = config.get("host", "local")
     valid_hosts = ("local", "container", "remote")
     if host not in valid_hosts:
-        errors.append(f"Invalid host: '{host}' (must be one of: {', '.join(valid_hosts)})")
+        errors.append(
+            f"Invalid host: '{host}' (must be one of: {', '.join(valid_hosts)})"
+        )
 
     # 3. Container runtime
     if host == "container":
         rt = config.get("container.rt", "auto")
         valid_rts = ("auto", "podman", "docker")
         if rt not in valid_rts:
-            errors.append(f"Invalid container.rt: '{rt}' (must be one of: {', '.join(valid_rts)})")
+            errors.append(
+                f"Invalid container.rt: '{rt}' (must be one of: {', '.join(valid_rts)})"
+            )
 
     # 4. Workflow file exists and parses
     if workflow_path:
@@ -49,19 +53,25 @@ def validate_project(
                 source = workflow_path.read_text(encoding="utf-8")
                 ast.parse(source, filename=str(workflow_path))
             except SyntaxError as e:
-                errors.append(f"Workflow syntax error: {workflow_path.name} line {e.lineno}: {e.msg}")
+                errors.append(
+                    f"Workflow syntax error: {workflow_path.name} line {e.lineno}: {e.msg}"
+                )
 
     # 5. Empty vars
     vars_dict = config.get("vars") or {}
     empty_vars = [k for k, v in vars_dict.items() if not v]
     if empty_vars:
-        warnings.append(f"Empty vars (use 'cutip vars set' or will be prompted): {', '.join(empty_vars)}")
+        warnings.append(
+            f"Empty vars (use 'cutip vars set' or will be prompted): {', '.join(empty_vars)}"
+        )
 
     # 6. Empty secrets
     secrets_dict = config.get("secrets") or {}
     empty_secrets = [k for k, v in secrets_dict.items() if not v]
     if empty_secrets:
-        warnings.append(f"Empty secrets (use 'cutip secrets set' or will be prompted): {', '.join(empty_secrets)}")
+        warnings.append(
+            f"Empty secrets (use 'cutip secrets set' or will be prompted): {', '.join(empty_secrets)}"
+        )
 
     # 7. Hosts file — check existence and empty values
     data = config.get("data") or {}
@@ -71,32 +81,42 @@ def validate_project(
         hosts_path = project_path.parent / hosts_ref
         if not hosts_path.exists():
             errors.append(f"{hosts_ref} not found")
-            errors.append(f"  Create with: cutip hosts set <key>=<value>")
+            errors.append("  Create with: cutip hosts set <key>=<value>")
         else:
             import yaml
+
             with open(hosts_path) as f:
                 h = yaml.safe_load(f) or {}
             empty_keys = [k for k, v in h.items() if not v and v != 0]
             if empty_keys:
                 warnings.append(f"Empty values in {hosts_ref}: {', '.join(empty_keys)}")
-                warnings.append(f"  Set with: cutip hosts set {' '.join(f'{k}=<value>' for k in empty_keys)}")
+                warnings.append(
+                    f"  Set with: cutip hosts set {' '.join(f'{k}=<value>' for k in empty_keys)}"
+                )
     elif host == "remote":
         # Fallback: host: remote without data.hosts
         hosts_path = project_path.parent / "hosts.yaml"
         if not hosts_path.exists() and not hosts:
             errors.append("hosts.yaml not found (required for host: remote)")
-            errors.append("  Create with: cutip hosts set host=<ip> username=<user> password=<pw>")
+            errors.append(
+                "  Create with: cutip hosts set host=<ip> username=<user> password=<pw>"
+            )
         else:
             h = hosts or {}
             missing = [f for f in ("host", "username", "password") if not h.get(f)]
             if missing:
-                errors.append(f"Missing SSH credentials in hosts.yaml: {', '.join(missing)}")
-                errors.append(f"  Set with: cutip hosts set {' '.join(f'{f}=<value>' for f in missing)}")
+                errors.append(
+                    f"Missing SSH credentials in hosts.yaml: {', '.join(missing)}"
+                )
+                errors.append(
+                    f"  Set with: cutip hosts set {' '.join(f'{f}=<value>' for f in missing)}"
+                )
 
     # 8. Container runtime reachable
     if host == "container":
         try:
             from rsty._core import container_connect
+
             container_connect()
         except ImportError:
             errors.append("rsty not installed (pip install rsty)")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,5 @@
 """Shared test fixtures for cutip tests."""
 
-import os
-import tempfile
-from pathlib import Path
-
 import pytest
 
 
@@ -24,22 +20,20 @@ def tmp_project(tmp_path):
 
         vars_block = ""
         if vars:
-            vars_block = "vars:\n" + "".join(f"  {k}: \"{v}\"\n" for k, v in vars.items())
+            vars_block = "vars:\n" + "".join(f'  {k}: "{v}"\n' for k, v in vars.items())
 
         secrets_block = ""
         if secrets:
-            secrets_block = "secrets:\n" + "".join(f"  {k}: \"{v}\"\n" for k, v in secrets.items())
+            secrets_block = "secrets:\n" + "".join(
+                f'  {k}: "{v}"\n' for k, v in secrets.items()
+            )
 
         project_file.write_text(
-            f"project: {name}\n"
-            f"host: {host}\n"
-            f"{vars_block}"
-            f"{secrets_block}"
-            f"{config_extra}"
+            f"project: {name}\nhost: {host}\n{vars_block}{secrets_block}{config_extra}"
         )
 
         if workflow_code is None:
-            workflow_code = '''
+            workflow_code = """
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -50,7 +44,7 @@ def main(ctx):
 @action(name="Hello")
 def hello(ctx):
     return "hello"
-'''
+"""
 
         workflow_file.write_text(workflow_code)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,22 +3,20 @@
 import json
 import subprocess
 import sys
-from pathlib import Path
-
-import pytest
 
 
 def _run_cutip(*args, cwd=None):
     """Run cutip CLI via python -m and return result."""
     result = subprocess.run(
         [sys.executable, "-m", "cutip", *args],
-        capture_output=True, text=True, cwd=cwd,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
     )
     return result
 
 
 class TestCLIHelp:
-
     def test_help(self):
         r = _run_cutip("--help")
         assert r.returncode == 0
@@ -37,7 +35,6 @@ class TestCLIHelp:
 
 
 class TestCLIInit:
-
     def test_init_creates_files(self, tmp_path):
         r = _run_cutip("init", "myapp", cwd=str(tmp_path))
         assert r.returncode == 0
@@ -72,7 +69,6 @@ class TestCLIInit:
 
 
 class TestCLIValidate:
-
     def test_validate_good_project(self, simple_project):
         project_file, _ = simple_project
         r = _run_cutip("validate", str(project_file))
@@ -92,7 +88,6 @@ class TestCLIValidate:
 
 
 class TestCLIPlan:
-
     def test_plan_shows_actions(self, simple_project):
         project_file, _ = simple_project
         r = _run_cutip("plan", str(project_file))
@@ -107,7 +102,6 @@ class TestCLIPlan:
 
 
 class TestCLIRun:
-
     def test_run_executes_workflow(self, simple_project):
         project_file, _ = simple_project
         r = _run_cutip("run", str(project_file))
@@ -137,7 +131,6 @@ class TestCLIRun:
 
 
 class TestCLITree:
-
     def test_tree_output(self, simple_project):
         project_file, _ = simple_project
         r = _run_cutip("tree", str(project_file))
@@ -153,7 +146,6 @@ class TestCLITree:
 
 
 class TestCLIShow:
-
     def test_show_summary(self, simple_project):
         project_file, _ = simple_project
         r = _run_cutip("show", str(project_file))
@@ -168,7 +160,6 @@ class TestCLIShow:
 
 
 class TestCLIVerify:
-
     def test_verify(self):
         r = _run_cutip("verify")
         assert r.returncode == 0

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,7 +2,6 @@
 
 import importlib.util
 import tempfile
-from pathlib import Path
 
 import pytest
 
@@ -15,8 +14,8 @@ from cutip.workflow.engine import (
 
 # ── WorkflowContext ──────────────────────────────────────────────────────────
 
-class TestWorkflowContext:
 
+class TestWorkflowContext:
     def test_from_config_local(self):
         ctx = WorkflowContext.from_config({"project": "test", "host": "local"})
         assert ctx.host == "local"
@@ -25,25 +24,31 @@ class TestWorkflowContext:
         assert ctx.results == {}
 
     def test_from_config_container(self):
-        ctx = WorkflowContext.from_config({
-            "project": "test",
-            "host": "container",
-            "container.rt": "podman",
-        })
+        ctx = WorkflowContext.from_config(
+            {
+                "project": "test",
+                "host": "container",
+                "container.rt": "podman",
+            }
+        )
         assert ctx.host == "container"
         assert ctx.container_runtime == "podman"
 
     def test_from_config_vars_and_secrets(self):
-        ctx = WorkflowContext.from_config({
-            "project": "test",
-            "vars": {"key": "value"},
-            "secrets": {"pw": "secret"},
-        })
+        ctx = WorkflowContext.from_config(
+            {
+                "project": "test",
+                "vars": {"key": "value"},
+                "secrets": {"pw": "secret"},
+            }
+        )
         assert ctx.vars == {"key": "value"}
         assert ctx.secrets == {"pw": "secret"}
 
     def test_from_config_null_vars(self):
-        ctx = WorkflowContext.from_config({"project": "test", "vars": None, "secrets": None})
+        ctx = WorkflowContext.from_config(
+            {"project": "test", "vars": None, "secrets": None}
+        )
         assert ctx.vars == {}
         assert ctx.secrets == {}
 
@@ -69,10 +74,12 @@ class TestWorkflowContext:
             _ = ctx.ssh
 
     def test_data_from_data_section(self):
-        ctx = WorkflowContext.from_config({
-            "project": "test",
-            "data": {"kubernetes": {"namespace": "prod"}},
-        })
+        ctx = WorkflowContext.from_config(
+            {
+                "project": "test",
+                "data": {"kubernetes": {"namespace": "prod"}},
+            }
+        )
         assert ctx.data["kubernetes"]["namespace"] == "prod"
 
     def test_close_connections(self):
@@ -80,6 +87,7 @@ class TestWorkflowContext:
 
         class FakeSSH:
             closed = False
+
             def close(self):
                 self.closed = True
 
@@ -89,6 +97,7 @@ class TestWorkflowContext:
 
 
 # ── WorkflowEngine ───────────────────────────────────────────────────────────
+
 
 def _load_module(code: str, name: str = "test_wf") -> object:
     """Write workflow code to a temp file and load it as a module."""
@@ -102,9 +111,8 @@ def _load_module(code: str, name: str = "test_wf") -> object:
 
 
 class TestWorkflowEngine:
-
     def test_sequential_execution(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -120,14 +128,14 @@ def a(ctx):
 @action(name="B")
 def b(ctx):
     return "b"
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test"})
         ctx = engine.run()
         assert ctx.results["A"] == "a"
         assert ctx.results["B"] == "b"
 
     def test_parallel_stage(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -143,14 +151,14 @@ def a(ctx):
 @action(name="B")
 def b(ctx):
     return "b"
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test"})
         ctx = engine.run()
         assert "A" in ctx.results
         assert "B" in ctx.results
 
     def test_retry_on_failure(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 counter = {"n": 0}
@@ -166,13 +174,13 @@ def flaky(ctx):
     if counter["n"] < 3:
         raise RuntimeError("not yet")
     return "ok"
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test"})
         ctx = engine.run()
         assert ctx.results["Flaky"] == "ok"
 
     def test_on_fail_triggers_recovery(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -187,14 +195,14 @@ def failing(ctx):
 @action(name="Recovery")
 def recovery(ctx):
     return "recovered"
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test"})
         ctx = engine.run()
         assert ctx.results["Recovery"] == "recovered"
         assert ctx.results["Failing"] is None
 
     def test_when_skips_action(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -210,14 +218,14 @@ def skipped(ctx):
 @action(name="Not skipped")
 def not_skipped(ctx):
     return "ran"
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test"})
         ctx = engine.run()
         assert "Skipped" not in ctx.results
         assert ctx.results["Not skipped"] == "ran"
 
     def test_continue_on_fail(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -233,13 +241,13 @@ def failing(ctx):
 @action(name="After")
 def after(ctx):
     return "continued"
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test"})
         ctx = engine.run()
         assert ctx.results["After"] == "continued"
 
     def test_action_failed_on_exhausted_retries(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -250,13 +258,13 @@ def main(ctx):
 @action(name="Always fail", retry=1, delay=0)
 def always_fail(ctx):
     raise RuntimeError("nope")
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test"})
         with pytest.raises(ActionFailed):
             engine.run()
 
     def test_conditional_branching(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -275,14 +283,14 @@ def local_action(ctx):
 @action(name="Remote action")
 def remote_action(ctx):
     return "remote"
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test", "host": "local"})
         ctx = engine.run()
         assert ctx.results["Local action"] == "local"
         assert "Remote action" not in ctx.results
 
     def test_stage_events_emitted(self):
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 @orchestrator
@@ -293,9 +301,11 @@ def main(ctx):
 @action(name="A")
 def a(ctx):
     return "a"
-''')
+""")
         events = []
-        engine = WorkflowEngine(module, {"project": "test"}, on_event=lambda e: events.append(e.event))
+        engine = WorkflowEngine(
+            module, {"project": "test"}, on_event=lambda e: events.append(e.event)
+        )
         engine.run()
         assert "stage_started" in events
         assert "action_started" in events
@@ -303,12 +313,12 @@ def a(ctx):
         assert "stage_completed" in events
 
     def test_fallback_to_main_without_decorators(self):
-        module = _load_module('''
+        module = _load_module("""
 ran = False
 def main(ctx):
     global ran
     ran = True
-''')
+""")
         config = {"project": "test"}
         engine = WorkflowEngine(module, config)
         engine.run()
@@ -316,7 +326,7 @@ def main(ctx):
 
     def test_fatal_error_stops_retry(self):
         """AuthError should not be retried."""
-        module = _load_module('''
+        module = _load_module("""
 from cutip.workflow import action, orchestrator, stage
 
 counter = {"n": 0}
@@ -334,7 +344,7 @@ def auth_fail(ctx):
         pass
     AuthError.__name__ = "AuthError"
     raise AuthError("bad creds")
-''')
+""")
         engine = WorkflowEngine(module, {"project": "test"})
         with pytest.raises(ActionFailed):
             engine.run()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,15 +1,9 @@
 """Tests for cutip.workflow.validate — comprehensive project validation."""
 
-import tempfile
-from pathlib import Path
-
-import pytest
-
 from cutip.workflow.validate import validate_project
 
 
 class TestValidateProject:
-
     def test_valid_local_project(self, tmp_path):
         wf = tmp_path / "test.workflow.py"
         wf.write_text("from cutip.workflow import action, orchestrator\n")
@@ -110,4 +104,3 @@ class TestValidateProject:
         )
         cred_errors = [e for e in errors if "missing" in e.lower() and "SSH" in e]
         assert cred_errors == []
-


### PR DESCRIPTION
Auto-fixes 23 unused imports left over from backcompat strip, removes 3 dead variables, adds # noqa F401 for two intentional importability probes, and applies ruff format across 14 files. 73/73 tests pass.