### PR TITLE
feat: workflow-declared CLI args + --vars k=v — v2.18.0

### DIFF
--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.17.0"
+VERSION = "2.18.0"
 console = Console()
 
 
@@ -90,12 +90,15 @@ def _resolve_workflow(project_path: Path, config: dict) -> Path:
     return project_path.parent / workflow_name
 
 
-def _load_config(project_path: Path) -> dict:
+def _load_config(project_path: Path, var_overrides: dict | None = None) -> dict:
     """Load and return project config as a dict.
 
     Resolution stages (in order):
       1. Parse YAML.
       2. Read globals from ``~/.cutip/data.yaml`` (flat dotted keys).
+      2b. Apply ``var_overrides`` (from ``--vars k=v`` or workflow-declared
+          cli_args, see ``cutip/workflow/cli_args.py``) into ``vars`` so
+          downstream substitution sees the runtime values.
       3. Resolve globals into ``vars`` / ``paths`` / ``secrets`` so they
          carry final values before the rest of the config is processed.
       4. Walk the entire config dict and substitute every ``{{ ns.key }}``
@@ -112,6 +115,12 @@ def _load_config(project_path: Path) -> dict:
 
     with open(project_path) as f:
         config = yaml.safe_load(f) or {}
+
+    if var_overrides:
+        if "vars" not in config or config["vars"] is None:
+            config["vars"] = {}
+        for k, v in var_overrides.items():
+            config["vars"][k] = v
 
     globals_flat = _globals.flatten(_globals.read_globals())
 
@@ -526,14 +535,67 @@ def cmd_run(args):
     """Run a workflow."""
     import yaml
 
-    if "--help" in sys.argv or "-h" in sys.argv:
-        console.print("[bold]cutip run[/bold] [project.yaml] [--bg]")
-        console.print("  Reads project YAML, runs the workflow")
-        console.print("  --bg   Detach: print cu-id and return; track via 'cutip ps'")
-        return
+    from cutip.workflow import cli_args as _cli_args
 
     project_path = _resolve_project(args.get("project"))
-    config = _load_config(project_path)
+
+    # Read the raw yaml to extract any cli_args declarations + decide whether
+    # this is a --help request that needs project-specific help.
+    with open(project_path) as f:
+        raw_config = yaml.safe_load(f) or {}
+    try:
+        specs = _cli_args.normalize_specs(raw_config.get("cli_args"))
+    except _cli_args.CliArgsError as e:
+        console.print(f"[red]Invalid cli_args block in {project_path.name}:[/red] {e}")
+        sys.exit(1)
+
+    if args.get("help"):
+        console.print("[bold]cutip run[/bold] [project.yaml] [--bg] [--vars k=v ...]")
+        console.print("  Reads project YAML, runs the workflow")
+        console.print("  --bg   Detach: print cu-id and return; track via 'cutip ps'")
+        console.print("  --vars Override vars block: --vars greeting=hi port=8080")
+        if specs:
+            console.print()
+            console.print(_cli_args.help_text(specs))
+        return
+
+    # Resolve workflow-declared cli_args from any unconsumed tokens.
+    cli_arg_user: dict = {}
+    cli_arg_defaults: dict = {}
+    if specs:
+        try:
+            cli_arg_user, cli_arg_defaults, leftover = _cli_args.parse_runtime(
+                specs, args.get("_unconsumed", [])
+            )
+        except _cli_args.CliArgsError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            sys.exit(1)
+        if leftover:
+            console.print(
+                f"[yellow]warning:[/yellow] unrecognized args ignored: {' '.join(leftover)}"
+            )
+    elif args.get("_unconsumed"):
+        # Project doesn't declare cli_args but user passed unknown flags.
+        # Don't silently swallow — surface them so the typo is visible.
+        console.print(
+            f"[yellow]warning:[/yellow] unrecognized args ignored "
+            f"(project has no cli_args block): {' '.join(args['_unconsumed'])}"
+        )
+
+    # Precedence (lowest → highest):
+    #   1. yaml `vars:` block          (handled by _load_config; we don't override)
+    #   2. cli_args defaults           — only applied where yaml vars is absent
+    #   3. --vars k=v                  — explicit user runtime override
+    #   4. cli_args explicit values    — explicit user runtime override (typed)
+    yaml_vars = (raw_config.get("vars") or {})
+    var_overrides: dict = {}
+    for k, v in cli_arg_defaults.items():
+        if k not in yaml_vars or yaml_vars[k] in (None, ""):
+            var_overrides[k] = v
+    var_overrides.update(args.get("cli_vars") or {})
+    var_overrides.update(cli_arg_user)
+
+    config = _load_config(project_path, var_overrides=var_overrides or None)
 
     # Background mode: spawn a detached daemon and exit
     if args.get("bg"):
@@ -2214,6 +2276,8 @@ def main():
 
     i = 0
     positional_consumed = False
+    cli_vars: dict = {}
+    unconsumed: list = []  # for run command — collected and matched against workflow-declared cli_args
     while i < len(remaining):
         arg = remaining[i]
         if arg in ("-h", "--help"):
@@ -2234,6 +2298,17 @@ def main():
         elif arg == "--path" and i + 1 < len(remaining):
             parsed["project"] = remaining[i + 1]
             i += 2
+        elif arg == "--vars":
+            # Greedy consume k=v tokens until next flag or end-of-args.
+            # Lets the user write: cutip run x.yaml --vars a=1 b=2 --bg
+            i += 1
+            while i < len(remaining):
+                tok = remaining[i]
+                if tok.startswith("-") or "=" not in tok:
+                    break
+                k, v = tok.split("=", 1)
+                cli_vars[k] = v
+                i += 1
         elif not arg.startswith("-") and not positional_consumed:
             if command == "init":
                 parsed["name"] = arg
@@ -2253,8 +2328,29 @@ def main():
         elif not arg.startswith("-") and positional_consumed:
             if command == "show" and "section" not in parsed:
                 parsed["section"] = arg
+            else:
+                # run command may have declared cli_args that take values
+                # at unflagged-positional positions if the parser routed
+                # there; defer to cmd_run.
+                unconsumed.append(arg)
             i += 1
         else:
+            # Unknown flag — could be a workflow-declared cli_arg for `run`.
+            # Tentatively grab it + a value if the next token looks like one.
+            unconsumed.append(arg)
             i += 1
+            if (
+                command == "run"
+                and i < len(remaining)
+                and not remaining[i].startswith("-")
+                and "=" not in remaining[i]
+            ):
+                unconsumed.append(remaining[i])
+                i += 1
+
+    if cli_vars:
+        parsed["cli_vars"] = cli_vars
+    if unconsumed:
+        parsed["_unconsumed"] = unconsumed
 
     COMMANDS[command](parsed)

--- a/cutip/workflow/cli_args.py
+++ b/cutip/workflow/cli_args.py
@@ -1,0 +1,241 @@
+"""Workflow-declared CLI arguments.
+
+A workflow's project YAML may include a ``cli_args:`` block declaring
+typed flags that ``cutip run`` will accept. The declared values are
+merged into ``config['vars']`` before template substitution, so any
+``{{ vars.X }}`` references in the rest of the YAML pick up the
+runtime override.
+
+Schema::
+
+    cli_args:
+      sheet_path:                # populates vars.sheet_path
+        short: -f                # optional short flag
+        long: --sheet            # optional long flag (default: --<var-name-kebabified>)
+        type: path               # str | int | float | bool | path (default: str)
+        required: true           # default: false
+        default: ""              # value if user doesn't pass the flag
+        help: "Input xlsx"       # one-line help string
+
+The generic ``--vars k=v [k=v ...]`` mechanism is a separate path
+implemented in cli.py — it doesn't go through this module. Declared
+cli_args take precedence over ``--vars`` when both name the same key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+VALID_TYPES = ("str", "int", "float", "bool", "path")
+
+# CLI flag names cutip reserves for itself; declared cli_args may not
+# claim these. Keeps the parser unambiguous.
+RESERVED_FLAGS = frozenset({
+    "-h", "--help",
+    "--bg",
+    "--vars",
+    "--hosts",
+    "--path",
+    "--json",
+    "--all",
+    "--version",
+})
+
+
+class CliArgsError(ValueError):
+    """Raised when a cli_args block is malformed or runtime args don't satisfy it."""
+
+
+def _kebab(name: str) -> str:
+    """``sheet_path`` → ``sheet-path`` for default --long flag."""
+    return name.replace("_", "-")
+
+
+def _coerce(value: str, type_: str, *, key: str, flag: str) -> Any:
+    """Convert a string CLI value to the declared type."""
+    if type_ == "str":
+        return value
+    if type_ == "int":
+        try:
+            return int(value)
+        except ValueError:
+            raise CliArgsError(f"{flag} (vars.{key}): expected int, got {value!r}")
+    if type_ == "float":
+        try:
+            return float(value)
+        except ValueError:
+            raise CliArgsError(f"{flag} (vars.{key}): expected float, got {value!r}")
+    if type_ == "bool":
+        v = value.strip().lower()
+        if v in ("true", "yes", "y", "1"):
+            return True
+        if v in ("false", "no", "n", "0"):
+            return False
+        raise CliArgsError(f"{flag} (vars.{key}): expected bool (true/false), got {value!r}")
+    if type_ == "path":
+        return str(Path(value).expanduser())
+    raise CliArgsError(f"unknown cli_args type {type_!r} for {key}")
+
+
+def normalize_specs(cli_args_block: Any) -> dict[str, dict]:
+    """Validate and normalize the raw ``cli_args:`` block from project YAML.
+
+    Returns a dict ``{var_name: spec}`` with every spec containing:
+    ``short`` (str|None), ``long`` (str), ``type`` (str), ``required`` (bool),
+    ``default`` (anything|None), ``help`` (str).
+
+    Raises CliArgsError on malformed input.
+    """
+    if cli_args_block is None:
+        return {}
+    if not isinstance(cli_args_block, dict):
+        raise CliArgsError(
+            f"cli_args must be a mapping of <var_name>: <spec>, got {type(cli_args_block).__name__}"
+        )
+
+    out: dict[str, dict] = {}
+    flag_owners: dict[str, str] = {}  # flag → var_name (for collision detection)
+    for key, raw in cli_args_block.items():
+        spec = raw or {}
+        if not isinstance(spec, dict):
+            raise CliArgsError(f"cli_args.{key}: spec must be a mapping, got {type(spec).__name__}")
+
+        short = spec.get("short")
+        long_ = spec.get("long") or f"--{_kebab(key)}"
+        type_ = spec.get("type", "str")
+        required = bool(spec.get("required", False))
+        default = spec.get("default")
+        help_ = spec.get("help", "")
+
+        # Validate type
+        if type_ not in VALID_TYPES:
+            raise CliArgsError(
+                f"cli_args.{key}.type: must be one of {VALID_TYPES}, got {type_!r}"
+            )
+
+        # Validate flag shapes
+        if short is not None:
+            if not (isinstance(short, str) and len(short) == 2 and short.startswith("-") and short[1] != "-"):
+                raise CliArgsError(
+                    f"cli_args.{key}.short: must be a single-dash 2-char flag like '-f', got {short!r}"
+                )
+            if short in RESERVED_FLAGS:
+                raise CliArgsError(f"cli_args.{key}.short={short!r} clashes with reserved cutip flag")
+        if not (isinstance(long_, str) and long_.startswith("--") and len(long_) > 2):
+            raise CliArgsError(
+                f"cli_args.{key}.long: must look like '--name', got {long_!r}"
+            )
+        if long_ in RESERVED_FLAGS:
+            raise CliArgsError(f"cli_args.{key}.long={long_!r} clashes with reserved cutip flag")
+
+        # Detect duplicate flags across declared args
+        for flag in (short, long_):
+            if flag is None:
+                continue
+            if flag in flag_owners:
+                raise CliArgsError(
+                    f"cli_args: flag {flag!r} declared by both {flag_owners[flag]!r} and {key!r}"
+                )
+            flag_owners[flag] = key
+
+        out[key] = {
+            "short": short,
+            "long": long_,
+            "type": type_,
+            "required": required,
+            "default": default,
+            "help": help_,
+        }
+    return out
+
+
+def parse_runtime(
+    specs: dict[str, dict], tokens: list[str]
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    """Match a list of unrecognized CLI tokens against declared cli_arg specs.
+
+    Returns ``(user_values, defaults, leftover)``:
+    - ``user_values``: ``{var_name: typed_value}`` for flags the user actually passed.
+    - ``defaults``: ``{var_name: typed_value}`` for declared specs the user
+      did NOT pass that have a non-None ``default`` — kept separate so the
+      caller can apply them at lower precedence than ``--vars k=v`` or yaml
+      ``vars:`` entries.
+    - ``leftover``: tokens that didn't match any declared flag.
+
+    Raises CliArgsError on type-coercion failure or missing required args.
+    """
+    # Build flag → (key, spec) map
+    by_flag: dict[str, tuple[str, dict]] = {}
+    for key, spec in specs.items():
+        if spec["short"]:
+            by_flag[spec["short"]] = (key, spec)
+        by_flag[spec["long"]] = (key, spec)
+
+    user_values: dict[str, Any] = {}
+    leftover: list[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+
+        # Handle --flag=value form
+        if "=" in tok and tok.startswith("--"):
+            flag, value = tok.split("=", 1)
+            if flag in by_flag:
+                key, spec = by_flag[flag]
+                user_values[key] = _coerce(value, spec["type"], key=key, flag=flag)
+                i += 1
+                continue
+
+        if tok in by_flag:
+            key, spec = by_flag[tok]
+            if spec["type"] == "bool" and (i + 1 >= len(tokens) or tokens[i + 1].startswith("-")):
+                # bare bool flag (without explicit value) → True
+                user_values[key] = True
+                i += 1
+            else:
+                if i + 1 >= len(tokens):
+                    raise CliArgsError(f"{tok}: missing value")
+                user_values[key] = _coerce(tokens[i + 1], spec["type"], key=key, flag=tok)
+                i += 2
+            continue
+
+        leftover.append(tok)
+        i += 1
+
+    # Defaults for args the user didn't pass; check required
+    defaults: dict[str, Any] = {}
+    for key, spec in specs.items():
+        if key in user_values:
+            continue
+        if spec["default"] is not None:
+            defaults[key] = spec["default"]
+        elif spec["required"]:
+            ident = spec["short"] or spec["long"]
+            raise CliArgsError(f"cli_args.{key} is required (pass {ident})")
+    return user_values, defaults, leftover
+
+
+def help_text(specs: dict[str, dict]) -> str:
+    """Render a one-screen help block for the declared cli_args. Empty if none."""
+    if not specs:
+        return ""
+    lines = ["Workflow CLI args:"]
+    for key, spec in specs.items():
+        flags = []
+        if spec["short"]:
+            flags.append(spec["short"])
+        flags.append(spec["long"])
+        flag_str = ", ".join(flags)
+        meta = []
+        if spec["type"] != "str":
+            meta.append(spec["type"])
+        if spec["required"]:
+            meta.append("required")
+        elif spec["default"] is not None:
+            meta.append(f"default={spec['default']!r}")
+        meta_str = f" [{', '.join(meta)}]" if meta else ""
+        help_str = f"  {spec['help']}" if spec["help"] else ""
+        lines.append(f"  {flag_str:<32}{meta_str}{help_str}")
+    return "\n".join(lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.17.0"
+version = "2.18.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,218 @@
+"""Tests for cutip.workflow.cli_args — workflow-declared CLI argument parsing.
+
+The full ``cutip run`` integration goes through cli.py and gets exercised
+by snf-dev workflows in CI; here we cover the pure-logic unit:
+spec normalization, runtime parsing, type coercion, and help rendering.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cutip.workflow import cli_args as ca
+
+
+# ── normalize_specs ──────────────────────────────────────────────────────────
+
+
+def test_normalize_minimal():
+    specs = ca.normalize_specs({"sheet_path": {}})
+    s = specs["sheet_path"]
+    assert s["short"] is None
+    assert s["long"] == "--sheet-path"
+    assert s["type"] == "str"
+    assert s["required"] is False
+    assert s["default"] is None
+    assert s["help"] == ""
+
+
+def test_normalize_full_spec():
+    specs = ca.normalize_specs(
+        {
+            "sheet_path": {
+                "short": "-f",
+                "long": "--sheet",
+                "type": "path",
+                "required": True,
+                "help": "Input xlsx",
+            }
+        }
+    )
+    s = specs["sheet_path"]
+    assert s["short"] == "-f"
+    assert s["long"] == "--sheet"
+    assert s["type"] == "path"
+    assert s["required"] is True
+    assert s["help"] == "Input xlsx"
+
+
+def test_normalize_kebabs_var_name_for_default_long():
+    # snake_case var → kebab-case --long
+    specs = ca.normalize_specs({"pod_namespace": {}})
+    assert specs["pod_namespace"]["long"] == "--pod-namespace"
+
+
+def test_normalize_none_block_returns_empty():
+    assert ca.normalize_specs(None) == {}
+    assert ca.normalize_specs({}) == {}
+
+
+def test_normalize_rejects_non_mapping_block():
+    with pytest.raises(ca.CliArgsError):
+        ca.normalize_specs([1, 2, 3])
+
+
+def test_normalize_rejects_invalid_type():
+    with pytest.raises(ca.CliArgsError, match="type"):
+        ca.normalize_specs({"x": {"type": "frobnicator"}})
+
+
+def test_normalize_rejects_bad_short_flag():
+    with pytest.raises(ca.CliArgsError, match="short"):
+        ca.normalize_specs({"x": {"short": "-foo"}})  # >2 chars
+
+
+def test_normalize_rejects_bad_long_flag():
+    with pytest.raises(ca.CliArgsError, match="long"):
+        ca.normalize_specs({"x": {"long": "noprefix"}})
+
+
+def test_normalize_rejects_reserved_flag_collision():
+    with pytest.raises(ca.CliArgsError, match="reserved"):
+        ca.normalize_specs({"x": {"long": "--bg"}})
+
+
+def test_normalize_rejects_duplicate_flag_across_args():
+    with pytest.raises(ca.CliArgsError, match="declared by both"):
+        ca.normalize_specs(
+            {
+                "first": {"short": "-f"},
+                "second": {"short": "-f"},
+            }
+        )
+
+
+# ── parse_runtime ────────────────────────────────────────────────────────────
+
+
+def test_parse_short_flag_with_value():
+    specs = ca.normalize_specs({"sheet": {"short": "-f"}})
+    values, defaults, leftover = ca.parse_runtime(specs, ["-f", "sheets/foo.xlsx"])
+    assert values == {"sheet": "sheets/foo.xlsx"}
+    assert leftover == []
+
+
+def test_parse_long_flag_with_value():
+    specs = ca.normalize_specs({"sheet": {"long": "--sheet"}})
+    values, defaults, leftover = ca.parse_runtime(specs, ["--sheet", "sheets/foo.xlsx"])
+    assert values == {"sheet": "sheets/foo.xlsx"}
+    assert leftover == []
+
+
+def test_parse_long_eq_value():
+    specs = ca.normalize_specs({"sheet": {"long": "--sheet"}})
+    values, _d, _ = ca.parse_runtime(specs, ["--sheet=sheets/foo.xlsx"])
+    assert values == {"sheet": "sheets/foo.xlsx"}
+
+
+def test_parse_int_coercion():
+    specs = ca.normalize_specs({"port": {"type": "int"}})
+    values, _d, _ = ca.parse_runtime(specs, ["--port", "8080"])
+    assert values == {"port": 8080}
+
+
+def test_parse_int_coercion_failure():
+    specs = ca.normalize_specs({"port": {"type": "int"}})
+    with pytest.raises(ca.CliArgsError, match="expected int"):
+        ca.parse_runtime(specs, ["--port", "abc"])
+
+
+def test_parse_bool_with_value():
+    specs = ca.normalize_specs({"flag": {"type": "bool"}})
+    values, _d, _ = ca.parse_runtime(specs, ["--flag", "true"])
+    assert values == {"flag": True}
+    values, _d, _ = ca.parse_runtime(specs, ["--flag", "no"])
+    assert values == {"flag": False}
+
+
+def test_parse_bool_bare_flag_implies_true():
+    specs = ca.normalize_specs({"flag": {"type": "bool"}})
+    values, _d, _ = ca.parse_runtime(specs, ["--flag"])
+    assert values == {"flag": True}
+
+
+def test_parse_path_expands_user(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    specs = ca.normalize_specs({"out": {"type": "path"}})
+    values, _d, _ = ca.parse_runtime(specs, ["--out", "~/data/foo.xlsx"])
+    assert values["out"] == str(tmp_path / "data" / "foo.xlsx")
+
+
+def test_parse_default_returned_separately_when_unset():
+    """Defaults aren't mingled with user values — caller chooses precedence."""
+    specs = ca.normalize_specs({"namespace": {"default": "sfm-1"}})
+    user_values, defaults, _ = ca.parse_runtime(specs, [])
+    assert user_values == {}
+    assert defaults == {"namespace": "sfm-1"}
+
+
+def test_parse_user_value_takes_precedence_over_default():
+    specs = ca.normalize_specs({"namespace": {"default": "sfm-1"}})
+    user_values, defaults, _ = ca.parse_runtime(specs, ["--namespace", "sfm-2"])
+    assert user_values == {"namespace": "sfm-2"}
+    # No default returned — user provided a value, default doesn't apply.
+    assert defaults == {}
+
+
+def test_parse_required_missing_raises():
+    specs = ca.normalize_specs({"sheet": {"short": "-f", "required": True}})
+    with pytest.raises(ca.CliArgsError, match="required"):
+        ca.parse_runtime(specs, [])
+
+
+def test_parse_unrecognized_tokens_become_leftover():
+    specs = ca.normalize_specs({"sheet": {"short": "-f"}})
+    values, defaults, leftover = ca.parse_runtime(
+        specs, ["-f", "sheets/foo.xlsx", "--unknown", "blah"]
+    )
+    assert values == {"sheet": "sheets/foo.xlsx"}
+    assert leftover == ["--unknown", "blah"]
+
+
+def test_parse_value_missing_raises():
+    specs = ca.normalize_specs({"sheet": {"long": "--sheet"}})
+    with pytest.raises(ca.CliArgsError, match="missing value"):
+        ca.parse_runtime(specs, ["--sheet"])  # no value follows
+
+
+# ── help_text ────────────────────────────────────────────────────────────────
+
+
+def test_help_text_renders_flags_and_metadata():
+    specs = ca.normalize_specs(
+        {
+            "sheet": {
+                "short": "-f",
+                "long": "--sheet",
+                "type": "path",
+                "required": True,
+                "help": "Input xlsx",
+            },
+            "namespace": {
+                "long": "--namespace",
+                "default": "sfm-1",
+                "help": "K8s ns",
+            },
+        }
+    )
+    out = ca.help_text(specs)
+    assert "-f" in out
+    assert "--sheet" in out
+    assert "path" in out
+    assert "required" in out
+    assert "Input xlsx" in out
+    assert "default='sfm-1'" in out
+
+
+def test_help_text_empty_for_no_specs():
+    assert ca.help_text({}) == ""

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.17.0"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- Add generic \`cutip run x.yaml --vars k=v [k=v ...]\` for ad-hoc var overrides (was documented in test-automation's README but never actually implemented).
- Add \`cli_args:\` block to project YAML for typed, declared flags per workflow:

\`\`\`yaml
cli_args:
  sheet_path:
    short: -f
    long: --sheet
    type: path
    required: true
    help: \"Input xlsx\"
\`\`\`

Then \`cutip run x.yaml -f sheets/foo.xlsx\` populates \`ctx.vars.sheet_path\` directly, with type coercion. \`cutip run x.yaml --help\` shows the project's flags alongside cutip's standard ones.

- Precedence (lowest → highest): yaml \`vars:\` < cli_args defaults < \`--vars k=v\` < declared cli_args explicit values.
- \`_load_config\` gains \`var_overrides=\` applied BEFORE template substitution so \`{{ vars.X }}\` references pick up runtime values.

## Test plan

- [x] 25 new unit tests in \`tests/test_cli_args.py\` (spec validation, runtime parsing, type coercion, help rendering, precedence)
- [x] Full suite — 250 passing
- [x] E2E smoke against demo workflow — all four cases verified (required arg, mixed --vars + cli_args, missing-required error, --help display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)