### PR TITLE
feat: cutip data set-path -g <path> — v2.17.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.16.0"
+VERSION = "2.17.0"
 console = Console()
 
 
@@ -1516,14 +1516,37 @@ def cmd_data(args):
                                       Set one or more values
       cutip data rm <dotted.path>     Remove an entry; cleans up emptied parents
       cutip data path                 Print the data file path
+      cutip data set-path -g <path>   Change the global data file location
       cutip data init                 Create an empty data file
     """
     from cutip import globals as _globals
 
     subcmd = args.get("subcmd")
+    use_global = bool(args.get("global"))
 
     if not subcmd or subcmd == "help":
         console.print(cmd_data.__doc__ or "cutip data")
+        return
+
+    if subcmd == "set-path":
+        # The data store is inherently global, but the -g flag is required
+        # for parity with `cutip hosts set-path` so the two surfaces stay
+        # symmetrical.
+        if not use_global:
+            console.print(
+                "[red]Error:[/red] 'cutip data set-path' is global-only. "
+                "Use: cutip data set-path -g <path>"
+            )
+            sys.exit(1)
+        new_path = args.get("key")  # parser puts the bare-positional arg in 'key'
+        if not new_path:
+            console.print("[red]Usage:[/red] cutip data set-path -g <path>")
+            sys.exit(1)
+        _globals.set_globals_path(new_path)
+        from cutip.hosts import config_path
+
+        console.print(f"  [green]✓[/green] Global data path → [cyan]{new_path}[/cyan]")
+        console.print(f"  (stored in {config_path()})")
         return
 
     gp = _globals.globals_path()
@@ -2150,7 +2173,7 @@ def main():
         return
 
     if command == "data":
-        valid_subs = {"list", "get", "set", "rm", "path", "init", "help"}
+        valid_subs = {"list", "get", "set", "rm", "path", "set-path", "init", "help"}
         if remaining and remaining[0] in valid_subs:
             parsed["subcmd"] = remaining[0]
             remaining = remaining[1:]
@@ -2158,9 +2181,14 @@ def main():
         for arg in remaining:
             if arg in ("-h", "--help"):
                 parsed["subcmd"] = "help"
+            elif arg in ("-g", "--global"):
+                parsed["global"] = True
             elif "=" in arg:
                 pairs.append(arg)
-            elif parsed.get("subcmd") in ("get", "rm") and "key" not in parsed:
+            elif (
+                parsed.get("subcmd") in ("get", "rm", "set-path")
+                and "key" not in parsed
+            ):
                 parsed["key"] = arg
         if pairs:
             parsed["pairs"] = pairs

--- a/cutip/globals.py
+++ b/cutip/globals.py
@@ -39,16 +39,51 @@ from typing import Any
 # ── File layout ─────────────────────────────────────────────────────────────
 
 
-def globals_path() -> Path:
-    """Return the path to the global data file (~/.cutip/data.yaml).
-
-    Honors the same ``data_path`` override mechanism as
-    ``cutip.hosts.global_hosts_path`` if it's ever needed; for now,
-    returns the default unless a future ``cutip data set-path`` is added.
-    """
+def default_globals_path() -> Path:
+    """Default location of the global data file: ``~/.cutip/data.yaml``."""
     from cutip.hosts import cutip_dir
 
     return cutip_dir() / "data.yaml"
+
+
+def globals_path() -> Path:
+    """Resolve the global data file path.
+
+    Reads ``data_path`` from ``~/.cutip/config.yaml`` if set, otherwise
+    returns the default ``~/.cutip/data.yaml``. Mirrors the override
+    mechanism of ``cutip.hosts.global_hosts_path``.
+    """
+    from cutip.hosts import config_path
+
+    cp = config_path()
+    if cp.exists():
+        try:
+            import yaml
+
+            cfg = yaml.safe_load(cp.read_text()) or {}
+            override = cfg.get("data_path")
+            if override:
+                return Path(str(override)).expanduser()
+        except Exception:
+            pass
+    return default_globals_path()
+
+
+def set_globals_path(path: Path | str) -> None:
+    """Persist a custom global data file path to ``~/.cutip/config.yaml``."""
+    import yaml
+
+    from cutip.hosts import config_path
+
+    cp = config_path()
+    cfg: dict[str, Any] = {}
+    if cp.exists():
+        try:
+            cfg = yaml.safe_load(cp.read_text()) or {}
+        except Exception:
+            cfg = {}
+    cfg["data_path"] = str(Path(str(path)).expanduser())
+    cp.write_text(yaml.safe_dump(cfg, sort_keys=False))
 
 
 # ── Read / write ────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.16.0"
+version = "2.17.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -183,3 +183,53 @@ def test_write_then_read_roundtrip(tmp_path):
 def test_globals_path_default(isolated_home):
     expected = isolated_home / ".cutip" / "data.yaml"
     assert _globals.globals_path() == expected
+
+
+def test_default_globals_path_ignores_override(isolated_home, tmp_path):
+    # default_globals_path() is the unconfigurable default and must not
+    # be affected by a config-yaml override.
+    _globals.set_globals_path(tmp_path / "elsewhere.yaml")
+    assert _globals.default_globals_path() == isolated_home / ".cutip" / "data.yaml"
+
+
+def test_set_globals_path_overrides_default(isolated_home, tmp_path):
+    custom = tmp_path / "custom-data.yaml"
+    _globals.set_globals_path(custom)
+    assert _globals.globals_path() == custom
+
+
+def test_set_globals_path_persists_in_config_yaml(isolated_home, tmp_path):
+    import yaml
+
+    from cutip.hosts import config_path
+
+    custom = tmp_path / "team-data.yaml"
+    _globals.set_globals_path(custom)
+    cfg = yaml.safe_load(config_path().read_text()) or {}
+    assert cfg.get("data_path") == str(custom)
+
+
+def test_set_globals_path_preserves_other_config_keys(isolated_home, tmp_path):
+    import yaml
+
+    from cutip.hosts import config_path, set_global_hosts_path
+
+    set_global_hosts_path(tmp_path / "h.yaml")
+    _globals.set_globals_path(tmp_path / "d.yaml")
+    cfg = yaml.safe_load(config_path().read_text()) or {}
+    assert cfg.get("hosts_path") == str(tmp_path / "h.yaml")
+    assert cfg.get("data_path") == str(tmp_path / "d.yaml")
+
+
+def test_globals_path_falls_back_when_config_unreadable(isolated_home, tmp_path):
+    # A malformed config.yaml shouldn't break globals_path() resolution.
+    from cutip.hosts import config_path
+
+    config_path().write_text("not: valid: yaml: at: all: : :")
+    # Resolution falls back silently to the default location.
+    assert _globals.globals_path() == isolated_home / ".cutip" / "data.yaml"
+
+
+def test_globals_path_expands_user_in_override(isolated_home):
+    _globals.set_globals_path("~/custom/data.yaml")
+    assert _globals.globals_path() == isolated_home / "custom" / "data.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.16.0"
+version = "2.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- Mirror \`cutip hosts set-path\` for the global data store: \`cutip data set-path -g <path>\` writes a \`data_path\` override into \`~/.cutip/config.yaml\`; \`globals_path()\` reads it on every load, falling back silently to \`~/.cutip/data.yaml\` if missing or unparseable.
- Lets users park \`data.yaml\` somewhere shared (team file under version control, per-environment splits, etc.) without touching \`HOME\` or symlinks.
- Surface parity: \`-g\` is required even though data is inherently global, matching \`hosts set-path\`.

## Test plan

- [x] 6 new tests in \`tests/test_globals.py\`: override roundtrip, default-ignores-override, config.yaml persistence, \`hosts_path\` preservation, malformed-config fallback, \`~/\` expansion
- [x] Full suite — 225 passed
- [x] CLI smoke: \`cutip data set-path /tmp/foo.yaml\` errors without \`-g\`; \`cutip data set-path -g /tmp/foo.yaml\` writes config; \`cutip data path\` reflects the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)