### PR TITLE
feat: ctx.ssh single-entry nested fallback — v2.11.1

### DIFF
--- a/cutip/workflow/engine.py
+++ b/cutip/workflow/engine.py
@@ -99,14 +99,42 @@ class WorkflowContext:
         if self._ssh is not None:
             return self._ssh
 
-        host = self._hosts.get("host", "")
-        username = self._hosts.get("username", "")
-        password = self._hosts.get("password", "")
-        port = int(self._hosts.get("port", "22"))
+        # Backward-compat resolution order:
+        # 1. Flat top-level fields on _hosts (legacy: host: …, username: …)
+        # 2. Single-entry nested hosts file (the named entry's fields)
+        # 3. Error — multiple entries means workflow must use ctx.host_for(name).
+        creds = {
+            "host": self._hosts.get("host", ""),
+            "username": self._hosts.get("username", ""),
+            "password": self._hosts.get("password", ""),
+            "port": self._hosts.get("port", "22"),
+        }
+        if not creds["host"] or not creds["username"] or not creds["password"]:
+            resolved = getattr(self, "_resolved_hosts", None) or {}
+            named = {k: v for k, v in resolved.items() if k != "_default"}
+            if len(named) == 1:
+                only = next(iter(named.values()))
+                creds = {
+                    "host": only.get("host", ""),
+                    "username": only.get("username", ""),
+                    "password": only.get("password", ""),
+                    "port": only.get("port", "22"),
+                }
+            elif len(named) > 1:
+                raise RuntimeError(
+                    "ctx.ssh is ambiguous: hosts.yaml has multiple named entries "
+                    f"({', '.join(sorted(named.keys()))}). Use ctx.host_for('<name>') "
+                    "to pick one explicitly."
+                )
+
+        host = creds["host"]
+        username = creds["username"]
+        password = creds["password"]
+        port = int(creds["port"])
 
         if not host or not username or not password:
             raise RuntimeError(
-                "SSH credentials not set. Run: cutip hosts set host=<ip> username=<user> password=<pw>"
+                "SSH credentials not set. Run: cutip hosts set <name>.host=<ip> <name>.username=<user> <name>.password=<pw>"
             )
 
         from rsty._core import ssh_connect

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.11.0"
+version = "2.11.1"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -73,6 +73,56 @@ class TestWorkflowContext:
         with pytest.raises(RuntimeError, match="SSH credentials not set"):
             _ = ctx.ssh
 
+    def test_ssh_uses_single_nested_entry(self, monkeypatch):
+        """ctx.ssh transparently uses the only named entry from a nested file."""
+        import sys
+        import types
+
+        captured = {}
+
+        def fake_connect(*, host, username, password, port):
+            captured.update(
+                {"host": host, "username": username, "password": password, "port": port}
+            )
+            return object()
+
+        # rsty isn't installed in the cutip dev env. Inject a fake module so
+        # the lazy `from rsty._core import ssh_connect` inside ctx.ssh works.
+        fake_core = types.ModuleType("rsty._core")
+        fake_core.ssh_connect = fake_connect
+        fake_rsty = types.ModuleType("rsty")
+        fake_rsty._core = fake_core
+        monkeypatch.setitem(sys.modules, "rsty", fake_rsty)
+        monkeypatch.setitem(sys.modules, "rsty._core", fake_core)
+
+        ctx = WorkflowContext.from_config(
+            {"project": "test", "host": "remote"},
+            hosts={"ub20": {"host": "10.0.0.1", "username": "u", "password": "p"}},
+        )
+        ctx._resolved_hosts = {
+            "ub20": {"host": "10.0.0.1", "username": "u", "password": "p"}
+        }
+        _ = ctx.ssh
+        assert captured == {
+            "host": "10.0.0.1",
+            "username": "u",
+            "password": "p",
+            "port": 22,
+        }
+
+    def test_ssh_multi_nested_entries_errors(self):
+        """Multiple named entries → ctx.ssh demands explicit host_for selection."""
+        ctx = WorkflowContext.from_config(
+            {"project": "test", "host": "remote"},
+            hosts={"a": {"host": "h1"}, "b": {"host": "h2"}},
+        )
+        ctx._resolved_hosts = {
+            "a": {"host": "h1", "username": "u", "password": "p"},
+            "b": {"host": "h2", "username": "u", "password": "p"},
+        }
+        with pytest.raises(RuntimeError, match="ambiguous"):
+            _ = ctx.ssh
+
     def test_data_from_data_section(self):
         ctx = WorkflowContext.from_config(
             {

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.11.0"
+version = "2.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Engine enhancement so workflows using `ctx.ssh` / `ctx.kubectl` keep working when hosts.yaml is in nested format with one named entry. Surfaced during snf-dev migration where most projects have a single host (ub20, sfm) and existing helpers are heavily used.

## Behavior

| hosts.yaml shape | `ctx.ssh` |
|---|---|
| Flat (legacy) | uses top-level `host/username/password` (unchanged) |
| Nested, one entry | uses that entry's fields (NEW) |
| Nested, multiple entries | raises with pointer to `ctx.host_for('<name>')` |

## Tests

- New: `test_ssh_uses_single_nested_entry`, `test_ssh_multi_nested_entries_errors`
- 155 pass total, 80% coverage