### PR TITLE
feat: cutip hosts promote (local → global) — v2.13.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.12.0"
+VERSION = "2.13.0"
 console = Console()
 
 
@@ -1036,6 +1036,11 @@ def cmd_hosts(args):
       cutip hosts migrate               Convert flat → nested in this project
       cutip hosts validate              Probe each host via SSH (project's hosts)
       cutip hosts validate -g           Probe every entry in the global file
+      cutip hosts promote [<name>...]   Move local entries to ~/.cutip/hosts.yaml
+                                        and replace each with `{global: true}`.
+                                        Without name, promotes ALL entries.
+                                        Use -f / --force to overwrite conflicting
+                                        global values; otherwise conflicts abort.
     """
     from cutip import hosts as _hosts
 
@@ -1209,6 +1214,54 @@ def cmd_hosts(args):
             console.print(
                 f"  Workflows should now use ctx.host_for('{default_name}') or update field references."
             )
+        return
+
+    if subcmd == "promote":
+        if use_global:
+            console.print(
+                "[red]Error:[/red] promote moves entries FROM local TO global; -g doesn't apply."
+            )
+            sys.exit(1)
+        project_path = _resolve_project(args.get("project"))
+        local_path = _resolve_hosts_path(project_path)
+        if not local_path.exists():
+            console.print(f"[red]Error:[/red] {local_path.name} not found")
+            sys.exit(1)
+        names = args.get("names")  # None = promote all
+        force = bool(args.get("force"))
+        try:
+            result = _hosts.promote_to_global(local_path, names=names, force=force)
+        except _hosts.HostsError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            sys.exit(1)
+
+        gp = _hosts.global_hosts_path()
+        for name in result.promoted:
+            console.print(f"  [green]✓[/green] Promoted [cyan]{name}[/cyan] → {gp}")
+        for name in result.skipped_already_global:
+            console.print(f"  [dim]○ {name} is already 'global: true' (skipped)[/dim]")
+        for name in result.skipped_missing:
+            console.print(
+                f"  [yellow]⚠[/yellow] '{name}' not found in {local_path.name}"
+            )
+        if result.conflicts:
+            console.print(
+                f"\n[red]✗[/red] {len(result.conflicts)} conflict(s) — "
+                f"global already has different values for:"
+            )
+            for name in result.conflicts:
+                console.print(f"    [red]•[/red] {name}")
+            console.print(
+                "\n  Use [cyan]-f[/cyan] (or [cyan]--force[/cyan]) to overwrite the global entries."
+            )
+            sys.exit(1)
+        if result.promoted:
+            console.print(
+                f"\n  Local {local_path.name} now references global creds. "
+                f"Run [cyan]cutip hosts list[/cyan] to confirm."
+            )
+        elif not (result.skipped_already_global or result.skipped_missing):
+            console.print("[dim]Nothing to promote.[/dim]")
         return
 
     if subcmd == "validate":
@@ -1759,27 +1812,35 @@ def main():
             "init",
             "migrate",
             "validate",
+            "promote",
             "help",
         }
         if remaining and remaining[0] in valid_subs:
             parsed["subcmd"] = remaining[0]
             remaining = remaining[1:]
         pairs = []
+        names: list[str] = []
         for arg in remaining:
             if arg in ("-h", "--help"):
                 parsed["subcmd"] = "help"
             elif arg in ("-g", "--global"):
                 parsed["global"] = True
+            elif arg in ("-f", "--force"):
+                parsed["force"] = True
             elif "=" in arg:
                 pairs.append(arg)
             elif arg.endswith(".yaml") or Path(arg).exists():
                 parsed["project"] = arg
             elif parsed.get("subcmd") in ("get", "set-path") and "key" not in parsed:
                 parsed["key"] = arg
+            elif parsed.get("subcmd") == "promote":
+                names.append(arg)
             elif not parsed.get("project"):
                 parsed["project"] = arg
         if pairs:
             parsed["pairs"] = pairs
+        if names:
+            parsed["names"] = names
         COMMANDS[command](parsed)
         return
 

--- a/cutip/hosts.py
+++ b/cutip/hosts.py
@@ -31,6 +31,7 @@ explicit via ``cutip hosts migrate``.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -218,6 +219,98 @@ def set_field(path: Path, host_name: str, field: str, value: str) -> None:
         )
     data[host_name][field] = value
     write_hosts_file(path, data)
+
+
+# ── Promotion (local → global) ──────────────────────────────────────────────
+
+
+@dataclass
+class PromoteResult:
+    """Outcome of a promote_to_global() call."""
+
+    promoted: list[str]  # names successfully copied to global
+    conflicts: list[str]  # names that exist in global with different values (skipped)
+    skipped_already_global: list[str]  # names already `global: true` in local
+    skipped_missing: list[str]  # names requested but not in local file
+
+
+def promote_to_global(
+    local_path: Path,
+    names: list[str] | None = None,
+    *,
+    force: bool = False,
+) -> PromoteResult:
+    """Copy local hosts entries to ``~/.cutip/hosts.yaml`` and replace each
+    promoted local entry with ``{global: true}``.
+
+    Args:
+        local_path: Path to the project's hosts.yaml.
+        names: Specific host names to promote. ``None`` means every entry
+            in the local file.
+        force: Overwrite global entries that already exist with different
+            values. Without ``force``, conflicts are reported and the
+            promotion of those names is skipped.
+
+    Returns:
+        ``PromoteResult`` describing what happened. The local file is only
+        modified for names that were actually promoted (no partial writes
+        on errors).
+
+    Raises:
+        HostsError: if the local file is in flat format (run ``migrate``
+            first) or if a requested entry isn't a mapping.
+    """
+    local = read_hosts_file(local_path)
+    if local and not is_nested(local):
+        raise HostsError(
+            f"{local_path.name} is in flat (legacy) format. "
+            "Run 'cutip hosts migrate' first, then re-run promote."
+        )
+
+    global_path = global_hosts_path()
+    global_data = read_hosts_file(global_path) if global_path.exists() else {}
+    if global_data and not is_nested(global_data):
+        raise HostsError(f"global hosts file at {global_path} is not in nested format")
+
+    targets: list[str] = list(names) if names else list(local.keys())
+    promoted: list[str] = []
+    conflicts: list[str] = []
+    skipped_already_global: list[str] = []
+    skipped_missing: list[str] = []
+
+    for name in targets:
+        if name not in local:
+            skipped_missing.append(name)
+            continue
+        entry = local[name]
+        if not isinstance(entry, dict):
+            raise HostsError(
+                f"local entry '{name}' is not a mapping (got {type(entry).__name__})"
+            )
+        if entry.get("global") is True:
+            skipped_already_global.append(name)
+            continue
+        # Conflict: existing global entry with different fields
+        existing = global_data.get(name)
+        if isinstance(existing, dict) and existing != entry and not force:
+            conflicts.append(name)
+            continue
+        global_data[name] = dict(entry)
+        promoted.append(name)
+
+    # Only persist if we actually moved something. Empty promote = no-op.
+    if promoted:
+        write_hosts_file(global_path, global_data)
+        for name in promoted:
+            local[name] = {"global": True}
+        write_hosts_file(local_path, local)
+
+    return PromoteResult(
+        promoted=promoted,
+        conflicts=conflicts,
+        skipped_already_global=skipped_already_global,
+        skipped_missing=skipped_missing,
+    )
 
 
 # ── Migration ───────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.12.0"
+version = "2.13.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -177,3 +177,136 @@ def test_get_field_returns_none_for_missing(tmp_path):
     assert hosts.get_field(p, "ub20", "host") == "h"
     assert hosts.get_field(p, "ub20", "username") is None
     assert hosts.get_field(p, "nonexistent", "host") is None
+
+
+# ── Promote (local → global) ────────────────────────────────────────────────
+
+
+def test_promote_copies_to_global_and_replaces_local(tmp_path, isolated_home):
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(
+        local, {"ub20": {"host": "1.2.3.4", "username": "u", "password": "p"}}
+    )
+    result = hosts.promote_to_global(local, names=["ub20"])
+    assert result.promoted == ["ub20"]
+    assert result.conflicts == []
+    # Local now references global
+    assert hosts.read_hosts_file(local) == {"ub20": {"global": True}}
+    # Global has the credentials
+    gp = hosts.global_hosts_path()
+    assert hosts.read_hosts_file(gp) == {
+        "ub20": {"host": "1.2.3.4", "username": "u", "password": "p"}
+    }
+
+
+def test_promote_all_when_no_names_given(tmp_path, isolated_home):
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(
+        local,
+        {
+            "ub20": {"host": "1", "username": "u", "password": "p"},
+            "sfm": {"host": "2", "username": "u", "password": "p"},
+        },
+    )
+    result = hosts.promote_to_global(local, names=None)
+    assert sorted(result.promoted) == ["sfm", "ub20"]
+    assert hosts.read_hosts_file(local) == {
+        "ub20": {"global": True},
+        "sfm": {"global": True},
+    }
+
+
+def test_promote_conflict_without_force_skips(tmp_path, isolated_home):
+    """Existing global entry with different values blocks the promote."""
+    gp = hosts.global_hosts_path()
+    hosts.write_hosts_file(
+        gp, {"ub20": {"host": "OLD", "username": "u", "password": "old-pw"}}
+    )
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(
+        local, {"ub20": {"host": "NEW", "username": "u", "password": "new-pw"}}
+    )
+    result = hosts.promote_to_global(local, names=["ub20"])
+    assert result.promoted == []
+    assert result.conflicts == ["ub20"]
+    # Neither side mutated
+    assert hosts.read_hosts_file(gp)["ub20"]["host"] == "OLD"
+    assert hosts.read_hosts_file(local)["ub20"]["host"] == "NEW"
+
+
+def test_promote_conflict_with_force_overwrites(tmp_path, isolated_home):
+    gp = hosts.global_hosts_path()
+    hosts.write_hosts_file(
+        gp, {"ub20": {"host": "OLD", "username": "u", "password": "old-pw"}}
+    )
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(
+        local, {"ub20": {"host": "NEW", "username": "u", "password": "new-pw"}}
+    )
+    result = hosts.promote_to_global(local, names=["ub20"], force=True)
+    assert result.promoted == ["ub20"]
+    assert result.conflicts == []
+    assert hosts.read_hosts_file(gp)["ub20"]["host"] == "NEW"
+    assert hosts.read_hosts_file(local) == {"ub20": {"global": True}}
+
+
+def test_promote_identical_global_entry_promotes_silently(tmp_path, isolated_home):
+    """If global already matches local exactly, promote still rewrites local
+    to {global: true} — there's no conflict."""
+    creds = {"host": "1", "username": "u", "password": "p"}
+    gp = hosts.global_hosts_path()
+    hosts.write_hosts_file(gp, {"ub20": creds})
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(local, {"ub20": creds})
+    result = hosts.promote_to_global(local, names=["ub20"])
+    assert result.promoted == ["ub20"]
+    assert result.conflicts == []
+    assert hosts.read_hosts_file(local) == {"ub20": {"global": True}}
+
+
+def test_promote_skips_already_global_entries(tmp_path, isolated_home):
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(local, {"ub20": {"global": True}})
+    result = hosts.promote_to_global(local, names=["ub20"])
+    assert result.promoted == []
+    assert result.skipped_already_global == ["ub20"]
+    # Local file unchanged
+    assert hosts.read_hosts_file(local) == {"ub20": {"global": True}}
+
+
+def test_promote_missing_name_is_reported(tmp_path, isolated_home):
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(local, {"ub20": {"host": "h"}})
+    result = hosts.promote_to_global(local, names=["nonexistent"])
+    assert result.promoted == []
+    assert result.skipped_missing == ["nonexistent"]
+
+
+def test_promote_rejects_flat_local_file(tmp_path, isolated_home):
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(local, {"host": "h", "username": "u", "password": "p"})
+    with pytest.raises(hosts.HostsError, match="flat \\(legacy\\) format"):
+        hosts.promote_to_global(local)
+
+
+def test_promote_partial_with_some_conflicts(tmp_path, isolated_home):
+    """Mixed batch: one entry promotes cleanly, another conflicts. The
+    clean one moves; the conflicting one stays put with original values."""
+    gp = hosts.global_hosts_path()
+    hosts.write_hosts_file(
+        gp, {"sfm": {"host": "OLD", "username": "u", "password": "old"}}
+    )
+    local = tmp_path / "local.yaml"
+    hosts.write_hosts_file(
+        local,
+        {
+            "ub20": {"host": "1", "username": "u", "password": "p"},
+            "sfm": {"host": "NEW", "username": "u", "password": "new"},
+        },
+    )
+    result = hosts.promote_to_global(local, names=None)
+    assert result.promoted == ["ub20"]
+    assert result.conflicts == ["sfm"]
+    final_local = hosts.read_hosts_file(local)
+    assert final_local["ub20"] == {"global": True}
+    assert final_local["sfm"] == {"host": "NEW", "username": "u", "password": "new"}

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

`cutip hosts promote [<name>...] [-f|--force]` — move local hosts entries to `~/.cutip/hosts.yaml` and replace each with `{global: true}`. Keeps credentials out of project repos.

## Behavior

- No argument: promotes ALL local entries.
- One or more names: promotes those specifically.
- Conflict (same name in global with different values) without `-f`: reports conflicts, skips them, exits 1.
- Conflict with `-f` / `--force`: overwrites global.
- Already-`{global: true}` entries: skipped silently.
- Missing names: reported but don't fail the run.

## Output

```
$ cutip hosts promote ub20
  ✓ Promoted ub20 → /home/u/.cutip/hosts.yaml

  Local hosts.yaml now references global creds. Run cutip hosts list to confirm.
```

```
$ cutip hosts promote sfm
✗ 1 conflict(s) — global already has different values for:
    • sfm

  Use -f (or --force) to overwrite the global entries.
(exit 1)
```

## Tests

9 new tests covering the full matrix: clean promote, all-or-named, conflict skip, force-overwrite, identical-global-no-conflict, already-global skip, missing-name reporting, flat-format rejection, partial-batch with mixed outcomes. 164 pass overall, 80% coverage.

## Follow-up

Snf-build's project hosts.yaml will be updated to `ub20: {global: true}` once this lands; user populates global once via `cutip hosts set -g ub20.host=... ub20.username=... ub20.password=...` (or runs promote first time on a populated repo).