### PR TITLE
release v2.8.0 — ctx.exec_tracked for cascade-kill

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.7.0"
+VERSION = "2.8.0"
 console = Console()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.7.0"
+version = "2.8.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Bundles Phase 2d (ctx.exec_tracked from PR #167) so workflows can opt into remote-PID tracking for cutip ps stop cascade-kill. snf-build retrofit lives in cutip-projects, not in this repo.