### PR TITLE
validate: empty vars + path existence — v2.9.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.8.4"
+VERSION = "2.9.0"
 console = Console()
 
 

--- a/cutip/workflow/validate.py
+++ b/cutip/workflow/validate.py
@@ -10,6 +10,26 @@ from pathlib import Path
 from typing import Any
 
 
+def _absolute_local_path(value: Any) -> Path | None:
+    """Return a Path if `value` looks like an absolute local path, else None.
+
+    Detects Unix absolute (`/...`), home-relative (`~/...`), and Windows
+    drive-letter paths (`C:\\...` or `C:/...`). Relative paths return None
+    because they could be relative to anywhere (incl. a remote host).
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    s = value.strip()
+    if s.startswith("~"):
+        return Path(s).expanduser()
+    if s.startswith("/"):
+        return Path(s)
+    # Windows drive letters: C:\ or C:/
+    if len(s) >= 3 and s[1] == ":" and s[2] in ("/", "\\"):
+        return Path(s)
+    return None
+
+
 def validate_project(
     project_path: Path,
     config: dict[str, Any],
@@ -57,13 +77,23 @@ def validate_project(
                     f"Workflow syntax error: {workflow_path.name} line {e.lineno}: {e.msg}"
                 )
 
-    # 5. Empty vars
+    # 5. Empty vars (error — must be set before workflow runs)
     vars_dict = config.get("vars") or {}
     empty_vars = [k for k, v in vars_dict.items() if not v]
     if empty_vars:
-        warnings.append(
-            f"Empty vars (use 'cutip vars set' or will be prompted): {', '.join(empty_vars)}"
+        errors.append(f"Empty vars: {', '.join(empty_vars)}")
+        errors.append(
+            f"  Set with: cutip vars set {' '.join(f'{k}=<value>' for k in empty_vars)}"
         )
+
+    # 5b. Path-shaped vars must point to existing local paths
+    # Heuristic: only flag values that look like absolute paths (Unix /,
+    # home-relative ~/, or Windows drive C:\). Relative paths are skipped
+    # because they could be relative to anywhere (including a remote host).
+    for k, v in vars_dict.items():
+        path = _absolute_local_path(v)
+        if path is not None and not path.exists():
+            errors.append(f"vars.{k} = {v!r} — path does not exist")
 
     # 6. Empty secrets
     secrets_dict = config.get("secrets") or {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.8.4"
+version = "2.9.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -104,3 +104,64 @@ class TestValidateProject:
         )
         cred_errors = [e for e in errors if "missing" in e.lower() and "SSH" in e]
         assert cred_errors == []
+
+    def test_empty_vars_are_errors(self, tmp_path):
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "vars": {"foo": "", "bar": "set"}},
+        )
+        assert any("Empty vars" in e and "foo" in e for e in errors)
+        # 'bar' is set, shouldn't appear in the empty-vars error
+        empty_err = next(e for e in errors if "Empty vars" in e)
+        assert "bar" not in empty_err
+
+    def test_var_with_nonexistent_absolute_path_errors(self, tmp_path):
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {
+                "project": "test",
+                "host": "local",
+                "vars": {"my_repo": "/nonexistent/path/abc-test-xyz-12345"},
+            },
+        )
+        assert any("path does not exist" in e and "my_repo" in e for e in errors)
+
+    def test_var_with_existing_absolute_path_passes(self, tmp_path):
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "vars": {"tmp_dir": "/tmp"}},
+        )
+        path_errors = [e for e in errors if "path does not exist" in e]
+        assert path_errors == []
+
+    def test_var_with_relative_path_skipped(self, tmp_path):
+        """Relative paths could be relative to anywhere — don't validate them."""
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {
+                "project": "test",
+                "host": "local",
+                "vars": {"some_path": "relative/path/that/does/not/exist"},
+            },
+        )
+        path_errors = [e for e in errors if "path does not exist" in e]
+        assert path_errors == []
+
+    def test_var_with_home_relative_path(self, tmp_path):
+        """~/ paths should be expanded and checked."""
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "vars": {"home": "~"}},
+        )
+        # ~ expands to a real dir
+        path_errors = [e for e in errors if "path does not exist" in e]
+        assert path_errors == []
+
+    def test_var_with_non_path_string_skipped(self, tmp_path):
+        """Plain strings (no leading /) shouldn't be path-checked."""
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "vars": {"greeting": "hello world"}},
+        )
+        path_errors = [e for e in errors if "path does not exist" in e]
+        assert path_errors == []

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.8.4"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Empty vars are now errors. Vars with absolute path values are existence-checked. cmd_run still prompts before validate, so the prompt UX for empty vars is preserved.