### PR TITLE
fix daemon: line-buffer stdout — v2.8.3

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.8.2"
+VERSION = "2.8.3"
 console = Console()
 
 

--- a/cutip/daemon.py
+++ b/cutip/daemon.py
@@ -123,9 +123,18 @@ def run_daemon(cu_id: str, hosts_path_arg: str | None = None) -> int:
     # (cp1252) which can't encode common Unicode glyphs (── ✓ → ⚠ etc.) we
     # use in workflow output. errors='replace' is a safety net so any
     # unexpected byte still doesn't crash the daemon.
+    #
+    # line_buffering=True forces a flush on every newline. Without this,
+    # Python uses block buffering when stdout is a file (~8KB), which
+    # means `cutip ps logs` sees nothing for long stretches even though
+    # the daemon is actively writing.
     try:
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+        sys.stdout.reconfigure(
+            encoding="utf-8", errors="replace", line_buffering=True
+        )
+        sys.stderr.reconfigure(
+            encoding="utf-8", errors="replace", line_buffering=True
+        )
     except (AttributeError, ValueError):
         # Older Python or non-text streams — leave alone.
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.8.2"
+version = "2.8.3"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.8.2"
+version = "2.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Daemon was block-buffering stdout when redirected to a file → cutip ps logs saw nothing for long stretches. Add line_buffering=True to the reconfigure call.