### PR TITLE
fix: cutip hosts get/list/validate apply template substitution — v2.15.1

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.15.0"
+VERSION = "2.15.1"
 console = Console()
 
 
@@ -1031,6 +1031,33 @@ def _resolve_hosts_path(project_path: Path) -> Path:
     return hosts_path
 
 
+def _resolved_hosts_with_substitution(
+    project_path: Path, hosts_path: Path
+) -> dict[str, dict]:
+    """Resolve hosts.yaml + apply template substitution against the project's
+    vars / paths / secrets / globals context.
+
+    Mirrors what ``cmd_run`` does when loading hosts before passing them to
+    the workflow engine. Used by ``cutip hosts get / list / validate`` so
+    those subcommands return resolved values, not raw ``{{ ... }}`` template
+    strings.
+    """
+    from cutip import globals as _globals
+    from cutip import hosts as _hosts_mod
+    from cutip.templating import substitute_in_obj
+
+    config = _load_config(project_path)
+    resolved = _hosts_mod.resolve(hosts_path)
+    globals_flat = _globals.flatten(_globals.read_globals())
+    return substitute_in_obj(
+        resolved,
+        vars=config.get("vars") or {},
+        paths=config.get("paths") or {},
+        secrets=config.get("secrets") or {},
+        globals=globals_flat,
+    )
+
+
 def _print_hosts_dict(data: dict, label: str | None = None) -> None:
     """Render a hosts dict (nested or flat) with sensitive values masked."""
     from cutip import hosts as _hosts
@@ -1155,7 +1182,16 @@ def cmd_hosts(args):
             if use_global:
                 console.print("  Create with: cutip hosts init -g")
             return
-        data = _hosts.read_hosts_file(target_path)
+        if use_global:
+            data = _hosts.read_hosts_file(target_path)
+        else:
+            # Apply project-context template substitution so list shows
+            # resolved values instead of raw {{ globals.X }} strings.
+            try:
+                data = _resolved_hosts_with_substitution(project_path, target_path)
+            except _hosts.HostsError as e:
+                console.print(f"[red]Error:[/red] {e}")
+                sys.exit(1)
         _print_hosts_dict(data, label=target_label)
         return
 
@@ -1170,7 +1206,12 @@ def cmd_hosts(args):
         if "." in key:
             host_name, field = key.split(".", 1)
             try:
-                resolved = _hosts.resolve(target_path) if not use_global else data
+                if use_global:
+                    resolved = data
+                else:
+                    resolved = _resolved_hosts_with_substitution(
+                        project_path, target_path
+                    )
             except _hosts.HostsError as e:
                 console.print(f"[red]Error:[/red] {e}")
                 sys.exit(1)
@@ -1334,7 +1375,9 @@ def cmd_hosts(args):
                 console.print(f"[red]Error:[/red] {target_label} not found")
                 sys.exit(1)
             try:
-                to_probe = _hosts.resolve(target_path)
+                # Substitute templates so the probe gets real credentials,
+                # not raw {{ globals.X }} strings.
+                to_probe = _resolved_hosts_with_substitution(project_path, target_path)
             except _hosts.HostsError as e:
                 console.print(f"[red]Error resolving hosts:[/red] {e}")
                 sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.15.0"
+version = "2.15.1"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -176,18 +176,59 @@ def test_end_to_end_hosts_yaml_shape():
     """Hosts entries can pull credentials from globals while keeping a
     per-project IP."""
     resolved_hosts = {
-        "sfm": {
-            "host": "100.94.115.88",
-            "username": "{{ globals.sfm.cred.username }}",
-            "password": "{{ globals.sfm.cred.password }}",
+        "myhost": {
+            "host": "10.0.0.1",
+            "username": "{{ globals.myhost.cred.username }}",
+            "password": "{{ globals.myhost.cred.password }}",
         }
     }
-    globals_flat = {"sfm.cred.username": "root", "sfm.cred.password": "Dell@force10"}
+    globals_flat = {
+        "myhost.cred.username": "test-user",
+        "myhost.cred.password": "test-pw",
+    }
     out = substitute_in_obj(resolved_hosts, globals=globals_flat)
     assert out == {
-        "sfm": {
-            "host": "100.94.115.88",
-            "username": "root",
-            "password": "Dell@force10",
+        "myhost": {
+            "host": "10.0.0.1",
+            "username": "test-user",
+            "password": "test-pw",
+        }
+    }
+
+
+def test_cli_resolved_hosts_with_substitution(tmp_path, monkeypatch):
+    """cutip.cli._resolved_hosts_with_substitution reads project + globals
+    and returns hosts with templates resolved. Covers the cmd_hosts get /
+    list / validate code path."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Set up project YAML
+    project_path = tmp_path / "proj.yaml"
+    project_path.write_text("project: smoke\nhost: remote\n")
+
+    # hosts.yaml with template references
+    hosts_path = tmp_path / "hosts.yaml"
+    hosts_path.write_text(
+        "myhost:\n"
+        "  host: 10.0.0.1\n"
+        "  username: '{{ globals.myhost.cred.username }}'\n"
+        "  password: '{{ globals.myhost.cred.password }}'\n"
+    )
+
+    # Globals data
+    cutip_dir = tmp_path / ".cutip"
+    cutip_dir.mkdir()
+    (cutip_dir / "data.yaml").write_text(
+        "myhost:\n  cred:\n    username: test-user\n    password: test-pw\n"
+    )
+
+    from cutip.cli import _resolved_hosts_with_substitution
+
+    resolved = _resolved_hosts_with_substitution(project_path, hosts_path)
+    assert resolved == {
+        "myhost": {
+            "host": "10.0.0.1",
+            "username": "test-user",
+            "password": "test-pw",
         }
     }

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.15.0"
+version = "2.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

2.15.0 wired engine-level template substitution into `cmd_run`'s host-loading path but missed `cutip hosts get / list / validate`. Templates leaked through unsubstituted, causing:

- `cutip hosts get sfm.password ./setup.yaml` returns the literal string `{{ globals.sfm.cred.password }}` instead of the resolved value
- `cutip hosts validate` SSH-probes with the template string as the password, causing 'authentication failed' on every entry that uses templates
- `cutip hosts list` prints raw `{{ ... }}` strings (with sensitive masking applied) instead of resolved values

## Fix

Extract a small `_resolved_hosts_with_substitution(project_path, hosts_path)` helper in `cli.py` that mirrors what `cmd_run` does:

1. `_load_config(project_path)` — picks up vars/paths/secrets (already substitution-applied in 2.15.0).
2. `_hosts.resolve(hosts_path)` — handles `{global: true}` references.
3. `substitute_in_obj(resolved, vars, paths, secrets, globals)` — resolves `{{ globals.X }}` / `{{ vars.X }}` / etc. in each entry's fields.

`cmd_hosts get / list / validate` now use this helper for project-mode operations. Global-mode (`-g`) is unchanged — globals data file is the SOURCE of substitution; no recursion to apply.

## Test

1 new integration test verifies the helper end-to-end with a tmp project + `~/.cutip/data.yaml` + templated `hosts.yaml`. 210 pass total, 81% coverage.

Tests use only fake IPs (`10.0.0.1`) and placeholder credentials (`test-user` / `test-pw`) — no real-looking creds in the test suite.