### PR TITLE
Phase 2: cutip run --bg + cutip ps (background processes)

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -1,5 +1,6 @@
 """cutip CLI — Python wrapper over Rust core, formatted with rich."""
 
+import os
 import sys
 import json
 import importlib.util
@@ -463,12 +464,34 @@ def cmd_run(args):
     import yaml
 
     if "--help" in sys.argv or "-h" in sys.argv:
-        console.print("[bold]cutip run[/bold] [project.yaml]")
+        console.print("[bold]cutip run[/bold] [project.yaml] [--bg]")
         console.print("  Reads project YAML, runs the workflow")
+        console.print("  --bg   Detach: print cu-id and return; track via 'cutip ps'")
         return
 
     project_path = _resolve_project(args.get("project"))
     config = _load_config(project_path)
+
+    # Background mode: spawn a detached daemon and exit
+    if args.get("bg"):
+        from cutip import processes as _proc
+        from cutip.daemon import spawn_daemon
+
+        workflow_path = _resolve_workflow(project_path, config)
+        if not workflow_path.exists():
+            console.print(f"[red]Error:[/red] {workflow_path.name} not found")
+            sys.exit(1)
+        cu_id = _proc.make_cu_id(config.get("project", project_path.stem))
+        pid = spawn_daemon(
+            cu_id,
+            project_path,
+            workflow_path,
+            hosts_path=args.get("hosts"),
+        )
+        console.print(f"  [green]✓[/green] Spawned [cyan]{cu_id}[/cyan] (pid {pid})")
+        console.print(f"  Tail logs:  cutip ps logs {cu_id}")
+        console.print(f"  Stop:       cutip ps stop {cu_id}")
+        return
 
     # Prompt for empty vars/secrets
     has_prompts = False
@@ -1052,6 +1075,230 @@ def cmd_cmd(args):
     sys.exit(result.returncode)
 
 
+# ── Background processes ────────────────────────────────────────────────────
+
+
+def cmd_ps(args):
+    """List/inspect/stop background cutip runs.
+
+    Subcommands:
+      cutip ps              List all background processes
+      cutip ps logs <id>    Tail stdout of a process
+      cutip ps stop <id>    SIGTERM the process + cascade-kill remote PIDs
+      cutip ps inspect <id> Show full meta + remote PID list
+      cutip ps clean        Prune completed processes older than N days
+    """
+    from cutip import processes as _proc
+
+    subcmd = args.get("subcmd") or "list"
+    target = args.get("key")  # cu-id (or prefix)
+
+    if subcmd in ("help", "--help"):
+        console.print("[bold]cutip ps[/bold] [list|logs|stop|inspect|clean] [<cu-id>]")
+        console.print("  list      List background processes (default)")
+        console.print("  logs      Tail stdout of a process")
+        console.print("  stop      Request stop + cascade-kill remote PIDs")
+        console.print("  inspect   Show meta + tracked remote PIDs")
+        console.print("  clean     Delete completed processes older than 7 days")
+        return
+
+    if subcmd == "list":
+        rows = list(_proc.list_processes())
+        if not rows:
+            console.print("[dim]No background processes.[/dim]")
+            return
+        table = Table(box=box.ROUNDED, title_style="bold")
+        table.add_column("cu-id", style="cyan")
+        table.add_column("project")
+        table.add_column("status")
+        table.add_column("started")
+        table.add_column("pid")
+        for m in rows:
+            color = {
+                "running": "green",
+                "starting": "yellow",
+                "succeeded": "green",
+                "failed": "red",
+                "stopped": "yellow",
+            }.get(m.status, "dim")
+            table.add_row(
+                m.cu_id,
+                m.project,
+                f"[{color}]{m.status}[/{color}]",
+                m.started_at,
+                str(m.host_pid or ""),
+            )
+        console.print(table)
+        return
+
+    if subcmd == "clean":
+        pruned = _proc.prune(older_than_days=7)
+        if pruned:
+            console.print(f"Pruned {len(pruned)} process(es):")
+            for cu in pruned:
+                console.print(f"  {cu}")
+        else:
+            console.print("[dim]Nothing to prune.[/dim]")
+        return
+
+    # All other subcommands need a target cu-id
+    if not target:
+        console.print(f"[red]Usage:[/red] cutip ps {subcmd} <cu-id>")
+        sys.exit(1)
+
+    try:
+        cu_id = _proc.resolve_cu_id(target)
+    except ValueError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    if subcmd == "logs":
+        stdout_p = _proc.stdout_path(cu_id)
+        if not stdout_p.exists():
+            console.print(f"[dim]No log yet for {cu_id}.[/dim]")
+            return
+        # Tail-follow the stdout file. Stops on Ctrl-C.
+        try:
+            with open(stdout_p) as f:
+                while True:
+                    line = f.readline()
+                    if line:
+                        sys.stdout.write(line)
+                        sys.stdout.flush()
+                    else:
+                        # Stop tailing if the process is in a terminal state
+                        meta = _proc.read_meta(cu_id)
+                        if _proc.is_terminal(meta.status):
+                            # Drain any remaining lines, then exit
+                            tail = f.read()
+                            if tail:
+                                sys.stdout.write(tail)
+                            return
+                        import time
+
+                        time.sleep(0.5)
+        except KeyboardInterrupt:
+            return
+
+    if subcmd == "stop":
+        meta = _proc.read_meta(cu_id)
+        if _proc.is_terminal(meta.status):
+            console.print(f"[dim]{cu_id} is already {meta.status}.[/dim]")
+            return
+        _proc.request_stop(cu_id)
+        console.print(f"  Stop requested for [cyan]{cu_id}[/cyan]")
+
+        # Cascade-kill: SIGTERM remote PIDs immediately so the daemon's
+        # shell session unwinds without having to wait for it to poll.
+        remote = _proc.list_remote_pids(cu_id)
+        if remote:
+            console.print(f"  Killing {len(remote)} remote process(es)...")
+            from rsty import ssh
+            from collections import defaultdict
+
+            by_host: dict[tuple[str, str], list[int]] = defaultdict(list)
+            for r in remote:
+                by_host[(r.host, r.username)].append(r.pid)
+            for (host, user), pids in by_host.items():
+                # We need the host's password — read from the cu-id's hosts cache
+                # if we cached it, otherwise fall back to user's hosts.yaml. For
+                # now keep it simple: we ONLY know the cu-id's project root.
+                # Best-effort: skip if we can't auth. The local SIGTERM (next)
+                # will at minimum kill the daemon and close SSH, which usually
+                # unwinds remote processes.
+                try:
+                    project_path = Path(meta.project_path)
+                    hp = project_path.parent / "hosts.yaml"
+                    if hp.exists():
+                        import yaml as _yaml
+
+                        with open(hp) as fh:
+                            h = _yaml.safe_load(fh) or {}
+                        password = h.get("password", "")
+                        if not password:
+                            console.print(
+                                f"  [yellow]⚠[/yellow] No password for {host} — "
+                                f"local SIGTERM only"
+                            )
+                            continue
+                        sesh = ssh.open(host=host, username=user, password=password)
+                        for pid in pids:
+                            try:
+                                ssh.signal(sesh, pid, "TERM")
+                                console.print(f"    SIGTERM → {host}:{pid}")
+                            except Exception as e:
+                                console.print(
+                                    f"    [yellow]⚠[/yellow] {host}:{pid} — {e}"
+                                )
+                        sesh.close()
+                except Exception as e:
+                    console.print(f"  [yellow]⚠[/yellow] {host}: {e}")
+
+        # Local SIGTERM the daemon
+        if meta.host_pid:
+            try:
+                if sys.platform == "win32":
+                    import signal
+
+                    os.kill(meta.host_pid, signal.CTRL_BREAK_EVENT)
+                else:
+                    import signal
+
+                    os.kill(meta.host_pid, signal.SIGTERM)
+                console.print(f"  SIGTERM → daemon pid {meta.host_pid}")
+            except ProcessLookupError:
+                pass
+            except PermissionError:
+                console.print(
+                    f"  [yellow]⚠[/yellow] No permission to signal {meta.host_pid}"
+                )
+
+        # Safety net: if the daemon doesn't update its own meta within 2s
+        # (e.g., it died before its SIGTERM handler ran), force the meta
+        # to "stopped" so `cutip ps` doesn't show a phantom "running" entry.
+        import time as _time
+
+        for _ in range(20):
+            _time.sleep(0.1)
+            if _proc.is_terminal(_proc.read_meta(cu_id).status):
+                return
+        _proc.update_meta(
+            cu_id,
+            status="stopped",
+            finished_at=_proc.now_iso(),
+            error="forced stop (daemon did not update meta)",
+        )
+        _proc.clear_stop(cu_id)
+        return
+
+    if subcmd == "inspect":
+        meta = _proc.read_meta(cu_id)
+        from dataclasses import asdict
+
+        console.print(
+            Panel(
+                json.dumps(asdict(meta), indent=2),
+                title=f"cutip ps inspect {cu_id}",
+                box=box.ROUNDED,
+            )
+        )
+        remote = _proc.list_remote_pids(cu_id)
+        if remote:
+            t = Table(title="Tracked remote processes", box=box.ROUNDED)
+            t.add_column("host", style="cyan")
+            t.add_column("user")
+            t.add_column("pid")
+            t.add_column("label")
+            t.add_column("started")
+            for r in remote:
+                t.add_row(r.host, r.username, str(r.pid), r.label, r.started_at)
+            console.print(t)
+        return
+
+    console.print(f"[red]Unknown ps subcommand:[/red] {subcmd}")
+    sys.exit(1)
+
+
 COMMANDS = {
     "init": cmd_init,
     "validate": cmd_validate,
@@ -1064,12 +1311,28 @@ COMMANDS = {
     "secrets": cmd_secrets,
     "hosts": cmd_hosts,
     "verify": cmd_verify,
+    "ps": cmd_ps,
 }
 
 
 def main():
     """Entry point for `cutip` and `python -m cutip`."""
     args = sys.argv[1:]
+
+    # Internal: daemon stage of `cutip run --bg`. The parent process spawns
+    # us with `cutip --bg-daemon <cu-id> [--hosts <path>]` and we run the
+    # workflow with stdout/stderr already redirected by the parent.
+    if args and args[0] == "--bg-daemon":
+        if len(args) < 2:
+            print("usage: cutip --bg-daemon <cu-id> [--hosts <path>]", file=sys.stderr)
+            sys.exit(2)
+        cu_id = args[1]
+        hosts_path = None
+        if len(args) >= 4 and args[2] == "--hosts":
+            hosts_path = args[3]
+        from cutip.daemon import run_daemon
+
+        sys.exit(run_daemon(cu_id, hosts_path))
 
     if not args or args[0] in ("-h", "--help", "help"):
         console.print(
@@ -1086,7 +1349,8 @@ def main():
                 "  vars       Manage project variables (list/get/set)\n"
                 "  secrets    Manage project secrets (list/get/set)\n"
                 "  hosts      Manage connection credentials (list/get/set)\n"
-                "  verify     Check prerequisites\n\n"
+                "  verify     Check prerequisites\n"
+                "  ps         List/inspect/stop background runs (cutip run --bg)\n\n"
                 "[bold]Usage:[/bold]\n"
                 "  cutip init myproject\n"
                 "  cutip run myproject.yaml\n"
@@ -1160,6 +1424,23 @@ def main():
         COMMANDS[command](parsed)
         return
 
+    if command == "ps":
+        # cutip ps [list|logs|stop|inspect|clean] [<cu-id>]
+        if remaining and remaining[0] in (
+            "list",
+            "logs",
+            "stop",
+            "inspect",
+            "clean",
+            "help",
+        ):
+            parsed["subcmd"] = remaining[0]
+            remaining = remaining[1:]
+        if remaining:
+            parsed["key"] = remaining[0]
+        COMMANDS[command](parsed)
+        return
+
     i = 0
     positional_consumed = False
     while i < len(remaining):
@@ -1169,6 +1450,9 @@ def main():
             i += 1
         elif arg == "--json":
             parsed["json"] = True
+            i += 1
+        elif arg == "--bg":
+            parsed["bg"] = True
             i += 1
         elif arg == "--hosts" and i + 1 < len(remaining):
             parsed["hosts"] = remaining[i + 1]

--- a/cutip/daemon.py
+++ b/cutip/daemon.py
@@ -1,0 +1,236 @@
+"""Background daemon spawning for ``cutip run --bg``.
+
+Cross-platform via subprocess (no fork/exec). The parent process:
+
+  1. Creates ``~/.cutip/processes/<cu-id>/`` with initial meta.json
+  2. Spawns a detached child: ``cutip --bg-daemon <cu-id>``
+  3. Prints the cu-id and exits
+
+The detached child re-reads the meta, redirects stdout/stderr to log files,
+runs the workflow, and updates meta on exit.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from cutip import processes
+
+
+def spawn_daemon(
+    cu_id: str,
+    project_path: Path,
+    workflow_path: Path,
+    *,
+    hosts_path: str | None = None,
+) -> int:
+    """Fork a detached cutip process to run the workflow in the background.
+
+    Returns the spawned PID. Writes initial meta.json before spawn.
+    Caller is responsible for printing the cu-id to the user.
+    """
+    import subprocess
+
+    # Initial meta — daemon will update once it starts
+    meta = processes.Meta(
+        cu_id=cu_id,
+        project=project_path.stem,
+        project_path=str(project_path.resolve()),
+        workflow_path=str(workflow_path.resolve()),
+        cwd=str(Path.cwd()),
+        started_at=processes.now_iso(),
+        status="starting",
+    )
+    processes.write_meta(meta)
+
+    # Build the child command. We invoke cutip itself with a hidden flag.
+    # Using `python -m cutip` rather than the `cutip` script is the most
+    # portable: works whether installed in a venv, with `uv tool install`,
+    # or via editable install. sys.executable points at the same Python.
+    cmd = [sys.executable, "-m", "cutip", "--bg-daemon", cu_id]
+    if hosts_path:
+        cmd.extend(["--hosts", hosts_path])
+
+    # Open log files now so the daemon can dup2 onto them
+    stdout_f = open(processes.stdout_path(cu_id), "ab", buffering=0)
+    stderr_f = open(processes.stderr_path(cu_id), "ab", buffering=0)
+
+    try:
+        if sys.platform == "win32":
+            # Windows: detach via creation flags. No fork needed.
+            DETACHED_PROCESS = 0x00000008
+            CREATE_NEW_PROCESS_GROUP = 0x00000200
+            creationflags = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+            popen = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_f,
+                stderr=stderr_f,
+                cwd=str(Path.cwd()),
+                close_fds=True,
+                creationflags=creationflags,
+            )
+        else:
+            # Unix: start_new_session=True detaches from controlling terminal
+            popen = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_f,
+                stderr=stderr_f,
+                cwd=str(Path.cwd()),
+                close_fds=True,
+                start_new_session=True,
+            )
+    finally:
+        # Parent doesn't need the file handles — daemon has its own copies via dup
+        stdout_f.close()
+        stderr_f.close()
+
+    processes.update_meta(cu_id, host_pid=popen.pid)
+    return popen.pid
+
+
+def run_daemon(cu_id: str, hosts_path_arg: str | None = None) -> int:
+    """Daemon entry point. Called by ``cutip --bg-daemon <cu-id>``.
+
+    Reads meta, runs the workflow, updates meta on exit.
+    Returns an exit code suitable for sys.exit().
+    """
+    import yaml
+
+    try:
+        meta = processes.read_meta(cu_id)
+    except FileNotFoundError:
+        # Nothing we can do — log to stderr (which is the redirected log file)
+        print(f"[daemon] no meta found for cu-id {cu_id}", file=sys.stderr)
+        return 2
+
+    processes.update_meta(cu_id, status="running")
+
+    # Install SIGTERM handler so `cutip ps stop` can interrupt us cleanly.
+    # Without this, a SIGTERM from the parent kills us mid-action and the
+    # meta.json never transitions out of "running".
+    import signal as _sig
+
+    def _on_sigterm(signum, frame):
+        processes.update_meta(
+            cu_id,
+            status="stopped",
+            finished_at=processes.now_iso(),
+            error="received SIGTERM",
+        )
+        # Re-raise as KeyboardInterrupt so any in-flight `try:` cleanup runs
+        raise KeyboardInterrupt("stop requested")
+
+    if sys.platform != "win32":
+        _sig.signal(_sig.SIGTERM, _on_sigterm)
+
+    project_path = Path(meta.project_path)
+    workflow_path = Path(meta.workflow_path)
+
+    # Re-establish the working directory the user invoked from. Workflow code
+    # often references relative paths.
+    try:
+        os.chdir(meta.cwd)
+    except OSError:
+        pass
+
+    # Load config + hosts the same way cmd_run does
+    with open(project_path) as f:
+        config = yaml.safe_load(f) or {}
+
+    hosts: dict | None = None
+    if hosts_path_arg:
+        hp = Path(hosts_path_arg)
+    else:
+        hp = project_path.parent / "hosts.yaml"
+    if hp.exists():
+        with open(hp) as f:
+            hosts = yaml.safe_load(f) or {}
+
+    # Import the workflow module
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("workflow", str(workflow_path))
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(project_path.parent))
+    spec.loader.exec_module(module)
+
+    # Detect decorator-based workflow
+    from cutip.workflow.decorators import _ACTION_ATTR
+
+    has_actions = any(
+        hasattr(getattr(module, attr, None), _ACTION_ATTR)
+        for attr in dir(module)
+        if callable(getattr(module, attr, None))
+    )
+
+    exit_code = 0
+    error_msg: str | None = None
+
+    try:
+        if has_actions:
+            from cutip.workflow.engine import WorkflowEngine, ActionFailed, ActionEvent
+
+            def on_event(event: ActionEvent) -> None:
+                # Daemon stdout is already redirected to stdout.log — print is enough
+                if event.event == "stage_started":
+                    print(f"\n── {event.action} ──")
+                elif event.event == "action_started":
+                    label = f"  ▶ {event.action}"
+                    if event.attempt > 1:
+                        label += f" (attempt {event.attempt})"
+                    print(label)
+                elif event.event == "action_completed":
+                    print(f"  ✓ {event.action}")
+                elif event.event == "action_failed":
+                    print(f"  ✗ {event.action}: {event.error}", file=sys.stderr)
+                elif event.event == "action_retrying":
+                    print(f"  ↻ {event.action} — {event.detail}")
+                elif event.event == "action_skipped":
+                    print(f"  ○ {event.action} (skipped)")
+
+            engine = WorkflowEngine(module, config, on_event=on_event, hosts=hosts)
+            try:
+                engine.run()
+            except ActionFailed as e:
+                error_msg = str(e)
+                exit_code = 1
+        elif hasattr(module, "run_standalone"):
+            module.run_standalone(config)
+        elif hasattr(module, "main"):
+            module.main(config)
+        else:
+            error_msg = "workflow has no @action functions, run_standalone(), or main()"
+            exit_code = 1
+    except KeyboardInterrupt:
+        # Raised by SIGTERM handler. Meta already updated to "stopped".
+        processes.clear_stop(cu_id)
+        return 130
+    except Exception as e:
+        # Any unexpected failure — capture for the meta file
+        import traceback
+
+        traceback.print_exc(file=sys.stderr)
+        error_msg = f"{type(e).__name__}: {e}"
+        exit_code = 1
+
+    # Determine final status
+    if processes.is_stop_requested(cu_id):
+        status = "stopped"
+    elif exit_code == 0:
+        status = "succeeded"
+    else:
+        status = "failed"
+
+    processes.update_meta(
+        cu_id,
+        status=status,
+        exit_code=exit_code,
+        finished_at=processes.now_iso(),
+        error=error_msg,
+    )
+    processes.clear_stop(cu_id)
+    return exit_code

--- a/cutip/processes.py
+++ b/cutip/processes.py
@@ -1,0 +1,254 @@
+"""Process state management for cutip background runs.
+
+Each `cutip run --bg` invocation writes its state to a directory under
+``~/.cutip/processes/<cu-id>/``. State is plain files so any of these
+work without a daemon: `cutip ps`, `cutip ps logs`, `cutip ps stop`,
+`cutip ps inspect` — they all just read/write files in this directory.
+
+Layout::
+
+    ~/.cutip/processes/snf-build-7f3a/
+    ├── meta.json       # project, started_at, status, host_pid, exit_code, ...
+    ├── stdout.log      # streamed during run; tail -f-able
+    ├── stderr.log      # streamed
+    ├── remote.json     # remote PIDs the daemon spawned (for cascade-kill)
+    └── stop.lock       # presence = stop requested; daemon polls + acts
+
+Status values: ``starting``, ``running``, ``succeeded``, ``failed``, ``stopped``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+
+# ── Layout ──────────────────────────────────────────────────────────────────
+
+
+def root_dir() -> Path:
+    """Return ``~/.cutip/processes/`` (creating it if missing)."""
+    p = Path.home() / ".cutip" / "processes"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def process_dir(cu_id: str) -> Path:
+    return root_dir() / cu_id
+
+
+def meta_path(cu_id: str) -> Path:
+    return process_dir(cu_id) / "meta.json"
+
+
+def stdout_path(cu_id: str) -> Path:
+    return process_dir(cu_id) / "stdout.log"
+
+
+def stderr_path(cu_id: str) -> Path:
+    return process_dir(cu_id) / "stderr.log"
+
+
+def remote_path(cu_id: str) -> Path:
+    return process_dir(cu_id) / "remote.json"
+
+
+def stop_lock_path(cu_id: str) -> Path:
+    return process_dir(cu_id) / "stop.lock"
+
+
+# ── cu-id generation ────────────────────────────────────────────────────────
+
+
+def make_cu_id(project: str) -> str:
+    """Return ``<project>-<4hex>`` slug, unique within the processes dir."""
+    base = project.lower().replace("/", "-").replace(" ", "-")
+    salt = f"{project}-{time.time_ns()}-{os.getpid()}"
+    short = hashlib.sha256(salt.encode()).hexdigest()[:4]
+    cu_id = f"{base}-{short}"
+    # Collision is essentially impossible given time_ns, but be safe.
+    n = 1
+    while process_dir(cu_id).exists():
+        n += 1
+        cu_id = f"{base}-{short}-{n}"
+    return cu_id
+
+
+def resolve_cu_id(prefix_or_id: str) -> str:
+    """Resolve a (possibly partial) cu-id to a full one.
+
+    Accepts an exact match, a unique prefix, or a unique 4-hex suffix.
+    Raises ValueError if ambiguous or not found.
+    """
+    candidates = [d.name for d in root_dir().iterdir() if d.is_dir()]
+
+    # Exact match
+    if prefix_or_id in candidates:
+        return prefix_or_id
+
+    # Prefix match
+    prefixed = [c for c in candidates if c.startswith(prefix_or_id)]
+    if len(prefixed) == 1:
+        return prefixed[0]
+    if len(prefixed) > 1:
+        raise ValueError(
+            f"Ambiguous cu-id prefix '{prefix_or_id}': matches {', '.join(sorted(prefixed))}"
+        )
+
+    # Suffix match (e.g., user typed just '7f3a')
+    suffixed = [c for c in candidates if c.endswith(f"-{prefix_or_id}")]
+    if len(suffixed) == 1:
+        return suffixed[0]
+    if len(suffixed) > 1:
+        raise ValueError(
+            f"Ambiguous cu-id suffix '{prefix_or_id}': matches {', '.join(sorted(suffixed))}"
+        )
+
+    raise ValueError(f"No cutip process found matching '{prefix_or_id}'")
+
+
+# ── Meta ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Meta:
+    """Process metadata stored at ~/.cutip/processes/<cu-id>/meta.json."""
+
+    cu_id: str
+    project: str
+    project_path: str  # absolute path to the project YAML
+    workflow_path: str  # absolute path to the workflow file
+    cwd: str  # working directory at spawn time
+    started_at: str  # ISO 8601
+    status: str = "starting"
+    host_pid: int | None = None  # the daemon's PID on this machine
+    exit_code: int | None = None
+    finished_at: str | None = None
+    error: str | None = None  # short error message if status == "failed"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def write_meta(meta: Meta) -> None:
+    process_dir(meta.cu_id).mkdir(parents=True, exist_ok=True)
+    meta_path(meta.cu_id).write_text(json.dumps(asdict(meta), indent=2))
+
+
+def read_meta(cu_id: str) -> Meta:
+    raw = meta_path(cu_id).read_text()
+    return Meta(**json.loads(raw))
+
+
+def update_meta(cu_id: str, **fields) -> Meta:
+    """Read meta, update given fields, write back. Returns the new Meta."""
+    meta = read_meta(cu_id)
+    for k, v in fields.items():
+        setattr(meta, k, v)
+    write_meta(meta)
+    return meta
+
+
+def list_processes() -> Iterator[Meta]:
+    """Yield Meta for every process in the state dir, newest first."""
+    items: list[Meta] = []
+    for d in root_dir().iterdir():
+        if not d.is_dir():
+            continue
+        try:
+            items.append(read_meta(d.name))
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
+    items.sort(key=lambda m: m.started_at, reverse=True)
+    yield from items
+
+
+# ── Remote PID tracking ─────────────────────────────────────────────────────
+
+
+@dataclass
+class RemoteProc:
+    host: str
+    username: str  # may be redacted before display, kept for cascade-kill SSH
+    pid: int
+    label: str  # human-readable label for `cutip ps inspect`
+    started_at: str = field(default_factory=now_iso)
+
+
+def append_remote_pid(cu_id: str, proc: RemoteProc) -> None:
+    """Append a remote process record to remote.json (creates file if missing)."""
+    path = remote_path(cu_id)
+    procs: list[dict] = []
+    if path.exists():
+        try:
+            procs = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            procs = []
+    procs.append(asdict(proc))
+    path.write_text(json.dumps(procs, indent=2))
+
+
+def list_remote_pids(cu_id: str) -> list[RemoteProc]:
+    path = remote_path(cu_id)
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return []
+    return [RemoteProc(**r) for r in raw]
+
+
+# ── Stop signaling ──────────────────────────────────────────────────────────
+
+
+def request_stop(cu_id: str) -> None:
+    """Write stop.lock so the daemon knows to terminate."""
+    stop_lock_path(cu_id).touch()
+
+
+def is_stop_requested(cu_id: str) -> bool:
+    return stop_lock_path(cu_id).exists()
+
+
+def clear_stop(cu_id: str) -> None:
+    p = stop_lock_path(cu_id)
+    if p.exists():
+        p.unlink()
+
+
+# ── Cleanup ─────────────────────────────────────────────────────────────────
+
+
+def is_terminal(status: str) -> bool:
+    return status in ("succeeded", "failed", "stopped")
+
+
+def prune(older_than_days: int = 7) -> list[str]:
+    """Delete process dirs whose status is terminal and older than N days.
+
+    Returns the list of cu-ids that were pruned.
+    """
+    import shutil
+
+    cutoff = time.time() - older_than_days * 86400
+    pruned: list[str] = []
+    for meta in list_processes():
+        if not is_terminal(meta.status):
+            continue
+        finished = meta.finished_at or meta.started_at
+        try:
+            ts = datetime.fromisoformat(finished).timestamp()
+        except ValueError:
+            continue
+        if ts < cutoff:
+            shutil.rmtree(process_dir(meta.cu_id), ignore_errors=True)
+            pruned.append(meta.cu_id)
+    return pruned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ omit = [
     "cutip/__main__.py",
     "cutip/cli.py",           # tested via subprocess integration (test_cli.py)
     "cutip/workflow/commands.py",  # AST utility, low-priority coverage
+    "cutip/daemon.py",        # tested via integration (cutip run --bg)
 ]
 
 [tool.coverage.report]

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -1,0 +1,206 @@
+"""Tests for cutip.processes — background-run state directory."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cutip import processes
+
+
+@pytest.fixture(autouse=True)
+def isolated_root(tmp_path, monkeypatch):
+    """Redirect ~/.cutip/processes/ to a tmp dir for each test."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Re-resolve home in case any path was cached
+    yield tmp_path
+
+
+def _make_meta(cu_id: str, **overrides) -> processes.Meta:
+    defaults = dict(
+        cu_id=cu_id,
+        project="test-project",
+        project_path="/tmp/test.yaml",
+        workflow_path="/tmp/test.workflow.py",
+        cwd="/tmp",
+        started_at=processes.now_iso(),
+    )
+    defaults.update(overrides)
+    return processes.Meta(**defaults)
+
+
+def test_make_cu_id_format():
+    cu_id = processes.make_cu_id("my-project")
+    parts = cu_id.split("-")
+    assert parts[0] == "my"
+    assert parts[1] == "project"
+    # Last part is 4 hex chars
+    assert len(parts[-1]) == 4
+    assert all(c in "0123456789abcdef" for c in parts[-1])
+
+
+def test_make_cu_id_collision_handling():
+    """Two cu-ids for the same project should differ."""
+    a = processes.make_cu_id("dup")
+    # Force collision by writing a meta first
+    processes.write_meta(_make_meta(a))
+    b = processes.make_cu_id("dup")
+    assert a != b
+
+
+def test_write_read_meta_roundtrip():
+    cu_id = "test-1234"
+    m = _make_meta(cu_id, host_pid=999, status="running")
+    processes.write_meta(m)
+    m2 = processes.read_meta(cu_id)
+    assert m2.cu_id == cu_id
+    assert m2.host_pid == 999
+    assert m2.status == "running"
+    # Verify on-disk JSON shape
+    raw = json.loads(processes.meta_path(cu_id).read_text())
+    assert raw["cu_id"] == cu_id
+    assert raw["host_pid"] == 999
+
+
+def test_update_meta():
+    cu_id = "test-update"
+    processes.write_meta(_make_meta(cu_id))
+    processes.update_meta(cu_id, status="succeeded", exit_code=0)
+    m = processes.read_meta(cu_id)
+    assert m.status == "succeeded"
+    assert m.exit_code == 0
+
+
+def test_list_processes_newest_first():
+    a = _make_meta("test-alpha")
+    b = _make_meta("test-beta")
+    a.started_at = "2026-04-28T10:00:00+00:00"
+    b.started_at = "2026-04-28T11:00:00+00:00"  # 1 hour newer
+    processes.write_meta(a)
+    processes.write_meta(b)
+    listed = list(processes.list_processes())
+    ids = [m.cu_id for m in listed]
+    assert ids[0] == "test-beta"  # newest first
+    assert "test-alpha" in ids
+
+
+def test_resolve_cu_id_exact():
+    processes.write_meta(_make_meta("exact-match-abcd"))
+    assert processes.resolve_cu_id("exact-match-abcd") == "exact-match-abcd"
+
+
+def test_resolve_cu_id_prefix():
+    processes.write_meta(_make_meta("prefix-test-xxxx"))
+    assert processes.resolve_cu_id("prefix-test") == "prefix-test-xxxx"
+
+
+def test_resolve_cu_id_suffix():
+    processes.write_meta(_make_meta("project-aaaa"))
+    assert processes.resolve_cu_id("aaaa") == "project-aaaa"
+
+
+def test_resolve_cu_id_ambiguous_prefix():
+    processes.write_meta(_make_meta("amb-1111"))
+    processes.write_meta(_make_meta("amb-2222"))
+    with pytest.raises(ValueError, match="Ambiguous"):
+        processes.resolve_cu_id("amb")
+
+
+def test_resolve_cu_id_not_found():
+    with pytest.raises(ValueError, match="No cutip process"):
+        processes.resolve_cu_id("nonexistent-xxxx")
+
+
+def test_remote_pid_tracking():
+    cu_id = "remote-test-abcd"
+    processes.write_meta(_make_meta(cu_id))
+
+    p1 = processes.RemoteProc(host="h1", username="u1", pid=100, label="make-A")
+    p2 = processes.RemoteProc(host="h2", username="u1", pid=200, label="make-B")
+    processes.append_remote_pid(cu_id, p1)
+    processes.append_remote_pid(cu_id, p2)
+
+    listed = processes.list_remote_pids(cu_id)
+    assert len(listed) == 2
+    assert listed[0].host == "h1"
+    assert listed[1].pid == 200
+
+
+def test_list_remote_pids_empty():
+    cu_id = "no-remote-abcd"
+    processes.write_meta(_make_meta(cu_id))
+    assert processes.list_remote_pids(cu_id) == []
+
+
+def test_stop_signaling():
+    cu_id = "stop-test-abcd"
+    processes.write_meta(_make_meta(cu_id))
+    assert processes.is_stop_requested(cu_id) is False
+    processes.request_stop(cu_id)
+    assert processes.is_stop_requested(cu_id) is True
+    processes.clear_stop(cu_id)
+    assert processes.is_stop_requested(cu_id) is False
+
+
+def test_is_terminal():
+    assert processes.is_terminal("succeeded") is True
+    assert processes.is_terminal("failed") is True
+    assert processes.is_terminal("stopped") is True
+    assert processes.is_terminal("running") is False
+    assert processes.is_terminal("starting") is False
+
+
+def test_prune_keeps_running():
+    """Running processes should never be pruned regardless of age."""
+    cu_id = "running-old-abcd"
+    # Old started_at, but status running
+    from datetime import datetime, timedelta, timezone
+
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat(
+        timespec="seconds"
+    )
+    m = _make_meta(cu_id, status="running")
+    m.started_at = old
+    processes.write_meta(m)
+
+    pruned = processes.prune(older_than_days=7)
+    assert cu_id not in pruned
+    assert processes.process_dir(cu_id).exists()
+
+
+def test_prune_removes_old_completed():
+    cu_id = "old-completed-abcd"
+    from datetime import datetime, timedelta, timezone
+
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat(
+        timespec="seconds"
+    )
+    m = _make_meta(cu_id, status="succeeded")
+    m.started_at = old
+    m.finished_at = old
+    processes.write_meta(m)
+
+    pruned = processes.prune(older_than_days=7)
+    assert cu_id in pruned
+    assert not processes.process_dir(cu_id).exists()
+
+
+def test_prune_keeps_recent_completed():
+    cu_id = "recent-ok-abcd"
+    m = _make_meta(cu_id, status="succeeded")
+    m.finished_at = processes.now_iso()
+    processes.write_meta(m)
+
+    pruned = processes.prune(older_than_days=7)
+    assert cu_id not in pruned
+
+
+def test_path_helpers():
+    cu_id = "paths-test-abcd"
+    assert processes.process_dir(cu_id).name == cu_id
+    assert processes.meta_path(cu_id).name == "meta.json"
+    assert processes.stdout_path(cu_id).name == "stdout.log"
+    assert processes.stderr_path(cu_id).name == "stderr.log"
+    assert processes.remote_path(cu_id).name == "remote.json"
+    assert processes.stop_lock_path(cu_id).name == "stop.lock"


### PR DESCRIPTION
## Summary

Phase 2 of the streaming + background-processes design. Adds detached workflow runs.

### New CLI surface
- \`cutip run --bg\` — spawn a detached daemon, return cu-id (e.g. \`snf-build-7f3a\`)
- \`cutip ps\` — list/inspect/stop/clean background runs (works outside any workspace)
  - \`ps\`, \`ps logs <id>\`, \`ps stop <id>\`, \`ps inspect <id>\`, \`ps clean\`
  - Accepts exact id, unique prefix, or unique suffix

### State layout
\`\`\`
~/.cutip/processes/<cu-id>/
├── meta.json     (project, status, host_pid, exit_code, ...)
├── stdout.log    (streamed)
├── stderr.log
├── remote.json   (tracked remote PIDs — Phase 2d)
└── stop.lock     (presence = stop requested)
\`\`\`

### Cross-platform
- Unix: \`subprocess.Popen(start_new_session=True)\` detaches from controlling terminal
- Windows: \`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP\` flags
- No fork/exec — works on both

### What's deferred to Phase 2d
Workflow opt-in to remote PID tracking (so \`cutip ps stop\` cascade-kills SSH-spawned processes on the actual remote hosts). Current stop only does local SIGTERM + best-effort SSH SIGTERM if a hosts.yaml is present.

## Test plan
- [x] 91 unit tests pass (18 new in tests/test_processes.py)
- [x] Coverage 79%
- [x] Manual end-to-end: spawned a 4s workflow → status went \`succeeded\`, logs captured
- [x] Manual stop: spawned a 60s workflow, ran \`ps stop\` after 2s → status \`stopped\`, daemon killed
- [x] cu-id prefix + suffix resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)