### PR TITLE
feat: rm subcommand for vars / secrets / data / hosts — v2.16.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.15.1"
+VERSION = "2.16.0"
 console = Console()
 
 
@@ -904,11 +904,12 @@ def cmd_vars(args):
     subcmd = args.get("subcmd")
     if not subcmd or subcmd == "help":
         console.print(
-            "[bold]cutip vars[/bold] <list|get|set> [project.yaml] [key=value ...]"
+            "[bold]cutip vars[/bold] <list|get|set|rm> [project.yaml] [key=value ...]"
         )
         console.print("  list   Show all vars and their values")
         console.print("  get    Get a single var value")
         console.print("  set    Set one or more vars")
+        console.print("  rm     Remove a var; prints the removed value")
         return
 
     project_path = _resolve_project(args.get("project"))
@@ -957,17 +958,34 @@ def cmd_vars(args):
             console.print(f"  [green]✓[/green] {k} = {v}")
         _yaml_write(project_path, config)
 
+    elif subcmd == "rm":
+        key = args.get("key")
+        if not key:
+            console.print("[red]Usage:[/red] cutip vars rm [project.yaml] <key>")
+            sys.exit(1)
+        vars_dict = config.get("vars") or {}
+        if key not in vars_dict:
+            console.print(f"[red]Error:[/red] var '{key}' not found")
+            sys.exit(1)
+        removed = vars_dict.pop(key)
+        if not vars_dict:
+            # Drop the empty section so re-loading doesn't carry an empty dict.
+            config.pop("vars", None)
+        _yaml_write(project_path, config)
+        console.print(f"  [green]✓[/green] removed {key} = {removed!r}")
+
 
 def cmd_secrets(args):
     """Manage project secrets."""
     subcmd = args.get("subcmd")
     if not subcmd or subcmd == "help":
         console.print(
-            "[bold]cutip secrets[/bold] <list|get|set> [project.yaml] [key=value ...]"
+            "[bold]cutip secrets[/bold] <list|get|set|rm> [project.yaml] [key=value ...]"
         )
         console.print("  list   Show all secret keys (values masked)")
         console.print("  get    Get a single secret value")
         console.print("  set    Set one or more secrets")
+        console.print("  rm     Remove a secret; prints (masked) confirmation")
         return
 
     project_path = _resolve_project(args.get("project"))
@@ -1015,6 +1033,23 @@ def cmd_secrets(args):
             config["secrets"][k] = v
             console.print(f"  [green]✓[/green] {k} = ****")
         _yaml_write(project_path, config)
+
+    elif subcmd == "rm":
+        key = args.get("key")
+        if not key:
+            console.print("[red]Usage:[/red] cutip secrets rm [project.yaml] <key>")
+            sys.exit(1)
+        secrets_dict = config.get("secrets") or {}
+        if key not in secrets_dict:
+            console.print(f"[red]Error:[/red] secret '{key}' not found")
+            sys.exit(1)
+        removed = secrets_dict.pop(key)
+        if not secrets_dict:
+            config.pop("secrets", None)
+        _yaml_write(project_path, config)
+        # Always mask removed secret values; user just needs to know it's gone.
+        disp = "****" if removed else "(empty)"
+        console.print(f"  [green]✓[/green] removed {key} = {disp}")
 
 
 def _is_sensitive(key: str) -> bool:
@@ -1103,6 +1138,8 @@ def cmd_hosts(args):
       cutip hosts get -g <host>.<field> Get from global
       cutip hosts set <host>.<field>=<value> [...]
       cutip hosts set -g <host>.<field>=<value> [...]
+      cutip hosts rm <host>[.<field>]   Remove an entry or one of its fields
+      cutip hosts rm -g <host>[.<field>] Remove from global hosts file
       cutip hosts path                  Print local hosts file path
       cutip hosts path -g               Print global hosts file path
       cutip hosts set-path -g <path>    Change global hosts file location
@@ -1273,6 +1310,47 @@ def cmd_hosts(args):
                 console.print(f"  [green]✓[/green] {k} = {disp}")
         return
 
+    if subcmd == "rm":
+        key = args.get("key")
+        if not key:
+            console.print("[red]Usage:[/red] cutip hosts rm [-g] <host>[.<field>]")
+            sys.exit(1)
+        if not target_path.exists():
+            console.print(f"[red]Error:[/red] {target_label} not found")
+            sys.exit(1)
+        existing = _hosts.read_hosts_file(target_path)
+        if "." in key:
+            # Field-level remove: <host>.<field>
+            host_name, field = key.split(".", 1)
+            entry = existing.get(host_name)
+            if not isinstance(entry, dict):
+                console.print(
+                    f"[red]Error:[/red] host '{host_name}' not found in {target_label}"
+                )
+                sys.exit(1)
+            if field not in entry:
+                console.print(
+                    f"[red]Error:[/red] field '{field}' not on host '{host_name}'"
+                )
+                sys.exit(1)
+            removed = entry.pop(field)
+            _hosts.write_hosts_file(target_path, existing)
+            disp = "****" if _is_sensitive(field) else repr(removed)
+            console.print(f"  [green]✓[/green] removed {host_name}.{field} = {disp}")
+        else:
+            # Entry-level remove
+            if key not in existing:
+                console.print(f"[red]Error:[/red] '{key}' not found in {target_label}")
+                sys.exit(1)
+            removed = existing.pop(key)
+            _hosts.write_hosts_file(target_path, existing)
+            if isinstance(removed, dict):
+                disp = f"<entry: {len(removed)} field(s)>"
+            else:
+                disp = "****" if _is_sensitive(key) else repr(removed)
+            console.print(f"  [green]✓[/green] removed {key} = {disp}")
+        return
+
     if subcmd == "migrate":
         if use_global:
             console.print("[red]Error:[/red] migrate is project-local only (no -g).")
@@ -1436,6 +1514,7 @@ def cmd_data(args):
       cutip data get <dotted.path>    Print one value
       cutip data set <dotted.path>=<value> [...]
                                       Set one or more values
+      cutip data rm <dotted.path>     Remove an entry; cleans up emptied parents
       cutip data path                 Print the data file path
       cutip data init                 Create an empty data file
     """
@@ -1525,6 +1604,33 @@ def cmd_data(args):
             disp = "****" if any(_is_sensitive(seg) for seg in k.split(".")) else v
             console.print(f"  [green]✓[/green] {k} = {disp}")
         _globals.write_globals(data, gp)
+        return
+
+    if subcmd == "rm":
+        key = args.get("key")
+        if not key:
+            console.print("[red]Usage:[/red] cutip data rm <dotted.path>")
+            sys.exit(1)
+        if not gp.exists():
+            console.print(f"[red]Error:[/red] {gp} does not exist")
+            sys.exit(1)
+        data = _globals.read_globals(gp)
+        try:
+            removed = _globals.remove_dotted(data, key)
+        except _globals.GlobalsError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            sys.exit(1)
+        _globals.write_globals(data, gp)
+        # Mask sensitive leaves; show full path so the user can confirm.
+        if any(_is_sensitive(seg) for seg in key.split(".")):
+            disp = "****"
+        elif isinstance(removed, dict):
+            # Non-leaf removal — show child count rather than the dict body
+            # (could be large, could contain sensitive descendants).
+            disp = f"<subtree: {len(removed)} child key(s)>"
+        else:
+            disp = repr(removed)
+        console.print(f"  [green]✓[/green] removed {key} = {disp}")
         return
 
     console.print(f"[red]Unknown data subcommand:[/red] {subcmd}")
@@ -1974,7 +2080,7 @@ def main():
 
     # Handle subcommand groups (vars, secrets)
     if command in ("vars", "secrets"):
-        if remaining and remaining[0] in ("list", "get", "set", "help"):
+        if remaining and remaining[0] in ("list", "get", "set", "rm", "help"):
             parsed["subcmd"] = remaining[0]
             remaining = remaining[1:]
         # Parse project file and key=value pairs
@@ -1986,7 +2092,7 @@ def main():
                 pairs.append(arg)
             elif arg.endswith(".yaml") or Path(arg).exists():
                 parsed["project"] = arg
-            elif parsed.get("subcmd") == "get" and "key" not in parsed:
+            elif parsed.get("subcmd") in ("get", "rm") and "key" not in parsed:
                 parsed["key"] = arg
             elif not parsed.get("project"):
                 parsed["project"] = arg
@@ -2002,6 +2108,7 @@ def main():
             "list",
             "get",
             "set",
+            "rm",
             "path",
             "set-path",
             "init",
@@ -2026,7 +2133,10 @@ def main():
                 pairs.append(arg)
             elif arg.endswith(".yaml") or Path(arg).exists():
                 parsed["project"] = arg
-            elif parsed.get("subcmd") in ("get", "set-path") and "key" not in parsed:
+            elif (
+                parsed.get("subcmd") in ("get", "set-path", "rm")
+                and "key" not in parsed
+            ):
                 parsed["key"] = arg
             elif parsed.get("subcmd") == "promote":
                 names.append(arg)
@@ -2040,7 +2150,7 @@ def main():
         return
 
     if command == "data":
-        valid_subs = {"list", "get", "set", "path", "init", "help"}
+        valid_subs = {"list", "get", "set", "rm", "path", "init", "help"}
         if remaining and remaining[0] in valid_subs:
             parsed["subcmd"] = remaining[0]
             remaining = remaining[1:]
@@ -2050,7 +2160,7 @@ def main():
                 parsed["subcmd"] = "help"
             elif "=" in arg:
                 pairs.append(arg)
-            elif parsed.get("subcmd") == "get" and "key" not in parsed:
+            elif parsed.get("subcmd") in ("get", "rm") and "key" not in parsed:
                 parsed["key"] = arg
         if pairs:
             parsed["pairs"] = pairs

--- a/cutip/globals.py
+++ b/cutip/globals.py
@@ -125,6 +125,47 @@ def set_dotted(data: dict[str, Any], dotted: str, value: Any) -> None:
     cur[segments[-1]] = value
 
 
+def remove_dotted(data: dict[str, Any], dotted: str) -> Any:
+    """Remove the entry at the dotted path, returning what was removed.
+
+    Cleans up emptied parent dicts (so removing the only key under
+    ``passwords.v22`` also removes ``passwords`` if it becomes empty).
+    Returns the removed leaf value.
+
+    Raises:
+        GlobalsError: if the path is empty, doesn't exist, or traverses
+            through a non-mapping value.
+    """
+    if not dotted:
+        raise GlobalsError("dotted path cannot be empty")
+    segments = dotted.split(".")
+    # Walk down, capturing each parent + key so we can clean up empties.
+    parents: list[tuple[dict[str, Any], str]] = []
+    cur: Any = data
+    for segment in segments[:-1]:
+        if not isinstance(cur, dict):
+            raise GlobalsError(f"path '{dotted}' traverses non-mapping at '{segment}'")
+        if segment not in cur:
+            raise GlobalsError(f"path '{dotted}' not found")
+        parents.append((cur, segment))
+        cur = cur[segment]
+
+    leaf_key = segments[-1]
+    if not isinstance(cur, dict):
+        raise GlobalsError(f"path '{dotted}' traverses non-mapping")
+    if leaf_key not in cur:
+        raise GlobalsError(f"path '{dotted}' not found")
+    removed = cur.pop(leaf_key)
+
+    # Walk parents in reverse, removing any that became empty.
+    for parent, key in reversed(parents):
+        if isinstance(parent[key], dict) and len(parent[key]) == 0:
+            del parent[key]
+        else:
+            break
+    return removed
+
+
 def flatten(data: dict[str, Any], prefix: str = "") -> dict[str, str]:
     """Flatten a nested dict to {dotted.path: str_value} for substitution.
 

--- a/cutip/templating.py
+++ b/cutip/templating.py
@@ -31,6 +31,7 @@ avoids passing context that hosts logic doesn't otherwise need.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -43,6 +44,9 @@ def _substitute_string(
     globals: Mapping[str, str],
 ) -> str:
     """Substitute ``{{ ns.key }}`` placeholders in a single string.
+
+    Whitespace-tolerant: ``{{ns.key}}``, ``{{ ns.key }}``, ``{{ ns.key}}``,
+    ``{{ns.key }}``, and any number of internal spaces all match.
 
     Idempotent: a string with no ``{{`` returns unchanged. Strings whose
     placeholders don't match any key in any namespace are returned with
@@ -59,8 +63,9 @@ def _substitute_string(
     ):
         for key, value in mapping.items():
             sval = value if isinstance(value, str) else str(value)
-            for pattern in (f"{{{{ {ns}.{key} }}}}", f"{{{{{ns}.{key}}}}}"):
-                result = result.replace(pattern, sval)
+            # \{\{\s*ns\.key\s*\}\}  — any (or no) whitespace inside braces.
+            pattern = re.compile(r"\{\{\s*" + re.escape(f"{ns}.{key}") + r"\s*\}\}")
+            result = pattern.sub(lambda _, v=sval: v, result)
     return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.15.1"
+version = "2.16.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -75,6 +75,61 @@ def test_set_dotted_rejects_empty_path():
         _globals.set_dotted({}, "", "x")
 
 
+# ── remove_dotted ───────────────────────────────────────────────────────────
+
+
+def test_remove_dotted_leaf_returns_value():
+    data = {"passwords": {"v22": "pw", "v23": "pw2"}}
+    removed = _globals.remove_dotted(data, "passwords.v22")
+    assert removed == "pw"
+    assert data == {"passwords": {"v23": "pw2"}}
+
+
+def test_remove_dotted_cleans_up_empty_parents():
+    data = {"passwords": {"v22": "pw"}}
+    _globals.remove_dotted(data, "passwords.v22")
+    assert data == {}
+
+
+def test_remove_dotted_cleans_up_multiple_levels():
+    data = {"a": {"b": {"c": {"leaf": "v"}}}}
+    _globals.remove_dotted(data, "a.b.c.leaf")
+    assert data == {}
+
+
+def test_remove_dotted_keeps_siblings_at_parents():
+    """Sibling at a higher level — only the immediate empty chain prunes."""
+    data = {
+        "passwords": {"v22": "pw"},
+        "constants": {"url": "x"},
+    }
+    _globals.remove_dotted(data, "passwords.v22")
+    assert data == {"constants": {"url": "x"}}
+
+
+def test_remove_dotted_returns_subtree_for_intermediate():
+    """Removing an intermediate path returns the dict it pointed at."""
+    data = {"passwords": {"v22": "pw", "v23": "pw2"}}
+    removed = _globals.remove_dotted(data, "passwords")
+    assert removed == {"v22": "pw", "v23": "pw2"}
+    assert data == {}
+
+
+def test_remove_dotted_missing_path():
+    with pytest.raises(_globals.GlobalsError, match="not found"):
+        _globals.remove_dotted({"a": 1}, "b")
+
+
+def test_remove_dotted_traverse_through_scalar():
+    with pytest.raises(_globals.GlobalsError, match="non-mapping"):
+        _globals.remove_dotted({"a": "scalar"}, "a.deeper")
+
+
+def test_remove_dotted_empty_path_rejected():
+    with pytest.raises(_globals.GlobalsError, match="empty"):
+        _globals.remove_dotted({"x": 1}, "")
+
+
 # ── flatten ─────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -51,6 +51,23 @@ def test_substitute_string_unspaced_form():
     assert _substitute_string("{{vars.x}}", {"x": "Y"}, {}, {}, {}) == "Y"
 
 
+def test_substitute_string_asymmetric_whitespace():
+    """Match all whitespace combinations — asymmetric forms common from
+    user typos (`{{ ns.key}}` or `{{ns.key }}`)."""
+    cases = [
+        "{{globals.x}}",
+        "{{ globals.x }}",
+        "{{ globals.x}}",  # left-only space
+        "{{globals.x }}",  # right-only space
+        "{{  globals.x  }}",  # multiple spaces
+        "{{\tglobals.x\t}}",  # tabs
+    ]
+    for c in cases:
+        assert _substitute_string(c, {}, {}, {}, {"x": "Y"}) == "Y", (
+            f"asymmetric form failed: {c!r}"
+        )
+
+
 def test_substitute_string_idempotent_after_resolve():
     """Re-running on already-resolved text is a no-op."""
     once = _substitute_string("{{ vars.x }}", {"x": "alice"}, {}, {}, {})

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.15.1"
+version = "2.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Adds `rm` to all four config subcommand groups. Each removes the requested entry and prints the removed value as confirmation.

```bash
cutip vars rm <key>                  # remove a project var
cutip secrets rm <key>               # remove a project secret (masked)
cutip data rm <dotted.path>          # remove a global data entry; cleans up empty parents
cutip hosts rm <name>                # remove a whole host entry
cutip hosts rm <name>.<field>        # remove a single field from a host entry
cutip hosts rm -g <name>[.<field>]   # same against ~/.cutip/hosts.yaml
```

## Behavior

- **Sensitive masking**: leaves whose dotted path or field name contains `password`/`secret`/`token`/`key` show `****` instead of the value.
- **Empty-parent cleanup** (data only): `cutip data rm passwords.v22` will also remove `passwords` if it becomes empty. Propagates upward through any chain of newly-empty parents.
- **Section pruning** (vars/secrets): removing the last entry drops the empty section from the YAML so re-loading doesn't carry an empty mapping.
- **Subtree removal** (data only): `cutip data rm passwords` removes the entire `passwords` subtree if it's not a scalar.

## Output examples

```
$ cutip vars rm drop_me
  ✓ removed drop_me = 'bye'

$ cutip secrets rm api_key
  ✓ removed api_key = ****

$ cutip data rm passwords.v22
  ✓ removed passwords.v22 = ****

$ cutip data rm passwords           # 2 keys remain → returns subtree
  ✓ removed passwords = <subtree: 2 child key(s)>

$ cutip hosts rm sfm.password
  ✓ removed sfm.password = ****

$ cutip hosts rm sfm                # whole entry
  ✓ removed sfm = <entry: 3 field(s)>
```

## Implementation

- `cutip/globals.py`: new `remove_dotted(data, path) -> Any` helper. Walks parents on the way down, removes the leaf, then unwinds removing emptied dicts. Errors clearly distinguish "not found" vs "traverses non-mapping" vs empty-path.
- `cutip/cli.py`: `rm` handlers added to `cmd_vars`, `cmd_secrets`, `cmd_data`, `cmd_hosts`. Parsers updated to accept the bare key argument for `rm` (alongside existing `get`).

## Tests

- 9 new `remove_dotted` tests (leaf, parent cleanup chains, sibling preservation, intermediate-path subtree, missing-path / non-mapping / empty-path errors)
- 218 total pass, 82% coverage
- Smoke-tested all four CLI flows end-to-end against a tmp project + `~/.cutip/data.yaml`