### PR TITLE
fix: daemon UTF-8 on Windows + bump 2.8.1

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.8.0"
+VERSION = "2.8.1"
 console = Console()
 
 

--- a/cutip/daemon.py
+++ b/cutip/daemon.py
@@ -100,6 +100,18 @@ def run_daemon(cu_id: str, hosts_path_arg: str | None = None) -> int:
     """
     import yaml
 
+    # Force UTF-8 on the redirected stdout/stderr. On Windows, when stdout
+    # is redirected to a file, Python defaults to the locale encoding
+    # (cp1252) which can't encode common Unicode glyphs (── ✓ → ⚠ etc.) we
+    # use in workflow output. errors='replace' is a safety net so any
+    # unexpected byte still doesn't crash the daemon.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        # Older Python or non-text streams — leave alone.
+        pass
+
     try:
         meta = processes.read_meta(cu_id)
     except FileNotFoundError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.8.0"
+version = "2.8.1"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.7.0"
+version = "2.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Daemon crashed on the first ── glyph because Python defaults redirected stdout to cp1252 on Windows. Force UTF-8 with errors='replace' safety net.