### PR TITLE
feat: engine-level template substitution — v2.15.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.14.0"
+VERSION = "2.15.0"
 console = Console()
 
 
@@ -93,16 +93,43 @@ def _resolve_workflow(project_path: Path, config: dict) -> Path:
 def _load_config(project_path: Path) -> dict:
     """Load and return project config as a dict.
 
-    Expands the ``paths:`` section against the project file's directory
-    and merges the resolved values into ``config['data']`` so workflow
-    code reads them via ``ctx.data["<name>"]`` like any other entry.
+    Resolution stages (in order):
+      1. Parse YAML.
+      2. Read globals from ``~/.cutip/data.yaml`` (flat dotted keys).
+      3. Resolve globals into ``vars`` / ``paths`` / ``secrets`` so they
+         carry final values before the rest of the config is processed.
+      4. Walk the entire config dict and substitute every ``{{ ns.key }}``
+         placeholder using the resolved vars/paths/secrets/globals maps.
+      5. Expand the ``paths:`` section against the project's directory
+         and merge the resolved values into ``config['data']`` so
+         workflow code reads them via ``ctx.data["<name>"]``.
     """
     import yaml
 
+    from cutip import globals as _globals
     from cutip.paths import merge_paths_into_data
+    from cutip.templating import resolve_substitution_maps, substitute_in_obj
 
     with open(project_path) as f:
         config = yaml.safe_load(f) or {}
+
+    globals_flat = _globals.flatten(_globals.read_globals())
+
+    # Stage 3: resolve globals into vars/paths/secrets.
+    vars_resolved, paths_resolved, secrets_resolved = resolve_substitution_maps(
+        config, globals_flat
+    )
+
+    # Stage 4: substitute all four namespaces across the entire config.
+    config = substitute_in_obj(
+        config,
+        vars=vars_resolved,
+        paths=paths_resolved,
+        secrets=secrets_resolved,
+        globals=globals_flat,
+    )
+
+    # Stage 5: existing path-section merge into data.
     merge_paths_into_data(config, project_path)
     return config
 
@@ -563,7 +590,9 @@ def cmd_run(args):
         hosts_path = _resolve_hosts_path(project_path)
 
     if hosts_path.exists():
+        from cutip import globals as _globals
         from cutip import hosts as _hosts_mod
+        from cutip.templating import substitute_in_obj
 
         try:
             resolved_hosts = _hosts_mod.resolve(hosts_path)
@@ -575,6 +604,24 @@ def cmd_run(args):
         # carries the nested raw dict.
         with open(hosts_path) as f:
             hosts = yaml.safe_load(f) or {}
+
+        # Substitute templates in resolved hosts using project's vars/paths/
+        # secrets (already resolved against globals at config-load time).
+        globals_flat = _globals.flatten(_globals.read_globals())
+        resolved_hosts = substitute_in_obj(
+            resolved_hosts,
+            vars=config.get("vars") or {},
+            paths=config.get("paths") or {},
+            secrets=config.get("secrets") or {},
+            globals=globals_flat,
+        )
+        hosts = substitute_in_obj(
+            hosts,
+            vars=config.get("vars") or {},
+            paths=config.get("paths") or {},
+            secrets=config.get("secrets") or {},
+            globals=globals_flat,
+        )
 
     # Pre-run validation
     workflow_path = _resolve_workflow(project_path, config)

--- a/cutip/daemon.py
+++ b/cutip/daemon.py
@@ -176,11 +176,26 @@ def run_daemon(cu_id: str, hosts_path_arg: str | None = None) -> int:
     except OSError:
         pass
 
-    # Load config + hosts the same way cmd_run does
+    # Load config + hosts the same way cmd_run does (template substitution
+    # included so daemon-mode behaves identically to foreground runs).
+    from cutip import globals as _globals
     from cutip.paths import merge_paths_into_data
+    from cutip.templating import resolve_substitution_maps, substitute_in_obj
 
     with open(project_path) as f:
         config = yaml.safe_load(f) or {}
+
+    globals_flat = _globals.flatten(_globals.read_globals())
+    vars_resolved, paths_resolved, secrets_resolved = resolve_substitution_maps(
+        config, globals_flat
+    )
+    config = substitute_in_obj(
+        config,
+        vars=vars_resolved,
+        paths=paths_resolved,
+        secrets=secrets_resolved,
+        globals=globals_flat,
+    )
     merge_paths_into_data(config, project_path)
 
     hosts: dict | None = None
@@ -200,6 +215,21 @@ def run_daemon(cu_id: str, hosts_path_arg: str | None = None) -> int:
             resolved_hosts = _hosts_mod.resolve(hp)
         except _hosts_mod.HostsError as e:
             print(f"[daemon] hosts resolve error: {e}", file=sys.stderr)
+        if resolved_hosts is not None:
+            resolved_hosts = substitute_in_obj(
+                resolved_hosts,
+                vars=vars_resolved,
+                paths=paths_resolved,
+                secrets=secrets_resolved,
+                globals=globals_flat,
+            )
+        hosts = substitute_in_obj(
+            hosts,
+            vars=vars_resolved,
+            paths=paths_resolved,
+            secrets=secrets_resolved,
+            globals=globals_flat,
+        )
 
     # Import the workflow module
     import importlib.util

--- a/cutip/templating.py
+++ b/cutip/templating.py
@@ -1,0 +1,125 @@
+"""Engine-level template substitution for cutip config + hosts files.
+
+Walks any nested dict / list / str structure and substitutes:
+
+  ``{{ vars.key }}``       from vars
+  ``{{ paths.key }}``      from paths (raw values, before merge into data)
+  ``{{ secrets.key }}``    from secrets
+  ``{{ globals.a.b.c }}``  from globals (dotted keys, pre-flattened)
+
+Both spaced (``{{ ns.key }}``) and unspaced (``{{ns.key}}``) forms are
+accepted, matching the runtime ``rsty.config.substitute_vars`` and the
+Rust resolver in cutip-core.
+
+Resolution order at config load (see ``cutip.cli._load_config``):
+
+  1. Read globals from ``~/.cutip/data.yaml`` (flat dotted keys).
+  2. Substitute globals into ``vars``, ``paths``, ``secrets``. These are
+     SOURCES for further substitution, so resolving them first means the
+     rest of the config sees their final values. Vars/paths/secrets
+     cannot reference each other — only globals.
+  3. Substitute vars + paths + secrets + globals into the entire config
+     (data, container, image, environment, mounts, etc.).
+  4. ``cutip.paths.merge_paths_into_data`` runs after substitution so
+     paths used by workflows are already expanded.
+
+For hosts.yaml, ``cutip.hosts.resolve()`` returns the dict; the caller
+(``cli.py`` / ``daemon.py``) then calls ``substitute_in_obj`` with the
+project's substitution context. That keeps ``hosts.resolve()`` pure and
+avoids passing context that hosts logic doesn't otherwise need.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def _substitute_string(
+    text: str,
+    vars: Mapping[str, str],
+    paths: Mapping[str, str],
+    secrets: Mapping[str, str],
+    globals: Mapping[str, str],
+) -> str:
+    """Substitute ``{{ ns.key }}`` placeholders in a single string.
+
+    Idempotent: a string with no ``{{`` returns unchanged. Strings whose
+    placeholders don't match any key in any namespace are returned with
+    the placeholders intact (caller decides whether to flag as an error).
+    """
+    if "{{" not in text:
+        return text
+    result = text
+    for ns, mapping in (
+        ("vars", vars),
+        ("paths", paths),
+        ("secrets", secrets),
+        ("globals", globals),
+    ):
+        for key, value in mapping.items():
+            sval = value if isinstance(value, str) else str(value)
+            for pattern in (f"{{{{ {ns}.{key} }}}}", f"{{{{{ns}.{key}}}}}"):
+                result = result.replace(pattern, sval)
+    return result
+
+
+def substitute_in_obj(
+    obj: Any,
+    *,
+    vars: Mapping[str, str] | None = None,
+    paths: Mapping[str, str] | None = None,
+    secrets: Mapping[str, str] | None = None,
+    globals: Mapping[str, str] | None = None,
+) -> Any:
+    """Recursively substitute templates in a dict / list / str structure.
+
+    Returns a new structure (input is not mutated). Values that aren't
+    strings, dicts, or lists pass through unchanged (int, bool, None, …).
+    """
+    v = vars or {}
+    p = paths or {}
+    s = secrets or {}
+    g = globals or {}
+
+    if isinstance(obj, str):
+        return _substitute_string(obj, v, p, s, g)
+    if isinstance(obj, dict):
+        return {
+            k: substitute_in_obj(val, vars=v, paths=p, secrets=s, globals=g)
+            for k, val in obj.items()
+        }
+    if isinstance(obj, list):
+        return [
+            substitute_in_obj(item, vars=v, paths=p, secrets=s, globals=g)
+            for item in obj
+        ]
+    return obj
+
+
+def resolve_substitution_maps(
+    config: dict,
+    globals_flat: Mapping[str, str],
+) -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
+    """Resolve globals into vars/paths/secrets, returning the final maps.
+
+    These three are the substitution SOURCES; they themselves can only
+    reference globals. Used at the start of config load before walking
+    the rest of the dict.
+    """
+    raw_vars = config.get("vars") or {}
+    raw_paths = config.get("paths") or {}
+    raw_secrets = config.get("secrets") or {}
+
+    def _resolve_one(mapping: Mapping[str, Any]) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for k, v in mapping.items():
+            if isinstance(v, str):
+                out[k] = _substitute_string(v, {}, {}, {}, globals_flat)
+            else:
+                # Coerce non-string values (rare; users who put ints/bools
+                # in vars: usually mean strings anyway).
+                out[k] = str(v)
+        return out
+
+    return _resolve_one(raw_vars), _resolve_one(raw_paths), _resolve_one(raw_secrets)

--- a/cutip/workflow/validate.py
+++ b/cutip/workflow/validate.py
@@ -129,18 +129,42 @@ def validate_project(
         if not hosts_path.exists() and not hosts:
             errors.append("hosts.yaml not found (required for host: remote)")
             errors.append(
-                "  Create with: cutip hosts set host=<ip> username=<user> password=<pw>"
+                "  Create with: cutip hosts set <name>.host=<ip> "
+                "<name>.username=<user> <name>.password=<pw>"
             )
         else:
             h = hosts or {}
-            missing = [f for f in ("host", "username", "password") if not h.get(f)]
-            if missing:
-                errors.append(
-                    f"Missing SSH credentials in hosts.yaml: {', '.join(missing)}"
-                )
-                errors.append(
-                    f"  Set with: cutip hosts set {' '.join(f'{f}=<value>' for f in missing)}"
-                )
+            from cutip.hosts import is_nested
+
+            if is_nested(h):
+                # Nested: every entry needs host/username/password (skip
+                # entries that defer to global via {global: true}).
+                for name, entry in h.items():
+                    if not isinstance(entry, dict):
+                        continue
+                    if entry.get("global") is True:
+                        continue
+                    missing = [
+                        f for f in ("host", "username", "password") if not entry.get(f)
+                    ]
+                    if missing:
+                        errors.append(
+                            f"hosts.yaml entry '{name}': missing {', '.join(missing)}"
+                        )
+                        errors.append(
+                            f"  Set with: cutip hosts set "
+                            f"{' '.join(f'{name}.{f}=<value>' for f in missing)}"
+                        )
+            else:
+                # Flat (legacy): top-level fields.
+                missing = [f for f in ("host", "username", "password") if not h.get(f)]
+                if missing:
+                    errors.append(
+                        f"Missing SSH credentials in hosts.yaml: {', '.join(missing)}"
+                    )
+                    errors.append(
+                        f"  Set with: cutip hosts set {' '.join(f'{f}=<value>' for f in missing)}"
+                    )
 
     # 8. Container runtime reachable
     if host == "container":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.14.0"
+version = "2.15.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -1,0 +1,193 @@
+"""Tests for cutip.templating — engine-level substitution helpers."""
+
+from __future__ import annotations
+
+
+from cutip.templating import (
+    _substitute_string,
+    resolve_substitution_maps,
+    substitute_in_obj,
+)
+
+
+# ── _substitute_string ──────────────────────────────────────────────────────
+
+
+def test_substitute_string_no_template_passthrough():
+    assert _substitute_string("plain text", {}, {}, {}, {}) == "plain text"
+
+
+def test_substitute_string_vars():
+    assert (
+        _substitute_string("hi {{ vars.name }}", {"name": "alice"}, {}, {}, {})
+        == "hi alice"
+    )
+
+
+def test_substitute_string_paths():
+    assert (
+        _substitute_string("src: {{ paths.repo }}", {}, {"repo": "/x"}, {}, {})
+        == "src: /x"
+    )
+
+
+def test_substitute_string_secrets():
+    assert (
+        _substitute_string("token={{ secrets.t }}", {}, {}, {"t": "abc"}, {})
+        == "token=abc"
+    )
+
+
+def test_substitute_string_globals_dotted():
+    assert (
+        _substitute_string(
+            "pw={{ globals.passwords.v22 }}", {}, {}, {}, {"passwords.v22": "P!"}
+        )
+        == "pw=P!"
+    )
+
+
+def test_substitute_string_unspaced_form():
+    assert _substitute_string("{{vars.x}}", {"x": "Y"}, {}, {}, {}) == "Y"
+
+
+def test_substitute_string_idempotent_after_resolve():
+    """Re-running on already-resolved text is a no-op."""
+    once = _substitute_string("{{ vars.x }}", {"x": "alice"}, {}, {}, {})
+    twice = _substitute_string(once, {"x": "alice"}, {}, {}, {})
+    assert once == twice == "alice"
+
+
+def test_substitute_string_unknown_placeholder_left_alone():
+    assert (
+        _substitute_string("{{ vars.unknown }}", {"x": "y"}, {}, {}, {})
+        == "{{ vars.unknown }}"
+    )
+
+
+def test_substitute_string_all_four_namespaces():
+    out = _substitute_string(
+        "{{ vars.a }}|{{ paths.b }}|{{ secrets.c }}|{{ globals.d.e }}",
+        {"a": "A"},
+        {"b": "B"},
+        {"c": "C"},
+        {"d.e": "D"},
+    )
+    assert out == "A|B|C|D"
+
+
+# ── substitute_in_obj ───────────────────────────────────────────────────────
+
+
+def test_substitute_in_obj_string():
+    assert substitute_in_obj("{{ vars.x }}", vars={"x": "v"}) == "v"
+
+
+def test_substitute_in_obj_passthrough_non_strings():
+    assert substitute_in_obj(42, vars={"x": "v"}) == 42
+    assert substitute_in_obj(True, vars={"x": "v"}) is True
+    assert substitute_in_obj(None, vars={"x": "v"}) is None
+
+
+def test_substitute_in_obj_dict_recurses():
+    obj = {"name": "{{ vars.name }}", "extra": {"deeper": "{{ vars.x }}"}}
+    out = substitute_in_obj(obj, vars={"name": "alice", "x": "Y"})
+    assert out == {"name": "alice", "extra": {"deeper": "Y"}}
+
+
+def test_substitute_in_obj_list_recurses():
+    obj = ["{{ vars.a }}", {"k": "{{ vars.b }}"}, 42]
+    out = substitute_in_obj(obj, vars={"a": "A", "b": "B"})
+    assert out == ["A", {"k": "B"}, 42]
+
+
+def test_substitute_in_obj_does_not_mutate_input():
+    original = {"a": "{{ vars.x }}"}
+    substitute_in_obj(original, vars={"x": "Y"})
+    assert original == {"a": "{{ vars.x }}"}
+
+
+def test_substitute_in_obj_no_kwargs_passes_through():
+    obj = {"a": "{{ vars.x }}", "b": 1}
+    out = substitute_in_obj(obj)
+    assert out == obj
+
+
+# ── resolve_substitution_maps ───────────────────────────────────────────────
+
+
+def test_resolve_substitution_maps_resolves_globals_in_vars():
+    config = {"vars": {"greeting": "hi {{ globals.user }}"}}
+    v, p, s = resolve_substitution_maps(config, {"user": "alice"})
+    assert v == {"greeting": "hi alice"}
+    assert p == {}
+    assert s == {}
+
+
+def test_resolve_substitution_maps_resolves_globals_in_paths():
+    config = {"paths": {"repo": "{{ globals.home }}/proj"}}
+    _, p, _ = resolve_substitution_maps(config, {"home": "/home/u"})
+    assert p == {"repo": "/home/u/proj"}
+
+
+def test_resolve_substitution_maps_resolves_globals_in_secrets():
+    config = {"secrets": {"db_pw": "{{ globals.passwords.db }}"}}
+    _, _, s = resolve_substitution_maps(config, {"passwords.db": "secret"})
+    assert s == {"db_pw": "secret"}
+
+
+def test_resolve_substitution_maps_coerces_non_strings():
+    """A var like `port: 22` (int) becomes string '22'."""
+    config = {"vars": {"port": 22}}
+    v, _, _ = resolve_substitution_maps(config, {})
+    assert v == {"port": "22"}
+
+
+def test_resolve_substitution_maps_empty_config():
+    v, p, s = resolve_substitution_maps({}, {})
+    assert v == {} and p == {} and s == {}
+
+
+# ── Integration: end-to-end shape ──────────────────────────────────────────
+
+
+def test_end_to_end_globals_then_config():
+    """Globals → vars/paths/secrets → rest of config."""
+    config = {
+        "vars": {"name": "{{ globals.user }}"},
+        "paths": {"repo": "{{ globals.home }}/code"},
+        "data": {
+            "greeting": "hello {{ vars.name }} at {{ paths.repo }}",
+            "list": ["{{ globals.user }}", "{{ vars.name }}"],
+        },
+    }
+    globals_flat = {"user": "alice", "home": "/home/alice"}
+
+    v, p, s = resolve_substitution_maps(config, globals_flat)
+    out = substitute_in_obj(config, vars=v, paths=p, secrets=s, globals=globals_flat)
+
+    assert out["vars"]["name"] == "alice"
+    assert out["paths"]["repo"] == "/home/alice/code"
+    assert out["data"]["greeting"] == "hello alice at /home/alice/code"
+    assert out["data"]["list"] == ["alice", "alice"]
+
+
+def test_end_to_end_hosts_yaml_shape():
+    """Hosts entries can pull credentials from globals while keeping a
+    per-project IP."""
+    resolved_hosts = {
+        "sfm": {
+            "host": "100.94.115.88",
+            "username": "{{ globals.sfm.cred.username }}",
+            "password": "{{ globals.sfm.cred.password }}",
+        }
+    }
+    globals_flat = {"sfm.cred.username": "root", "sfm.cred.password": "Dell@force10"}
+    out = substitute_in_obj(resolved_hosts, globals=globals_flat)
+    assert out == {
+        "sfm": {
+            "host": "100.94.115.88",
+            "username": "root",
+            "password": "Dell@force10",
+        }
+    }

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -105,6 +105,56 @@ class TestValidateProject:
         cred_errors = [e for e in errors if "missing" in e.lower() and "SSH" in e]
         assert cred_errors == []
 
+    def test_remote_ssh_nested_complete_credentials(self, tmp_path):
+        """Nested hosts.yaml with full creds passes."""
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "remote"},
+            hosts={
+                "sfm": {"host": "10.0.0.1", "username": "root", "password": "pw"},
+            },
+        )
+        cred_errors = [e for e in errors if "missing" in e.lower()]
+        assert cred_errors == []
+
+    def test_remote_ssh_nested_missing_credentials(self, tmp_path):
+        """Nested entry with missing fields surfaces a per-entry error."""
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "remote"},
+            hosts={
+                "sfm": {"host": "10.0.0.1"},  # missing username + password
+            },
+        )
+        assert any("sfm" in e and "username" in e for e in errors)
+        assert any("sfm" in e and "password" in e for e in errors)
+
+    def test_remote_ssh_nested_global_ref_skipped(self, tmp_path):
+        """Entries with `{global: true}` are skipped — credentials come from
+        ~/.cutip/hosts.yaml at run time and aren't checked at validate."""
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "remote"},
+            hosts={"sfm": {"global": True}},
+        )
+        cred_errors = [e for e in errors if "missing" in e.lower()]
+        assert cred_errors == []
+
+    def test_remote_ssh_nested_multi_entry(self, tmp_path):
+        """Per-entry checks: one entry full, one missing fields → only the
+        bad one errors."""
+        errors, _ = validate_project(
+            tmp_path / "test.yaml",
+            {"project": "test", "host": "remote"},
+            hosts={
+                "good": {"host": "h", "username": "u", "password": "p"},
+                "bad": {"host": "h2"},  # missing username/password
+            },
+        )
+        # Bad entry surfaces; good entry doesn't
+        assert any("bad" in e and "missing" in e for e in errors)
+        assert not any("'good'" in e for e in errors)
+
     def test_empty_vars_are_errors(self, tmp_path):
         errors, _ = validate_project(
             tmp_path / "test.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Walks every string in config.yaml + hosts.yaml at config-load time and substitutes `{{ vars.X }}`, `{{ paths.X }}`, `{{ secrets.X }}`, and `{{ globals.X.Y.Z }}` placeholders. Unlocks two consolidation patterns:

### 1. Shared paths/passwords across workflows

```yaml
# ~/.cutip/data.yaml
ssh_keys:
  private: 'C:/Users/Joshua/.ssh/id_ed25519'
  public:  'C:/Users/Joshua/.ssh/id_ed25519.pub'
```

```yaml
# any project YAML
paths:
  ssh_private_key: '{{ globals.ssh_keys.private }}'
  ssh_public_key:  '{{ globals.ssh_keys.public }}'
```

### 2. Per-VM IP, shared credentials

```yaml
# project hosts.yaml — IP per project, creds from globals
sfm:
  host: 100.94.115.88
  username: '{{ globals.sfm.cred.username }}'
  password: '{{ globals.sfm.cred.password }}'
```

Workflow code reads already-resolved values via `ctx.data['ssh_private_key']` / `ctx.host_for('sfm')['password']` — no manual `config.substitute_vars` calls.

## Resolution order

1. Parse YAML.
2. Read `~/.cutip/data.yaml` (flat dotted keys).
3. **Stage 1** — resolve globals into vars / paths / secrets so they carry final values before further substitution. Vars / paths / secrets cannot reference each other; only globals.
4. **Stage 2** — recursive walk: substitute all four namespaces into every string value in the config dict (handles nested dicts and lists).
5. `merge_paths_into_data` runs after substitution so paths in `ctx.data` are fully resolved.

For hosts.yaml, `cli.py` and `daemon.py` call `substitute_in_obj` on `resolved_hosts` (and the raw `hosts` dict) using the project's substitution context. `cutip.hosts.resolve()` stays pure — no globals dep.

## Companion fix

Validator's `host: remote` branch now correctly handles nested hosts.yaml. Per-entry checks (`host` / `username` / `password`) with helpful `cutip hosts set <name>.<field>=<value>` hints. Entries with `{global: true}` are skipped — credentials resolve from `~/.cutip/hosts.yaml` at run time and aren't validated upfront.

## New module

`cutip/templating.py`:
- `_substitute_string` — placeholder substitution in a single string
- `substitute_in_obj` — recursive walk over dict / list / str / pass-through
- `resolve_substitution_maps` — resolve globals into vars/paths/secrets

100% coverage on the new module.

## Tests

| Layer | Count | Status |
|---|---|---|
| New templating | 22 | pass |
| New validator (nested hosts) | 4 | pass |
| Total | 209 | pass, 81% coverage |

## Backward compat

- Existing flat hosts.yaml: unchanged path through validator + resolver.
- Existing template usage in workflow code (`config.substitute_vars(...)`) keeps working — values that already arrived resolved are no-ops on re-substitution (idempotent).
- Strings without `{{` short-circuit: zero-cost for the 99% of fields without templates.
- Projects with no `~/.cutip/data.yaml`: globals dict is empty, no substitutions happen, behavior is identical to before.