### PR TITLE
fix: cutip ps stop on Windows — taskkill /T /F — v2.10.1

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -1439,18 +1439,36 @@ def cmd_ps(args):
                 except Exception as e:
                     console.print(f"  [yellow]⚠[/yellow] {host}: {e}")
 
-        # Local SIGTERM the daemon
+        # Local stop the daemon
+        # Windows: CTRL_BREAK_EVENT can't reach a DETACHED_PROCESS daemon
+        # (no shared console), and the daemon's SIGTERM handler is Unix-only
+        # anyway. Use taskkill /T to cascade-kill the whole process tree;
+        # the safety net below will mark meta as stopped.
         if meta.host_pid:
             try:
                 if sys.platform == "win32":
-                    import signal
+                    import subprocess
 
-                    os.kill(meta.host_pid, signal.CTRL_BREAK_EVENT)
+                    result = subprocess.run(
+                        ["taskkill", "/PID", str(meta.host_pid), "/T", "/F"],
+                        capture_output=True,
+                        text=True,
+                    )
+                    if result.returncode == 0:
+                        console.print(f"  Killed daemon tree (pid {meta.host_pid})")
+                    elif result.returncode == 128:
+                        # 128 = process not found (already exited)
+                        pass
+                    else:
+                        console.print(
+                            f"  [yellow]⚠[/yellow] taskkill rc={result.returncode}: "
+                            f"{(result.stderr or result.stdout).strip()}"
+                        )
                 else:
                     import signal
 
                     os.kill(meta.host_pid, signal.SIGTERM)
-                console.print(f"  SIGTERM → daemon pid {meta.host_pid}")
+                    console.print(f"  SIGTERM → daemon pid {meta.host_pid}")
             except ProcessLookupError:
                 pass
             except PermissionError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.10.0"
+version = "2.10.1"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.10.0"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

`cutip ps stop <cu-id>` on Windows raised `OSError: [WinError 87] The parameter is incorrect` from `os.kill(pid, signal.CTRL_BREAK_EVENT)`.

## Root cause

`CTRL_BREAK_EVENT` is delivered via Win32 `GenerateConsoleCtrlEvent`, which requires the caller and the target to share a console. Our daemons are spawned with `DETACHED_PROCESS | CREATE_NO_WINDOW` (daemon.py:78–82) — they have no console, so the call fails. Furthermore, the daemon's SIGTERM handler is Unix-only (daemon.py:166: `if sys.platform != "win32":`), so even if the signal had been delivered, no graceful cleanup would have run.

This bug has existed since Phase 2 (cutip 2.7.0); it surfaced now because users hadn't exercised `cutip ps stop` on Windows until snf-build runs landed.

## Fix

On Windows, replace the signal call with `taskkill /PID <pid> /T /F`:
- `/T` — cascade-kill the entire process tree (daemon + any children, including bash wrappers spawned by ctx.exec_tracked).
- `/F` — force-kill (no graceful close window). This matches the prior behavior where the safety-net always force-stopped after 2s anyway.
- `rc=128` (process not found) is treated as success — same race tolerance as Unix `ProcessLookupError`.

The Unix path is unchanged.

## Test plan

- [x] `uv run pytest` — 142 pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] On Windows: `cutip run --bg <project>`, then `cutip ps stop <cu-id>` — should report `Killed daemon tree (pid N)` and the daemon should exit
- [ ] Verify `cutip ps` shows status=stopped after a stop call