### PR TITLE
feat: cutip data + {{ globals.X.Y.Z }} resolver — v2.14.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.13.0"
+VERSION = "2.14.0"
 console = Console()
 
 
@@ -1338,6 +1338,109 @@ def _print_probe_results(hosts_dict: dict, label: str) -> int:
     return failed
 
 
+def cmd_data(args):
+    """Manage the global data store at ~/.cutip/data.yaml.
+
+    Subcommands:
+      cutip data list                 List entries (flattened, dotted paths)
+      cutip data get <dotted.path>    Print one value
+      cutip data set <dotted.path>=<value> [...]
+                                      Set one or more values
+      cutip data path                 Print the data file path
+      cutip data init                 Create an empty data file
+    """
+    from cutip import globals as _globals
+
+    subcmd = args.get("subcmd")
+
+    if not subcmd or subcmd == "help":
+        console.print(cmd_data.__doc__ or "cutip data")
+        return
+
+    gp = _globals.globals_path()
+
+    if subcmd == "path":
+        console.print(gp)
+        return
+
+    if subcmd == "init":
+        if gp.exists():
+            console.print(f"[dim]Global data file already exists: {gp}[/dim]")
+            return
+        _globals.write_globals({}, gp)
+        console.print(f"  [green]✓[/green] Created [cyan]{gp}[/cyan]")
+        console.print("  Add entries with: cutip data set <dotted.path>=<value>")
+        return
+
+    if subcmd == "list":
+        if not gp.exists():
+            console.print(f"[dim]{gp} does not exist.[/dim]")
+            console.print("  Create with: cutip data init")
+            return
+        data = _globals.read_globals(gp)
+        if not data:
+            console.print("[dim]No entries.[/dim]")
+            return
+        flat = _globals.flatten(data)
+        for k in sorted(flat):
+            # Mask if any segment of the dotted path looks sensitive —
+            # 'passwords.v22' should hide its value even though 'v22' alone
+            # doesn't match the sensitive list.
+            disp = (
+                "****" if any(_is_sensitive(seg) for seg in k.split(".")) else flat[k]
+            )
+            console.print(f"  [cyan]{k}[/cyan] = {disp}")
+        return
+
+    if subcmd == "get":
+        key = args.get("key")
+        if not key:
+            console.print("[red]Usage:[/red] cutip data get <dotted.path>")
+            sys.exit(1)
+        data = _globals.read_globals(gp)
+        value = _globals.lookup(data, key)
+        if value is None:
+            console.print(f"[red]Error:[/red] '{key}' not found in {gp.name}")
+            sys.exit(1)
+        if isinstance(value, dict):
+            console.print(
+                f"[red]Error:[/red] '{key}' is a mapping, not a scalar. "
+                f"Drill deeper or use 'cutip data list'."
+            )
+            sys.exit(1)
+        console.print(value)
+        return
+
+    if subcmd == "set":
+        pairs = args.get("pairs", [])
+        if not pairs:
+            console.print(
+                "[red]Usage:[/red] cutip data set <dotted.path>=<value> [...]"
+            )
+            sys.exit(1)
+        data = _globals.read_globals(gp)
+        for pair in pairs:
+            if "=" not in pair:
+                console.print(
+                    f"[red]Error:[/red] invalid format '{pair}', "
+                    f"expected <dotted.path>=<value>"
+                )
+                sys.exit(1)
+            k, v = pair.split("=", 1)
+            try:
+                _globals.set_dotted(data, k, v)
+            except _globals.GlobalsError as e:
+                console.print(f"[red]Error:[/red] {e}")
+                sys.exit(1)
+            disp = "****" if any(_is_sensitive(seg) for seg in k.split(".")) else v
+            console.print(f"  [green]✓[/green] {k} = {disp}")
+        _globals.write_globals(data, gp)
+        return
+
+    console.print(f"[red]Unknown data subcommand:[/red] {subcmd}")
+    sys.exit(1)
+
+
 def cmd_cmd(args):
     """Execute a project-defined command."""
     import subprocess
@@ -1686,6 +1789,7 @@ COMMANDS = {
     "vars": cmd_vars,
     "secrets": cmd_secrets,
     "hosts": cmd_hosts,
+    "data": cmd_data,
     "verify": cmd_verify,
     "ps": cmd_ps,
 }
@@ -1725,6 +1829,7 @@ def main():
                 "  vars       Manage project variables (list/get/set)\n"
                 "  secrets    Manage project secrets (list/get/set)\n"
                 "  hosts      Manage connection credentials (list/get/set)\n"
+                "  data       Manage global data store (~/.cutip/data.yaml)\n"
                 "  verify     Check prerequisites\n"
                 "  ps         List/inspect/stop background runs (cutip run --bg)\n\n"
                 "[bold]Usage:[/bold]\n"
@@ -1841,6 +1946,24 @@ def main():
             parsed["pairs"] = pairs
         if names:
             parsed["names"] = names
+        COMMANDS[command](parsed)
+        return
+
+    if command == "data":
+        valid_subs = {"list", "get", "set", "path", "init", "help"}
+        if remaining and remaining[0] in valid_subs:
+            parsed["subcmd"] = remaining[0]
+            remaining = remaining[1:]
+        pairs = []
+        for arg in remaining:
+            if arg in ("-h", "--help"):
+                parsed["subcmd"] = "help"
+            elif "=" in arg:
+                pairs.append(arg)
+            elif parsed.get("subcmd") == "get" and "key" not in parsed:
+                parsed["key"] = arg
+        if pairs:
+            parsed["pairs"] = pairs
         COMMANDS[command](parsed)
         return
 

--- a/cutip/globals.py
+++ b/cutip/globals.py
@@ -1,0 +1,145 @@
+"""Global data store for cutip — shared values across projects.
+
+Storage: ``~/.cutip/data.yaml`` (sibling of ``~/.cutip/hosts.yaml``).
+
+Free-form nested YAML — typically used for shared constants like
+default passwords keyed by product version, IPs by environment, or
+URLs to internal services::
+
+    passwords:
+      v22: "DefaultPw123!"
+      v23: "OtherPw456!"
+    constants:
+      artifactory_url: "http://artifactory.internal/"
+
+Templates in workflow YAML (or any string passed through
+``rsty.config.substitute_vars``) reference values via dotted paths::
+
+    auth: "admin:{{ globals.passwords.v22 }}"
+
+Resolution rules:
+
+- Only leaf scalars (str/int/float/bool) are substitutable. Dict/list
+  values can't render into a string and stay as the unresolved
+  placeholder.
+- Missing keys leave the placeholder untouched (caller's job to detect
+  via the resolver's ``find_unresolved`` helper).
+
+The CLI surface is ``cutip data list/get/set/path/init`` (parallel to
+``cutip hosts``, but no per-project tier — globals are by definition
+global).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+# ── File layout ─────────────────────────────────────────────────────────────
+
+
+def globals_path() -> Path:
+    """Return the path to the global data file (~/.cutip/data.yaml).
+
+    Honors the same ``data_path`` override mechanism as
+    ``cutip.hosts.global_hosts_path`` if it's ever needed; for now,
+    returns the default unless a future ``cutip data set-path`` is added.
+    """
+    from cutip.hosts import cutip_dir
+
+    return cutip_dir() / "data.yaml"
+
+
+# ── Read / write ────────────────────────────────────────────────────────────
+
+
+def read_globals(path: Path | None = None) -> dict[str, Any]:
+    """Read the globals file, returning the raw nested dict.
+
+    Returns an empty dict if the file does not exist.
+    """
+    p = path or globals_path()
+    if not p.exists():
+        return {}
+    import yaml
+
+    return yaml.safe_load(p.read_text()) or {}
+
+
+def write_globals(data: dict[str, Any], path: Path | None = None) -> None:
+    """Write a globals dict to the given path (creating parent dirs)."""
+    import yaml
+
+    p = path or globals_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(data, sort_keys=False, default_flow_style=False))
+
+
+# ── Dotted-path lookup + flatten ────────────────────────────────────────────
+
+
+class GlobalsError(RuntimeError):
+    """Raised when a globals operation fails."""
+
+
+def lookup(data: dict[str, Any], dotted: str) -> Any:
+    """Walk ``data`` along the dotted path, returning the leaf value.
+
+    Returns ``None`` if any segment is missing or the path traverses a
+    non-mapping. Does NOT coerce the result to a string — callers can
+    decide how to handle non-scalar leaves.
+    """
+    if not dotted:
+        return None
+    cur: Any = data
+    for segment in dotted.split("."):
+        if not isinstance(cur, dict):
+            return None
+        if segment not in cur:
+            return None
+        cur = cur[segment]
+    return cur
+
+
+def set_dotted(data: dict[str, Any], dotted: str, value: Any) -> None:
+    """Set a nested value at the dotted path, creating intermediate dicts.
+
+    Raises GlobalsError if any intermediate path traverses a non-mapping
+    leaf.
+    """
+    if not dotted:
+        raise GlobalsError("dotted path cannot be empty")
+    segments = dotted.split(".")
+    cur: dict[str, Any] = data
+    for segment in segments[:-1]:
+        existing = cur.get(segment)
+        if existing is None:
+            cur[segment] = {}
+        elif not isinstance(existing, dict):
+            raise GlobalsError(
+                f"path '{dotted}' traverses non-mapping at '{segment}' "
+                f"(value: {existing!r})"
+            )
+        cur = cur[segment]
+    cur[segments[-1]] = value
+
+
+def flatten(data: dict[str, Any], prefix: str = "") -> dict[str, str]:
+    """Flatten a nested dict to {dotted.path: str_value} for substitution.
+
+    Only leaf scalars (str/int/float/bool) are included. Dicts recurse;
+    lists, ``None``, and other types are skipped — they can't be
+    substituted into a string template.
+    """
+    out: dict[str, str] = {}
+    for k, v in data.items():
+        key = f"{prefix}.{k}" if prefix else str(k)
+        if isinstance(v, dict):
+            out.update(flatten(v, key))
+        elif isinstance(v, bool):
+            # Order matters: bool is a subclass of int.
+            out[key] = "true" if v else "false"
+        elif isinstance(v, (str, int, float)):
+            out[key] = str(v)
+    return out

--- a/cutip/workflow/engine.py
+++ b/cutip/workflow/engine.py
@@ -90,6 +90,24 @@ class WorkflowContext:
         return self.config.get("data", {})
 
     @property
+    def globals(self) -> dict[str, str]:
+        """Flattened global data from ~/.cutip/data.yaml.
+
+        Returns dotted-path keys mapped to scalar string values, suitable
+        for passing as the ``globals`` argument to
+        ``rsty.config.substitute_vars``. The underlying file is loaded
+        once per workflow run.
+        """
+        cached = getattr(self, "_globals_cache", None)
+        if cached is not None:
+            return cached
+        from cutip import globals as _globals
+
+        flat = _globals.flatten(_globals.read_globals())
+        self._globals_cache = flat
+        return flat
+
+    @property
     def ssh(self) -> Any:
         """SSH session — created on first access from hosts.yaml credentials.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.13.0"
+version = "2.14.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,3 @@
-pub mod validate;
-pub mod tree;
 pub mod show;
+pub mod tree;
+pub mod validate;

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -13,14 +13,14 @@ use crate::config::loader;
 pub fn show(section: &str, path: Option<&str>) -> PyResult<String> {
     let config_path = match path {
         Some(p) => std::path::PathBuf::from(p),
-        None => loader::find_config(&std::env::current_dir().map_err(|e| {
-            PyRuntimeError::new_err(format!("{e}"))
-        })?)
+        None => loader::find_config(
+            &std::env::current_dir().map_err(|e| PyRuntimeError::new_err(format!("{e}")))?,
+        )
         .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?,
     };
 
-    let config = loader::load_config(&config_path)
-        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    let config =
+        loader::load_config(&config_path).map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
 
     let yaml = match section {
         "data" => {

--- a/src/commands/tree.rs
+++ b/src/commands/tree.rs
@@ -12,15 +12,14 @@ use crate::config::loader;
 pub fn tree(path: Option<&str>) -> PyResult<String> {
     let config_path = match path {
         Some(p) => std::path::PathBuf::from(p),
-        None => loader::find_config(&std::env::current_dir().map_err(|e| {
-            PyRuntimeError::new_err(format!("{e}"))
-        })?)
+        None => loader::find_config(
+            &std::env::current_dir().map_err(|e| PyRuntimeError::new_err(format!("{e}")))?,
+        )
         .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?,
     };
 
-    let config = loader::load_config(&config_path)
-        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    let config =
+        loader::load_config(&config_path).map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
 
-    serde_json::to_string_pretty(&config)
-        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    serde_json::to_string_pretty(&config).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,6 @@
 //!
 //! One file replaces cutip.yaml + paths.yaml + secrets.yaml + cards + units + groups.
 
-pub mod model;
 pub mod loader;
+pub mod model;
 pub mod resolve;

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -1,14 +1,15 @@
-//! Template resolution for {{ vars.X }}, {{ paths.X }}, and {{ secrets.X }}
-//! placeholders.
+//! Template resolution for `{{ vars.X }}`, `{{ paths.X }}`, `{{ secrets.X }}`,
+//! and `{{ globals.X.Y.Z }}` placeholders.
 
 use std::collections::HashMap;
 
 use super::model::Config;
 
-/// Resolve all `{{ vars.X }}`, `{{ paths.X }}`, and `{{ secrets.X }}`
-/// placeholders in a string against the provided maps.
+/// Resolve all `{{ vars.X }}`, `{{ paths.X }}`, `{{ secrets.X }}`, and
+/// `{{ globals.X.Y.Z }}` placeholders in a string against the provided maps.
 ///
-/// Substitution order: vars first, then paths, then secrets. Within each
+/// `globals` keys are pre-flattened dotted paths (e.g. `"passwords.v22"`).
+/// Substitution order: vars → paths → secrets → globals. Within each
 /// namespace both `{{ ns.key }}` (with spaces) and `{{ns.key}}` (without)
 /// are supported.
 pub fn resolve_string(
@@ -16,6 +17,7 @@ pub fn resolve_string(
     vars: &HashMap<String, String>,
     paths: &HashMap<String, String>,
     secrets: &HashMap<String, String>,
+    globals: &HashMap<String, String>,
 ) -> String {
     let mut result = template.to_string();
 
@@ -43,6 +45,16 @@ pub fn resolve_string(
         let patterns = [
             format!("{{{{ secrets.{key} }}}}"),
             format!("{{{{secrets.{key}}}}}"),
+        ];
+        for pattern in &patterns {
+            result = result.replace(pattern, value);
+        }
+    }
+
+    for (key, value) in globals {
+        let patterns = [
+            format!("{{{{ globals.{key} }}}}"),
+            format!("{{{{globals.{key}}}}}"),
         ];
         for pattern in &patterns {
             result = result.replace(pattern, value);
@@ -112,6 +124,7 @@ mod tests {
             &map(&[]),
             &map(&[("repo", "/home/u/proj")]),
             &map(&[]),
+            &map(&[]),
         );
         assert_eq!(result, "src: /home/u/proj");
     }
@@ -123,37 +136,73 @@ mod tests {
             &map(&[]),
             &map(&[("repo", "/home/u/proj")]),
             &map(&[]),
+            &map(&[]),
         );
         assert_eq!(result, "src: /home/u/proj");
     }
 
     #[test]
     fn resolve_paths_does_not_collide_with_vars() {
-        // Same key in both vars and paths — paths wins for {{ paths.X }},
-        // vars wins for {{ vars.X }}. They never overlap by construction.
         let result = resolve_string(
             "v={{ vars.x }} p={{ paths.x }}",
             &map(&[("x", "from-vars")]),
             &map(&[("x", "from-paths")]),
+            &map(&[]),
             &map(&[]),
         );
         assert_eq!(result, "v=from-vars p=from-paths");
     }
 
     #[test]
-    fn resolve_all_three_namespaces() {
+    fn resolve_all_four_namespaces() {
         let result = resolve_string(
-            "{{ vars.a }}|{{ paths.b }}|{{ secrets.c }}",
+            "{{ vars.a }}|{{ paths.b }}|{{ secrets.c }}|{{ globals.d.e }}",
             &map(&[("a", "VA")]),
             &map(&[("b", "PB")]),
             &map(&[("c", "SC")]),
+            &map(&[("d.e", "GD")]),
         );
-        assert_eq!(result, "VA|PB|SC");
+        assert_eq!(result, "VA|PB|SC|GD");
     }
 
     #[test]
-    fn find_unresolved_picks_up_paths() {
-        let unresolved = find_unresolved("src: {{ paths.missing }}");
-        assert_eq!(unresolved, vec!["{{ paths.missing }}"]);
+    fn resolve_globals_dotted_paths() {
+        let result = resolve_string(
+            "pw={{ globals.passwords.v22 }} url={{globals.constants.artifactory}}",
+            &map(&[]),
+            &map(&[]),
+            &map(&[]),
+            &map(&[
+                ("passwords.v22", "DefaultPw123"),
+                ("constants.artifactory", "http://artifactory.internal/"),
+            ]),
+        );
+        assert_eq!(
+            result,
+            "pw=DefaultPw123 url=http://artifactory.internal/"
+        );
+    }
+
+    #[test]
+    fn resolve_globals_missing_leaves_placeholder() {
+        let result = resolve_string(
+            "{{ globals.missing.path }}",
+            &map(&[]),
+            &map(&[]),
+            &map(&[]),
+            &map(&[]),
+        );
+        assert_eq!(result, "{{ globals.missing.path }}");
+    }
+
+    #[test]
+    fn find_unresolved_picks_up_paths_and_globals() {
+        let unresolved = find_unresolved(
+            "src: {{ paths.missing }}, pw: {{ globals.x.y }}"
+        );
+        assert_eq!(
+            unresolved,
+            vec!["{{ paths.missing }}", "{{ globals.x.y }}"]
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
-mod config;
 mod commands;
+mod config;
 
 /// cutip._core — Rust core for the cutip Python package.
 #[pymodule]

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -1,0 +1,130 @@
+"""Tests for cutip.globals — global data store + dotted-path lookup."""
+
+from __future__ import annotations
+
+import pytest
+
+from cutip import globals as _globals
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect ~/.cutip/ to a tmp dir per-test."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    yield tmp_path
+
+
+# ── lookup ──────────────────────────────────────────────────────────────────
+
+
+def test_lookup_simple():
+    data = {"x": "hello"}
+    assert _globals.lookup(data, "x") == "hello"
+
+
+def test_lookup_nested():
+    data = {"passwords": {"v22": "pw"}}
+    assert _globals.lookup(data, "passwords.v22") == "pw"
+
+
+def test_lookup_missing_returns_none():
+    data = {"x": "hello"}
+    assert _globals.lookup(data, "y") is None
+    assert _globals.lookup(data, "x.deeper") is None
+
+
+def test_lookup_returns_dict_when_path_is_intermediate():
+    """Looking up an intermediate node returns the dict; caller decides."""
+    data = {"passwords": {"v22": "pw"}}
+    assert _globals.lookup(data, "passwords") == {"v22": "pw"}
+
+
+def test_lookup_empty_path_returns_none():
+    assert _globals.lookup({"x": 1}, "") is None
+
+
+# ── set_dotted ──────────────────────────────────────────────────────────────
+
+
+def test_set_dotted_creates_nested():
+    data: dict = {}
+    _globals.set_dotted(data, "passwords.v22", "pw")
+    assert data == {"passwords": {"v22": "pw"}}
+
+
+def test_set_dotted_extends_existing():
+    data = {"passwords": {"v22": "old"}}
+    _globals.set_dotted(data, "passwords.v23", "new")
+    assert data == {"passwords": {"v22": "old", "v23": "new"}}
+
+
+def test_set_dotted_overwrites_leaf():
+    data = {"passwords": {"v22": "old"}}
+    _globals.set_dotted(data, "passwords.v22", "new")
+    assert data["passwords"]["v22"] == "new"
+
+
+def test_set_dotted_rejects_traversal_through_scalar():
+    data = {"passwords": "scalar-not-a-dict"}
+    with pytest.raises(_globals.GlobalsError, match="non-mapping"):
+        _globals.set_dotted(data, "passwords.v22", "pw")
+
+
+def test_set_dotted_rejects_empty_path():
+    with pytest.raises(_globals.GlobalsError, match="empty"):
+        _globals.set_dotted({}, "", "x")
+
+
+# ── flatten ─────────────────────────────────────────────────────────────────
+
+
+def test_flatten_empty():
+    assert _globals.flatten({}) == {}
+
+
+def test_flatten_simple_scalars():
+    data = {"a": "1", "b": "2"}
+    assert _globals.flatten(data) == {"a": "1", "b": "2"}
+
+
+def test_flatten_nested():
+    data = {"passwords": {"v22": "pw1", "v23": "pw2"}}
+    assert _globals.flatten(data) == {
+        "passwords.v22": "pw1",
+        "passwords.v23": "pw2",
+    }
+
+
+def test_flatten_coerces_int_float_bool():
+    data = {"port": 22, "ratio": 1.5, "active": True, "off": False}
+    flat = _globals.flatten(data)
+    assert flat == {"port": "22", "ratio": "1.5", "active": "true", "off": "false"}
+
+
+def test_flatten_skips_lists_and_none():
+    data = {"a": "ok", "list": [1, 2, 3], "missing": None, "nested": {"b": "c"}}
+    assert _globals.flatten(data) == {"a": "ok", "nested.b": "c"}
+
+
+def test_flatten_deep_nesting():
+    data = {"a": {"b": {"c": {"d": "deep"}}}}
+    assert _globals.flatten(data) == {"a.b.c.d": "deep"}
+
+
+# ── read / write ────────────────────────────────────────────────────────────
+
+
+def test_read_missing_returns_empty(tmp_path):
+    assert _globals.read_globals(tmp_path / "nope.yaml") == {}
+
+
+def test_write_then_read_roundtrip(tmp_path):
+    p = tmp_path / "data.yaml"
+    payload = {"passwords": {"v22": "pw"}, "url": "http://x"}
+    _globals.write_globals(payload, p)
+    assert _globals.read_globals(p) == payload
+
+
+def test_globals_path_default(isolated_home):
+    expected = isolated_home / ".cutip" / "data.yaml"
+    assert _globals.globals_path() == expected

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.13.0"
+version = "2.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Global data store at `~/.cutip/data.yaml` for cross-project shared values (passwords keyed by version, internal URLs, default usernames). Referenced from any string template via dotted paths:

```yaml
# anywhere a {{ ... }} template is rendered:
auth: 'admin:{{ globals.passwords.v22 }}'
```

```bash
cutip data init
cutip data set passwords.v22=DefaultPw123 constants.artifactory=http://x/
cutip data list                # passwords.v22 = ****  (sensitive masked)
cutip data get passwords.v22   # DefaultPw123
```

## Why

Surfaced during snf-dev rollout — multiple projects share the same SFM default root password keyed by product version. Hardcoding in each repo or copying through hosts.yaml is repetitive and fragile.

## Components

| Layer | What |
|---|---|
| Storage | `~/.cutip/data.yaml` — free-form nested YAML |
| Module | `cutip/globals.py` — read/write/lookup/set_dotted/flatten |
| CLI | `cutip data list/get/set/path/init` (global-only — no `-g` flag) |
| Context | `ctx.globals` property — flattened {dotted: scalar} for runtime substitution |
| Resolver | `src/config/resolve.rs` — `resolve_string` takes globals (4th arg) |
| Validate output | UI table renders sensitive masking when any path segment matches "password"/"secret"/"token"/"key" |

## Tests

| Layer | Count | Status |
|---|---|---|
| Rust resolver | 7 (4 new) | pass |
| Python (globals.py) | 19 new | pass, 100% coverage on the new module |
| Python total | 183 | pass, 81% coverage |
| CLI smoke | init/set/list/get end-to-end | confirmed |

## Companion PR

rsty 0.9.0 (https://github.com/joshuajerome/rsty/pull/56) adds the matching `substitute_vars` extension so YAML mount sources / env values in workflows can render `{{ globals.X.Y.Z }}` at runtime.

## Backward compat

- Existing projects with no `~/.cutip/data.yaml` see no behavior change.
- Resolver's existing 3-arg semantics (vars/paths/secrets) preserved; new arg added at the end.
- `{{ globals.X.Y.Z }}` placeholders in legacy projects without a data file remain as literal strings (caller can detect via `find_unresolved`).