### PR TITLE
hosts: nested + global formats; add typed paths section — v2.10.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -91,11 +91,19 @@ def _resolve_workflow(project_path: Path, config: dict) -> Path:
 
 
 def _load_config(project_path: Path) -> dict:
-    """Load and return project config as a dict."""
+    """Load and return project config as a dict.
+
+    Expands the ``paths:`` section against the project file's directory
+    and merges the resolved values into ``config['data']`` so workflow
+    code reads them via ``ctx.data["<name>"]`` like any other entry.
+    """
     import yaml
+
+    from cutip.paths import merge_paths_into_data
 
     with open(project_path) as f:
         config = yaml.safe_load(f) or {}
+    merge_paths_into_data(config, project_path)
     return config
 
 
@@ -513,14 +521,30 @@ def cmd_run(args):
         console.print()
 
     # Load hosts file (for remote connections)
+    # Two values are produced:
+    #   `hosts`           — the raw dict (flat or nested) for backward compat
+    #                       with workflows that use ctx._hosts["host"] directly
+    #   `resolved_hosts`  — the fully resolved nested dict (with global: true
+    #                       references expanded) for ctx.host(name)
     hosts = None
+    resolved_hosts = None
     hosts_path_arg = args.get("hosts")
     if hosts_path_arg:
         hosts_path = Path(hosts_path_arg)
     else:
-        hosts_path = project_path.parent / "hosts.yaml"
+        hosts_path = _resolve_hosts_path(project_path)
 
     if hosts_path.exists():
+        from cutip import hosts as _hosts_mod
+
+        try:
+            resolved_hosts = _hosts_mod.resolve(hosts_path)
+        except _hosts_mod.HostsError as e:
+            console.print(f"[red]Error resolving hosts:[/red] {e}")
+            sys.exit(1)
+        # For flat-format files, ctx._hosts retains the original flat shape
+        # (existing workflows do ctx._hosts["host"]); for nested, ctx._hosts
+        # carries the nested raw dict.
         with open(hosts_path) as f:
             hosts = yaml.safe_load(f) or {}
 
@@ -563,7 +587,7 @@ def cmd_run(args):
     )
 
     if has_actions:
-        _run_with_engine(module, config, project_path, hosts)
+        _run_with_engine(module, config, project_path, hosts, resolved_hosts)
     elif hasattr(module, "run_standalone"):
         module.run_standalone(config)
     elif hasattr(module, "main"):
@@ -575,7 +599,7 @@ def cmd_run(args):
         sys.exit(1)
 
 
-def _run_with_engine(module, config, project_path, hosts=None):
+def _run_with_engine(module, config, project_path, hosts=None, resolved_hosts=None):
     """Execute a workflow using the cutip execution engine."""
     from datetime import datetime
     from cutip.workflow.engine import WorkflowEngine, ActionFailed, ActionEvent
@@ -623,6 +647,8 @@ def _run_with_engine(module, config, project_path, hosts=None):
             pass
 
     engine = WorkflowEngine(module, config, on_event=on_event, hosts=hosts)
+    if resolved_hosts is not None:
+        engine.ctx._resolved_hosts = resolved_hosts
 
     try:
         engine.run()
@@ -930,27 +956,33 @@ def _resolve_hosts_path(project_path: Path) -> Path:
     return hosts_path
 
 
-def cmd_hosts(args):
-    """Manage project hosts file."""
-    subcmd = args.get("subcmd")
-    if not subcmd or subcmd == "help":
-        console.print(
-            "[bold]cutip hosts[/bold] <list|get|set> [project.yaml] [key=value ...]"
-        )
-        console.print("  list   Show all host entries (passwords masked)")
-        console.print("  get    Get a single host value")
-        console.print("  set    Set one or more host values")
+def _print_hosts_dict(data: dict, label: str | None = None) -> None:
+    """Render a hosts dict (nested or flat) with sensitive values masked."""
+    from cutip import hosts as _hosts
+
+    if not data:
+        console.print(f"[dim]No hosts defined{f' in {label}' if label else ''}.[/dim]")
         return
 
-    project_path = _resolve_project(args.get("project"))
-    hosts_path = _resolve_hosts_path(project_path)
-    hosts = _yaml_read(hosts_path)
-
-    if subcmd == "list":
-        if not hosts:
-            console.print(f"[dim]No hosts defined in {hosts_path.name}[/dim]")
-            return
-        for k, v in hosts.items():
+    if _hosts.is_nested(data):
+        for name, entry in data.items():
+            if isinstance(entry, dict) and entry.get("global") is True:
+                console.print(f"  [cyan]{name}[/cyan]  [dim](→ global)[/dim]")
+                continue
+            console.print(f"  [cyan]{name}[/cyan]")
+            if not isinstance(entry, dict):
+                console.print(f"    [red]invalid entry: {entry!r}[/red]")
+                continue
+            for k, v in entry.items():
+                if not v and v != 0:
+                    console.print(f"    {k} = [yellow](empty)[/yellow]")
+                elif _is_sensitive(k):
+                    console.print(f"    {k} = [dim]****[/dim]")
+                else:
+                    console.print(f"    {k} = [dim]{v}[/dim]")
+    else:
+        # Flat (legacy) — render at top level
+        for k, v in data.items():
             if not v and v != 0:
                 console.print(f"  {k} = [yellow](empty)[/yellow]")
             elif _is_sensitive(k):
@@ -958,39 +990,199 @@ def cmd_hosts(args):
             else:
                 console.print(f"  {k} = [dim]{v}[/dim]")
 
-    elif subcmd == "get":
-        key = args.get("key")
-        if not key:
-            console.print("[red]Usage:[/red] cutip hosts get [project.yaml] <key>")
-            sys.exit(1)
-        if key in hosts:
-            console.print(hosts[key] or "")
-        else:
+
+def cmd_hosts(args):
+    """Manage project hosts file (per-project + optional global tier).
+
+    Subcommands:
+      cutip hosts list                  List local entries
+      cutip hosts list -g               List global (~/.cutip/hosts.yaml) entries
+      cutip hosts get <host>.<field>    Get a value (or `<field>` for flat files)
+      cutip hosts get -g <host>.<field> Get from global
+      cutip hosts set <host>.<field>=<value> [...]
+      cutip hosts set -g <host>.<field>=<value> [...]
+      cutip hosts path                  Print local hosts file path
+      cutip hosts path -g               Print global hosts file path
+      cutip hosts set-path -g <path>    Change global hosts file location
+      cutip hosts init -g               Create the global hosts file
+      cutip hosts migrate               Convert flat → nested in this project
+    """
+    from cutip import hosts as _hosts
+
+    subcmd = args.get("subcmd")
+    use_global = bool(args.get("global"))
+
+    if not subcmd or subcmd == "help":
+        console.print(cmd_hosts.__doc__ or "cutip hosts")
+        return
+
+    # Global-only subcommands
+    if subcmd == "init":
+        if not use_global:
             console.print(
-                f"[red]Error:[/red] key '{key}' not found in {hosts_path.name}"
+                "[red]Error:[/red] 'cutip hosts init' is global-only. Use: cutip hosts init -g"
+            )
+            console.print(
+                "  (local hosts.yaml is auto-created on first 'cutip hosts set <host>.<field>=<value>')"
             )
             sys.exit(1)
+        gp = _hosts.global_hosts_path()
+        if gp.exists():
+            console.print(f"[dim]Global hosts file already exists: {gp}[/dim]")
+            return
+        _hosts.write_hosts_file(gp, {})
+        console.print(f"  [green]✓[/green] Created [cyan]{gp}[/cyan]")
+        console.print("  Add entries with: cutip hosts set -g <host>.<field>=<value>")
+        return
 
-    elif subcmd == "set":
+    if subcmd == "set-path":
+        if not use_global:
+            console.print(
+                "[red]Error:[/red] 'cutip hosts set-path' is global-only. Use: cutip hosts set-path -g <path>"
+            )
+            sys.exit(1)
+        new_path = args.get("key")  # parser puts the bare-positional arg in 'key'
+        if not new_path:
+            console.print("[red]Usage:[/red] cutip hosts set-path -g <path>")
+            sys.exit(1)
+        _hosts.set_global_hosts_path(new_path)
+        console.print(f"  [green]✓[/green] Global hosts path → [cyan]{new_path}[/cyan]")
+        console.print(f"  (stored in {_hosts.config_path()})")
+        return
+
+    if subcmd == "path":
+        if use_global:
+            console.print(_hosts.global_hosts_path())
+        else:
+            project_path = _resolve_project(args.get("project"))
+            console.print(_resolve_hosts_path(project_path))
+        return
+
+    # Resolve target file (global or project-local) for list/get/set/migrate
+    if use_global:
+        target_path = _hosts.global_hosts_path()
+        target_label = str(target_path)
+    else:
+        project_path = _resolve_project(args.get("project"))
+        target_path = _resolve_hosts_path(project_path)
+        target_label = target_path.name
+
+    if subcmd == "list":
+        if not target_path.exists():
+            console.print(f"[dim]{target_label} does not exist.[/dim]")
+            if use_global:
+                console.print("  Create with: cutip hosts init -g")
+            return
+        data = _hosts.read_hosts_file(target_path)
+        _print_hosts_dict(data, label=target_label)
+        return
+
+    if subcmd == "get":
+        key = args.get("key")
+        if not key:
+            console.print(
+                "[red]Usage:[/red] cutip hosts get [-g] <host>.<field>  (or <field> for flat files)"
+            )
+            sys.exit(1)
+        data = _hosts.read_hosts_file(target_path)
+        if "." in key:
+            host_name, field = key.split(".", 1)
+            try:
+                resolved = _hosts.resolve(target_path) if not use_global else data
+            except _hosts.HostsError as e:
+                console.print(f"[red]Error:[/red] {e}")
+                sys.exit(1)
+            if host_name not in resolved or not isinstance(
+                resolved.get(host_name), dict
+            ):
+                console.print(
+                    f"[red]Error:[/red] host '{host_name}' not found in {target_label}"
+                )
+                sys.exit(1)
+            value = resolved[host_name].get(field)
+            console.print(value if value is not None else "")
+            return
+        # No dot — treat as flat-file lookup
+        if not _hosts.is_nested(data) and key in data:
+            console.print(data[key] if data[key] is not None else "")
+            return
+        console.print(
+            f"[red]Error:[/red] '{key}' not found in {target_label}. "
+            f"For nested files use '<host>.<field>' syntax."
+        )
+        sys.exit(1)
+
+    if subcmd == "set":
         pairs = args.get("pairs", [])
         if not pairs:
             console.print(
-                "[red]Usage:[/red] cutip hosts set [project.yaml] key=value ..."
+                "[red]Usage:[/red] cutip hosts set [-g] <host>.<field>=<value> ..."
             )
             sys.exit(1)
+        existing = _hosts.read_hosts_file(target_path)
         for pair in pairs:
             if "=" not in pair:
                 console.print(
-                    f"[red]Error:[/red] invalid format '{pair}', expected key=value"
+                    f"[red]Error:[/red] invalid format '{pair}', expected <host>.<field>=<value>"
                 )
                 sys.exit(1)
             k, v = pair.split("=", 1)
-            hosts[k] = v
-            if _is_sensitive(k):
-                console.print(f"  [green]✓[/green] {k} = ****")
+            if "." in k:
+                host_name, field = k.split(".", 1)
+                try:
+                    _hosts.set_field(target_path, host_name, field, v)
+                except _hosts.HostsError as e:
+                    console.print(f"[red]Error:[/red] {e}")
+                    sys.exit(1)
+                disp = "****" if _is_sensitive(field) else v
+                console.print(f"  [green]✓[/green] {host_name}.{field} = {disp}")
             else:
-                console.print(f"  [green]✓[/green] {k} = {v}")
-        _yaml_write(hosts_path, hosts)
+                # Flat-file backward compat: only allowed if file is flat or empty
+                if existing and _hosts.is_nested(existing):
+                    console.print(
+                        f"[red]Error:[/red] {target_label} is in nested format. "
+                        f"Use '<host>.{k}=<value>' instead of '{k}=<value>'."
+                    )
+                    sys.exit(1)
+                existing[k] = v
+                _hosts.write_hosts_file(target_path, existing)
+                disp = "****" if _is_sensitive(k) else v
+                console.print(f"  [green]✓[/green] {k} = {disp}")
+        return
+
+    if subcmd == "migrate":
+        if use_global:
+            console.print("[red]Error:[/red] migrate is project-local only (no -g).")
+            sys.exit(1)
+        if not target_path.exists():
+            console.print(
+                f"[dim]{target_label} does not exist — nothing to migrate.[/dim]"
+            )
+            return
+        existing = _hosts.read_hosts_file(target_path)
+        if _hosts.is_nested(existing):
+            console.print(f"[dim]{target_label} is already in nested format.[/dim]")
+            return
+        # Pick a default name. If the project YAML has a hint, use it; else 'default'.
+        default_name = "default"
+        try:
+            project_path = _resolve_project(args.get("project"))
+            cfg = _load_config(project_path)
+            default_name = cfg.get("project", "default")
+        except SystemExit:
+            pass
+        migrated = _hosts.migrate(target_path, default_name=default_name)
+        if migrated:
+            console.print(
+                f"  [green]✓[/green] Migrated {target_label}: flat → nested under [cyan]{default_name}[/cyan]"
+            )
+            console.print(
+                f"  Workflows should now use ctx.host_for('{default_name}') or update field references."
+            )
+        return
+
+    console.print(f"[red]Unknown hosts subcommand:[/red] {subcmd}")
+    sys.exit(1)
 
 
 def cmd_cmd(args):
@@ -1414,8 +1606,8 @@ def main():
         COMMANDS[command](parsed)
         return
 
-    # Handle subcommand groups (vars, secrets, hosts)
-    if command in ("vars", "secrets", "hosts"):
+    # Handle subcommand groups (vars, secrets)
+    if command in ("vars", "secrets"):
         if remaining and remaining[0] in ("list", "get", "set", "help"):
             parsed["subcmd"] = remaining[0]
             remaining = remaining[1:]
@@ -1429,6 +1621,41 @@ def main():
             elif arg.endswith(".yaml") or Path(arg).exists():
                 parsed["project"] = arg
             elif parsed.get("subcmd") == "get" and "key" not in parsed:
+                parsed["key"] = arg
+            elif not parsed.get("project"):
+                parsed["project"] = arg
+        if pairs:
+            parsed["pairs"] = pairs
+        COMMANDS[command](parsed)
+        return
+
+    # `hosts` has its own richer subcommand surface (list/get/set/path/
+    # set-path/init/migrate, plus the -g flag for global tier).
+    if command == "hosts":
+        valid_subs = {
+            "list",
+            "get",
+            "set",
+            "path",
+            "set-path",
+            "init",
+            "migrate",
+            "help",
+        }
+        if remaining and remaining[0] in valid_subs:
+            parsed["subcmd"] = remaining[0]
+            remaining = remaining[1:]
+        pairs = []
+        for arg in remaining:
+            if arg in ("-h", "--help"):
+                parsed["subcmd"] = "help"
+            elif arg in ("-g", "--global"):
+                parsed["global"] = True
+            elif "=" in arg:
+                pairs.append(arg)
+            elif arg.endswith(".yaml") or Path(arg).exists():
+                parsed["project"] = arg
+            elif parsed.get("subcmd") in ("get", "set-path") and "key" not in parsed:
                 parsed["key"] = arg
             elif not parsed.get("project"):
                 parsed["project"] = arg

--- a/cutip/daemon.py
+++ b/cutip/daemon.py
@@ -177,17 +177,29 @@ def run_daemon(cu_id: str, hosts_path_arg: str | None = None) -> int:
         pass
 
     # Load config + hosts the same way cmd_run does
+    from cutip.paths import merge_paths_into_data
+
     with open(project_path) as f:
         config = yaml.safe_load(f) or {}
+    merge_paths_into_data(config, project_path)
 
     hosts: dict | None = None
+    resolved_hosts: dict | None = None
     if hosts_path_arg:
         hp = Path(hosts_path_arg)
     else:
-        hp = project_path.parent / "hosts.yaml"
+        # Honor data.hosts in the project YAML
+        data_hosts = (config.get("data") or {}).get("hosts", "hosts.yaml")
+        hp = project_path.parent / data_hosts
     if hp.exists():
+        from cutip import hosts as _hosts_mod
+
         with open(hp) as f:
             hosts = yaml.safe_load(f) or {}
+        try:
+            resolved_hosts = _hosts_mod.resolve(hp)
+        except _hosts_mod.HostsError as e:
+            print(f"[daemon] hosts resolve error: {e}", file=sys.stderr)
 
     # Import the workflow module
     import importlib.util
@@ -232,6 +244,8 @@ def run_daemon(cu_id: str, hosts_path_arg: str | None = None) -> int:
                     print(f"  ○ {event.action} (skipped)")
 
             engine = WorkflowEngine(module, config, on_event=on_event, hosts=hosts)
+            if resolved_hosts is not None:
+                engine.ctx._resolved_hosts = resolved_hosts
             try:
                 engine.run()
             except ActionFailed as e:

--- a/cutip/hosts.py
+++ b/cutip/hosts.py
@@ -1,0 +1,239 @@
+"""Hosts file management for cutip.
+
+Two storage tiers:
+  - **local**:  ``<project>/hosts.yaml`` (per-project)
+  - **global**: ``~/.cutip/hosts.yaml`` (shared across projects)
+
+The path of the global file can be changed via ``cutip hosts set-path -g``,
+which writes to ``~/.cutip/config.yaml``.
+
+Two file formats are recognized:
+  - **flat** (legacy): top-level keys are the field names::
+
+        host: 10.0.0.1
+        username: root
+        password: secret
+
+  - **nested** (current): top-level keys are host *names*, each a dict
+    of fields. A host entry can use ``global: true`` to defer to the
+    same name in the global file::
+
+        ub20:
+          host: ub20login-eqx-10
+          username: joshua.jerome
+          password: secret
+        sfm:
+          global: true        # pulled from ~/.cutip/hosts.yaml
+
+The parser auto-detects format on read. Migration (flat → nested) is
+explicit via ``cutip hosts migrate``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+# ── File layout ─────────────────────────────────────────────────────────────
+
+
+def cutip_dir() -> Path:
+    """Return ``~/.cutip/`` (creating it if missing)."""
+    p = Path.home() / ".cutip"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def config_path() -> Path:
+    """Path to ``~/.cutip/config.yaml`` (the cutip global config)."""
+    return cutip_dir() / "config.yaml"
+
+
+def default_global_hosts_path() -> Path:
+    """Default path for the global hosts file."""
+    return cutip_dir() / "hosts.yaml"
+
+
+def global_hosts_path() -> Path:
+    """Resolve the global hosts file path.
+
+    Reads ``hosts_path`` from ``~/.cutip/config.yaml`` if set, otherwise
+    returns the default ``~/.cutip/hosts.yaml``.
+    """
+    cp = config_path()
+    if cp.exists():
+        try:
+            import yaml
+
+            cfg = yaml.safe_load(cp.read_text()) or {}
+            override = cfg.get("hosts_path")
+            if override:
+                return Path(str(override)).expanduser()
+        except Exception:
+            pass
+    return default_global_hosts_path()
+
+
+def set_global_hosts_path(path: Path | str) -> None:
+    """Persist a custom global hosts file path to ``~/.cutip/config.yaml``."""
+    import yaml
+
+    cp = config_path()
+    cfg: dict[str, Any] = {}
+    if cp.exists():
+        try:
+            cfg = yaml.safe_load(cp.read_text()) or {}
+        except Exception:
+            cfg = {}
+    cfg["hosts_path"] = str(Path(str(path)).expanduser())
+    cp.write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+
+# ── Format detection ────────────────────────────────────────────────────────
+
+
+def is_nested(data: dict | None) -> bool:
+    """Return True if `data` is in nested format (host names → field dicts).
+
+    Heuristic: a dict is nested if any top-level value is itself a dict.
+    Empty dict treated as nested (the new default).
+    """
+    if not data:
+        return True
+    return any(isinstance(v, dict) for v in data.values())
+
+
+# ── Read / write ────────────────────────────────────────────────────────────
+
+
+def read_hosts_file(path: Path) -> dict[str, Any]:
+    """Read a hosts file, returning the raw parsed dict.
+
+    Returns an empty dict if the file does not exist.
+    """
+    if not path.exists():
+        return {}
+    import yaml
+
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def write_hosts_file(path: Path, data: dict[str, Any]) -> None:
+    """Write a hosts dict to the given path (creating parent dirs)."""
+    import yaml
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False, default_flow_style=False))
+
+
+# ── Resolution ──────────────────────────────────────────────────────────────
+
+
+class HostsError(RuntimeError):
+    """Raised when hosts files can't be parsed or resolved."""
+
+
+def resolve(local_path: Path) -> dict[str, dict]:
+    """Read local + global, resolve `global: true` references, return nested dict.
+
+    Output is always nested: ``{"<host_name>": {"host": ..., "username": ...,
+    "password": ...}, ...}``.
+
+    For flat-format input files, the entire file becomes a single host
+    entry under the key ``"_default"``. Workflows can read it via
+    ``ctx.host_for("_default")`` — but typically existing workflows that use
+    ``ctx._hosts["host"]`` keep working unchanged because the raw dict
+    is also exposed.
+
+    Raises HostsError if a `global: true` reference can't be resolved.
+    """
+    local = read_hosts_file(local_path)
+
+    if not is_nested(local):
+        # Flat file: wrap as single-entry nested
+        return {"_default": local} if local else {}
+
+    out: dict[str, dict] = {}
+    global_data: dict | None = None  # lazy-load
+
+    for name, entry in local.items():
+        if not isinstance(entry, dict):
+            raise HostsError(
+                f"Host entry '{name}' must be a mapping, got {type(entry).__name__}"
+            )
+
+        # Reference to a global entry
+        if entry.get("global") is True:
+            if global_data is None:
+                gp = global_hosts_path()
+                if not gp.exists():
+                    raise HostsError(
+                        f"Host '{name}' is marked 'global: true' but the global "
+                        f"hosts file does not exist at {gp}. Run: cutip hosts init -g"
+                    )
+                global_data = read_hosts_file(gp)
+                if not is_nested(global_data):
+                    raise HostsError(
+                        f"Global hosts file at {gp} must be in nested format "
+                        f"(host names as top-level keys)"
+                    )
+            if name not in global_data:
+                raise HostsError(
+                    f"Host '{name}' marked 'global: true' but not found in {global_hosts_path()}. "
+                    f"Available: {', '.join(sorted(global_data.keys()))}"
+                )
+            out[name] = dict(global_data[name])
+        else:
+            out[name] = dict(entry)
+
+    return out
+
+
+def get_field(local_path: Path, host_name: str, field: str) -> Any:
+    """Get a single field from a host entry. Returns None if missing."""
+    resolved = resolve(local_path)
+    if host_name not in resolved:
+        return None
+    return resolved[host_name].get(field)
+
+
+def set_field(path: Path, host_name: str, field: str, value: str) -> None:
+    """Set a host's field in the file, ensuring nested format.
+
+    Reads the existing file (if any). If it's in flat format, raises
+    HostsError telling the caller to migrate first. Always writes nested.
+    """
+    data = read_hosts_file(path)
+    if data and not is_nested(data):
+        raise HostsError(
+            f"{path.name} is in flat (legacy) format. Run 'cutip hosts migrate' "
+            f"first, then re-run this command."
+        )
+    if host_name not in data:
+        data[host_name] = {}
+    if not isinstance(data[host_name], dict):
+        raise HostsError(
+            f"Host '{host_name}' has a non-mapping entry: {data[host_name]!r}"
+        )
+    data[host_name][field] = value
+    write_hosts_file(path, data)
+
+
+# ── Migration ───────────────────────────────────────────────────────────────
+
+
+def migrate(path: Path, default_name: str = "default") -> bool:
+    """Convert a flat hosts.yaml to nested in-place.
+
+    Returns True if migrated, False if already nested (no-op) or empty.
+    `default_name` is the host name to use for the converted entry.
+    """
+    data = read_hosts_file(path)
+    if not data:
+        return False
+    if is_nested(data):
+        return False
+    new_data = {default_name: dict(data)}
+    write_hosts_file(path, new_data)
+    return True

--- a/cutip/paths.py
+++ b/cutip/paths.py
@@ -1,0 +1,73 @@
+"""Path expansion + merge for the project YAML ``paths:`` section.
+
+The ``paths:`` section is a typed sibling of ``data:``. Values are filesystem
+paths; cutip expands ``~`` / ``$VAR`` and resolves relatives against the
+project YAML's directory, then merges the result into ``ctx.data`` so workflow
+code reads them like any other data entry.
+
+This module is the single source of truth for that expansion. Both the
+runtime (``cli.py``, ``daemon.py``) and the validator call into it so they
+agree on what each path means.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _looks_absolute(raw: str) -> bool:
+    """True if `raw` should be treated as already-absolute before expansion.
+
+    Covers Unix absolute (``/...``), home-relative (``~/...``), and Windows
+    drive-letter paths (``C:\\`` or ``C:/``). Pure relatives (``./x``,
+    ``foo/bar``) return False — they get resolved against the project dir.
+    """
+    if not raw:
+        return False
+    if raw.startswith(("/", "~")):
+        return True
+    if len(raw) >= 3 and raw[1] == ":" and raw[2] in ("/", "\\"):
+        return True
+    return False
+
+
+def expand_path(value: str, base_dir: Path) -> str:
+    """Expand ``~`` and ``$VAR``; resolve relatives against ``base_dir``.
+
+    Always returns an absolute path string. Empty input returns "" unchanged
+    so the validator can flag it.
+    """
+    if not isinstance(value, str) or not value:
+        return value
+    expanded = os.path.expandvars(os.path.expanduser(value))
+    p = Path(expanded)
+    if not p.is_absolute():
+        p = (base_dir / p).resolve(strict=False)
+    return str(p)
+
+
+def merge_paths_into_data(config: dict[str, Any], project_path: Path) -> None:
+    """Expand each entry under ``paths:`` and merge into ``config['data']``.
+
+    Mutates ``config`` in place. ``paths`` keys that collide with existing
+    ``data`` keys overwrite them — paths are typed and validated, so they win.
+    No-op if ``paths`` is missing or not a mapping.
+    """
+    paths = config.get("paths")
+    if not isinstance(paths, dict):
+        return
+    base = project_path.parent
+    data = config.get("data")
+    if data is None:
+        data = {}
+        config["data"] = data
+    if not isinstance(data, dict):
+        return
+    for k, v in paths.items():
+        if isinstance(v, str):
+            data[k] = expand_path(v, base)
+        else:
+            # Non-string value: pass through; validator will flag.
+            data[k] = v

--- a/cutip/workflow/engine.py
+++ b/cutip/workflow/engine.py
@@ -169,6 +169,46 @@ class WorkflowContext:
         self._kubectl = None
         self._container = None
 
+    def host_for(self, name: str) -> dict[str, str]:
+        """Return the resolved host config for the given name.
+
+        Works regardless of the hosts file format:
+          - **Nested** (current): returns ``{"host": ..., "username": ...,
+            "password": ...}`` for the named entry. Resolves
+            ``global: true`` references against ``~/.cutip/hosts.yaml``
+            transparently.
+          - **Flat** (legacy): the entire flat dict is treated as a single
+            unnamed host. ``ctx.host_for("default")`` (or any name) returns it.
+
+        Raises:
+            KeyError: if ``name`` isn't found in the resolved hosts.
+
+        Example::
+
+            ub20 = ctx.host_for("ub20")
+            sesh = ssh.open(host=ub20["host"], username=ub20["username"],
+                           password=ub20["password"])
+        """
+        # If we already have resolved nested data, look it up
+        resolved = getattr(self, "_resolved_hosts", None)
+        if resolved is not None:
+            if name in resolved:
+                return dict(resolved[name])
+            # For flat-file backward compat: any name returns the flat dict
+            if "_default" in resolved:
+                return dict(resolved["_default"])
+            raise KeyError(
+                f"host '{name}' not found in hosts file. "
+                f"Available: {', '.join(sorted(resolved.keys()))}"
+            )
+
+        # Fall back to the raw _hosts dict (flat, legacy path)
+        if self._hosts:
+            return dict(self._hosts)
+        raise KeyError(
+            f"host '{name}' requested but no hosts file is loaded for this project"
+        )
+
     def exec_tracked(
         self,
         sesh: Any,

--- a/cutip/workflow/validate.py
+++ b/cutip/workflow/validate.py
@@ -158,4 +158,36 @@ def validate_project(
     if raw_data is not None and not isinstance(raw_data, dict):
         errors.append(f"'data' section must be a mapping, got {type(data).__name__}")
 
+    # 10. Paths section
+    raw_paths = config.get("paths")
+    if raw_paths is not None:
+        if not isinstance(raw_paths, dict):
+            errors.append(
+                f"'paths' section must be a mapping, got {type(raw_paths).__name__}"
+            )
+        else:
+            from cutip.paths import _looks_absolute, expand_path
+
+            for key, value in raw_paths.items():
+                if not isinstance(value, str):
+                    errors.append(
+                        f"paths.{key} must be a string, got {type(value).__name__}"
+                    )
+                    continue
+                if not value:
+                    errors.append(f"paths.{key} is empty")
+                    errors.append(
+                        f"  Set with: cutip vars set {key}=<path>  (or edit {project_path.name})"
+                    )
+                    continue
+                was_absolute = _looks_absolute(value)
+                resolved = expand_path(value, project_path.parent)
+                if not Path(resolved).exists():
+                    if was_absolute:
+                        errors.append(f"paths.{key} = {value!r} — path does not exist")
+                    else:
+                        warnings.append(
+                            f"paths.{key} = {value!r} → {resolved} (does not exist)"
+                        )
+
     return errors, warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.9.0"
+version = "2.10.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -1,0 +1,181 @@
+"""Tests for cutip.hosts — local + global hosts file management."""
+
+from __future__ import annotations
+
+import pytest
+
+from cutip import hosts
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect ~/.cutip/ to a tmp dir per-test."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    yield tmp_path
+
+
+# ── Format detection ────────────────────────────────────────────────────────
+
+
+def test_is_nested_with_nested_dict():
+    assert hosts.is_nested({"ub20": {"host": "h", "username": "u"}}) is True
+
+
+def test_is_nested_with_flat_dict():
+    assert hosts.is_nested({"host": "h", "username": "u"}) is False
+
+
+def test_is_nested_with_empty_dict():
+    """Empty defaults to nested (the new default format)."""
+    assert hosts.is_nested({}) is True
+    assert hosts.is_nested(None) is True
+
+
+def test_is_nested_mixed_returns_true():
+    """If any value is a dict, treat as nested."""
+    assert hosts.is_nested({"ub20": {"host": "h"}, "extra": "scalar"}) is True
+
+
+# ── Read / write ────────────────────────────────────────────────────────────
+
+
+def test_write_then_read(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.write_hosts_file(p, {"ub20": {"host": "h", "username": "u"}})
+    data = hosts.read_hosts_file(p)
+    assert data == {"ub20": {"host": "h", "username": "u"}}
+
+
+def test_read_missing_returns_empty(tmp_path):
+    assert hosts.read_hosts_file(tmp_path / "nope.yaml") == {}
+
+
+# ── Resolution ──────────────────────────────────────────────────────────────
+
+
+def test_resolve_flat_wraps_as_default(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.write_hosts_file(p, {"host": "10.0.0.1", "username": "root"})
+    assert hosts.resolve(p) == {
+        "_default": {"host": "10.0.0.1", "username": "root"}
+    }
+
+
+def test_resolve_nested_passes_through(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.write_hosts_file(
+        p,
+        {"ub20": {"host": "h1", "username": "u1"}, "sfm": {"host": "h2"}},
+    )
+    resolved = hosts.resolve(p)
+    assert resolved["ub20"]["host"] == "h1"
+    assert resolved["sfm"]["host"] == "h2"
+
+
+def test_resolve_global_reference(tmp_path, isolated_home):
+    # Set up global file with a "sfm" entry
+    gp = hosts.global_hosts_path()
+    hosts.write_hosts_file(gp, {"sfm": {"host": "1.2.3.4", "username": "root"}})
+
+    # Local file with global: true reference
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(local, {"sfm": {"global": True}})
+
+    resolved = hosts.resolve(local)
+    assert resolved["sfm"] == {"host": "1.2.3.4", "username": "root"}
+
+
+def test_resolve_global_missing_file_errors(tmp_path):
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(local, {"sfm": {"global": True}})
+    with pytest.raises(hosts.HostsError, match="global hosts file does not exist"):
+        hosts.resolve(local)
+
+
+def test_resolve_global_missing_entry_errors(tmp_path, isolated_home):
+    gp = hosts.global_hosts_path()
+    hosts.write_hosts_file(gp, {"other": {"host": "x"}})
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(local, {"sfm": {"global": True}})
+    with pytest.raises(hosts.HostsError, match="not found in"):
+        hosts.resolve(local)
+
+
+def test_resolve_invalid_entry_errors(tmp_path):
+    """Mixed file (one valid nested entry + one scalar) is detected as nested
+    and the scalar entry should error."""
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(
+        local,
+        {"valid": {"host": "h"}, "ub20": "this should be a dict"},
+    )
+    with pytest.raises(hosts.HostsError, match="must be a mapping"):
+        hosts.resolve(local)
+
+
+# ── set_field ───────────────────────────────────────────────────────────────
+
+
+def test_set_field_creates_file(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.set_field(p, "ub20", "host", "1.2.3.4")
+    assert hosts.read_hosts_file(p) == {"ub20": {"host": "1.2.3.4"}}
+
+
+def test_set_field_appends_to_existing_host(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.write_hosts_file(p, {"ub20": {"host": "h"}})
+    hosts.set_field(p, "ub20", "username", "u")
+    data = hosts.read_hosts_file(p)
+    assert data == {"ub20": {"host": "h", "username": "u"}}
+
+
+def test_set_field_rejects_flat_file(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.write_hosts_file(p, {"host": "h", "username": "u"})  # flat
+    with pytest.raises(hosts.HostsError, match="flat \\(legacy\\) format"):
+        hosts.set_field(p, "ub20", "host", "x")
+
+
+# ── Migration ───────────────────────────────────────────────────────────────
+
+
+def test_migrate_flat_to_nested(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.write_hosts_file(p, {"host": "h", "username": "u"})
+    assert hosts.migrate(p, default_name="myhost") is True
+    assert hosts.read_hosts_file(p) == {"myhost": {"host": "h", "username": "u"}}
+
+
+def test_migrate_already_nested_noop(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.write_hosts_file(p, {"ub20": {"host": "h"}})
+    assert hosts.migrate(p) is False
+
+
+def test_migrate_empty_noop(tmp_path):
+    p = tmp_path / "h.yaml"
+    p.write_text("")
+    assert hosts.migrate(p) is False
+
+
+# ── Global path ─────────────────────────────────────────────────────────────
+
+
+def test_default_global_path(isolated_home):
+    expected = isolated_home / ".cutip" / "hosts.yaml"
+    assert hosts.global_hosts_path() == expected
+
+
+def test_set_and_get_global_path(isolated_home, tmp_path):
+    custom = tmp_path / "custom-hosts.yaml"
+    hosts.set_global_hosts_path(custom)
+    assert hosts.global_hosts_path() == custom
+
+
+def test_get_field_returns_none_for_missing(tmp_path):
+    p = tmp_path / "h.yaml"
+    hosts.write_hosts_file(p, {"ub20": {"host": "h"}})
+    assert hosts.get_field(p, "ub20", "host") == "h"
+    assert hosts.get_field(p, "ub20", "username") is None
+    assert hosts.get_field(p, "nonexistent", "host") is None

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -56,9 +56,7 @@ def test_read_missing_returns_empty(tmp_path):
 def test_resolve_flat_wraps_as_default(tmp_path):
     p = tmp_path / "h.yaml"
     hosts.write_hosts_file(p, {"host": "10.0.0.1", "username": "root"})
-    assert hosts.resolve(p) == {
-        "_default": {"host": "10.0.0.1", "username": "root"}
-    }
+    assert hosts.resolve(p) == {"_default": {"host": "10.0.0.1", "username": "root"}}
 
 
 def test_resolve_nested_passes_through(tmp_path):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,128 @@
+"""Tests for cutip.paths — typed paths section expansion + merge."""
+
+from __future__ import annotations
+
+from cutip.paths import _looks_absolute, expand_path, merge_paths_into_data
+
+
+# ── _looks_absolute ─────────────────────────────────────────────────────────
+
+
+def test_looks_absolute_unix():
+    assert _looks_absolute("/usr/local") is True
+
+
+def test_looks_absolute_home():
+    assert _looks_absolute("~/dev") is True
+
+
+def test_looks_absolute_windows_drive():
+    assert _looks_absolute("C:/Users") is True
+    assert _looks_absolute("C:\\Users") is True
+
+
+def test_looks_absolute_relative():
+    assert _looks_absolute("./foo") is False
+    assert _looks_absolute("foo/bar") is False
+    assert _looks_absolute("") is False
+
+
+# ── expand_path ─────────────────────────────────────────────────────────────
+
+
+def test_expand_path_absolute_passthrough(tmp_path):
+    abs_path = "/tmp/cutip-x"
+    assert expand_path(abs_path, tmp_path) == abs_path
+
+
+def test_expand_path_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert expand_path("~/proj", tmp_path) == str(tmp_path / "proj")
+
+
+def test_expand_path_envvar(monkeypatch, tmp_path):
+    monkeypatch.setenv("CUTIP_TEST_DIR", "/opt/cutip-test")
+    assert expand_path("$CUTIP_TEST_DIR/sub", tmp_path) == "/opt/cutip-test/sub"
+
+
+def test_expand_path_relative(tmp_path):
+    base = tmp_path / "proj"
+    base.mkdir()
+    result = expand_path("./build", base)
+    assert result == str((base / "build").resolve())
+
+
+def test_expand_path_empty(tmp_path):
+    assert expand_path("", tmp_path) == ""
+
+
+def test_expand_path_non_string(tmp_path):
+    assert expand_path(None, tmp_path) is None  # type: ignore[arg-type]
+
+
+# ── merge_paths_into_data ───────────────────────────────────────────────────
+
+
+def test_merge_paths_creates_data(tmp_path):
+    project = tmp_path / "p.yaml"
+    project.write_text("")
+    config = {"paths": {"build": "/tmp/build"}}
+    merge_paths_into_data(config, project)
+    assert config["data"] == {"build": "/tmp/build"}
+
+
+def test_merge_paths_extends_existing_data(tmp_path):
+    project = tmp_path / "p.yaml"
+    project.write_text("")
+    config = {
+        "data": {"force_clean": False},
+        "paths": {"build": "/tmp/build"},
+    }
+    merge_paths_into_data(config, project)
+    assert config["data"] == {"force_clean": False, "build": "/tmp/build"}
+
+
+def test_merge_paths_resolves_relative(tmp_path):
+    project = tmp_path / "proj.yaml"
+    project.write_text("")
+    config = {"paths": {"work": "./build"}}
+    merge_paths_into_data(config, project)
+    assert config["data"]["work"] == str((tmp_path / "build").resolve())
+
+
+def test_merge_paths_no_paths_section(tmp_path):
+    project = tmp_path / "p.yaml"
+    project.write_text("")
+    config = {"data": {"x": 1}}
+    merge_paths_into_data(config, project)
+    assert config["data"] == {"x": 1}
+
+
+def test_merge_paths_paths_overrides_data(tmp_path):
+    """paths win over data on key collision (paths are typed + validated)."""
+    project = tmp_path / "p.yaml"
+    project.write_text("")
+    config = {
+        "data": {"build": "/old"},
+        "paths": {"build": "/new"},
+    }
+    merge_paths_into_data(config, project)
+    assert config["data"]["build"] == "/new"
+
+
+def test_merge_paths_non_mapping_paths(tmp_path):
+    """Garbage paths section is ignored (validator catches the type error)."""
+    project = tmp_path / "p.yaml"
+    project.write_text("")
+    config = {"paths": "not a dict", "data": {"x": 1}}
+    merge_paths_into_data(config, project)
+    assert config["data"] == {"x": 1}
+
+
+def test_merge_paths_non_string_value_passthrough(tmp_path):
+    """Non-string values pass through; validator flags them."""
+    project = tmp_path / "p.yaml"
+    project.write_text("")
+    config = {"paths": {"build": 42}}
+    merge_paths_into_data(config, project)
+    assert config["data"]["build"] == 42

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -165,3 +165,65 @@ class TestValidateProject:
         )
         path_errors = [e for e in errors if "path does not exist" in e]
         assert path_errors == []
+
+    # ── paths section ───────────────────────────────────────────────────────
+
+    def test_paths_empty_value_errors(self, tmp_path):
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "paths": {"build": ""}},
+        )
+        assert any("paths.build is empty" in e for e in errors)
+
+    def test_paths_absolute_missing_errors(self, tmp_path):
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {
+                "project": "test",
+                "host": "local",
+                "paths": {"build": "/nonexistent/cutip-xyz-99999"},
+            },
+        )
+        assert any("paths.build" in e and "does not exist" in e for e in errors)
+
+    def test_paths_absolute_existing_passes(self, tmp_path):
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "paths": {"tmp": "/tmp"}},
+        )
+        path_errors = [e for e in errors if "paths.tmp" in e]
+        assert path_errors == []
+
+    def test_paths_relative_missing_warns(self, tmp_path):
+        errors, warnings = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "paths": {"build": "./missing"}},
+        )
+        path_errors = [e for e in errors if "paths.build" in e]
+        assert path_errors == []
+        assert any("paths.build" in w for w in warnings)
+
+    def test_paths_relative_existing_passes(self, tmp_path):
+        (tmp_path / "build").mkdir()
+        errors, warnings = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "paths": {"build": "./build"}},
+        )
+        path_errors = [e for e in errors if "paths.build" in e]
+        path_warnings = [w for w in warnings if "paths.build" in w]
+        assert path_errors == []
+        assert path_warnings == []
+
+    def test_paths_non_mapping_errors(self, tmp_path):
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "paths": "not a dict"},
+        )
+        assert any("paths" in e and "mapping" in e for e in errors)
+
+    def test_paths_non_string_value_errors(self, tmp_path):
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "local", "paths": {"build": 42}},
+        )
+        assert any("paths.build" in e and "string" in e for e in errors)

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- **Phase 3** — hosts refactor: nested format with named entries, global file at `~/.cutip/hosts.yaml`, `global: true` references for cross-project sharing.
- **Phase 3+** — typed `paths:` section in project YAML: `~`/`\$VAR`/relative-to-yaml-dir expansion at load, merged into `ctx.data` so workflows read it like any other entry.
- 35 new tests + 7 validator cases. 142 pass, 78% coverage.

## Hosts (`cutip.hosts`)

**File formats** (auto-detected on read):
- *Flat* (legacy): top-level keys are field names.
- *Nested* (current): top-level keys are host names → field dicts. Entry can use `global: true` to defer to the same name in `~/.cutip/hosts.yaml`.

**CLI** — `cutip hosts <subcommand>`:
- `list [-g]` — print all entries (sensitive values masked).
- `get [-g] <host>.<field>` — print one field.
- `set [-g] <host>.<field>=<value>` — set a field, creating the host if missing.
- `path [-g]` — print the resolved hosts file path.
- `set-path -g <path>` — persist a custom global path to `~/.cutip/config.yaml`.
- `init -g` — create an empty global hosts file (global-only by design).
- `migrate` — convert a flat file to nested in-place (explicit, no auto-migrate).

**Workflow API**:
- `ctx.host_for(name)` returns the resolved field dict (with `global: true` expanded).
- Existing workflows that use `ctx._hosts["host"]` keep working — flat files become `{"_default": {...}}` and `host_for` falls back to `_default`.

## Paths (`cutip.paths`)

\`\`\`yaml
project: my-app
paths:
  build_repo: ~/dev/snf-build       # ~ expanded
  artifacts: ./dist                  # resolved against project YAML's dir
  cache: \$XDG_CACHE_HOME/cutip      # env-var expanded
data:
  force_clean: false
\`\`\`

- Expansion happens once at config load (`cli.py` + `daemon.py`).
- Resolved values are merged into `config['data']`; workflow reads `ctx.data['build_repo']`.
- No new accessor — paths win on key collision because they're typed and validated.

**Validator rules**:
- Empty value → error.
- Originally-absolute path that doesn't exist → error.
- Originally-relative path that doesn't exist → warning (workflow may create it).
- Type checks (paths must be a mapping, values must be strings).

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/e2e` — 142 pass, 78% coverage
- [x] `uv run --with ruff ruff check` clean
- [x] `uv run --with ruff ruff format --check` clean
- [x] Smoke: `cutip hosts init -g` creates `~/.cutip/hosts.yaml`
- [x] Smoke: `cutip hosts set -g ub20.host=...` writes nested entry
- [x] Smoke: `cutip run` against project with mixed valid/invalid paths surfaces correct errors + warnings
- [ ] Run a real workflow against `ub20login-eqx-10.force10networks.com` after merge

## Backwards compatibility

- Flat hosts files still parse and run unchanged.
- `ctx._hosts["host"]` on flat files still returns the host string.
- `data:` section is unchanged — `paths:` only adds entries (with overrides on collision).