### PR TITLE
feat: cutip projects — discover all cutip projects under cwd — v2.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         run: |
           .venv/bin/python -m cutip --help
           .venv/bin/python -m cutip --version
-          .venv/bin/python -m cutip validate example/sfm-vm-support.yaml
-          .venv/bin/python -m cutip tree example/sfm-vm-support.yaml
+          .venv/bin/python -m cutip validate example/web-app-deploy.yaml
+          .venv/bin/python -m cutip tree example/web-app-deploy.yaml
           .venv/bin/python -m cutip verify
-          .venv/bin/python -m cutip validate --json example/sfm-vm-support.yaml
+          .venv/bin/python -m cutip validate --json example/web-app-deploy.yaml

--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -14,7 +14,7 @@ from rich import box
 
 from cutip._core import validate as _validate, tree as _tree, show as _show
 
-VERSION = "2.18.0"
+VERSION = "2.19.0"
 console = Console()
 
 
@@ -236,6 +236,134 @@ def cmd_validate(args):
         console.print(
             "\n[dim]Network checks skipped. Use 'cutip hosts validate' or 'cutip validate --all' for live probes.[/dim]"
         )
+
+
+def cmd_projects(args):
+    """Discover all cutip projects in the current directory tree.
+
+    Walks cwd recursively, finds every *.yaml with `project:` + `host:`
+    keys, prints a table with project name, host, and the first comment
+    line as description. Useful for monorepos that host many cutip
+    projects scattered across subdirectories.
+    """
+    import yaml as _yaml
+
+    cwd = Path.cwd()
+    skip_dirs = {
+        ".git",
+        "node_modules",
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".cutip",
+        "target",
+        "dist",
+        "site",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+    }
+
+    found = []
+    for yaml_path in sorted(cwd.rglob("*.yaml")):
+        if any(part in skip_dirs for part in yaml_path.relative_to(cwd).parts):
+            continue
+        try:
+            text = yaml_path.read_text(encoding="utf-8")
+            data = _yaml.safe_load(text)
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        # Cutip artifact YAMLs (apiVersion: cutip/v1) use a different shape
+        # and aren't project files — skip them.
+        if isinstance(data.get("apiVersion"), str) and data["apiVersion"].startswith(
+            "cutip/"
+        ):
+            continue
+        if "project" not in data or "host" not in data:
+            continue
+
+        found.append(
+            {
+                "path": yaml_path.relative_to(cwd),
+                "project": str(data["project"]),
+                "host": str(data.get("host", "local")),
+                "workflow": data.get("workflow"),
+                "description": _first_yaml_comment(text),
+            }
+        )
+
+    if args.get("json"):
+        print(
+            json.dumps(
+                [
+                    {
+                        "path": str(p["path"]),
+                        "project": p["project"],
+                        "host": p["host"],
+                        "workflow": p["workflow"],
+                        "description": p["description"],
+                    }
+                    for p in found
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    if not found:
+        console.print(f"[dim]No cutip projects found under {cwd}[/dim]")
+        return
+
+    host_color = {"local": "green", "container": "yellow", "remote": "magenta"}
+
+    table = Table(
+        title=f"cutip projects under {cwd.name}/",
+        box=box.ROUNDED,
+        show_lines=False,
+    )
+    table.add_column("path", style="cyan", no_wrap=False)
+    table.add_column("project", style="bold")
+    table.add_column("host")
+    table.add_column("description", style="dim", no_wrap=False)
+
+    for p in found:
+        color = host_color.get(p["host"], "white")
+        table.add_row(
+            str(p["path"]),
+            p["project"],
+            f"[{color}]{p['host']}[/{color}]",
+            p["description"],
+        )
+
+    console.print(table)
+    console.print(f"[dim]{len(found)} project{'s' if len(found) != 1 else ''}[/dim]")
+
+
+def _first_yaml_comment(text: str) -> str:
+    """Return the first prose-shaped comment line from a YAML file.
+
+    Scans the first 30 lines (comments may appear before or after the
+    leading `project:`/`host:` keys — snf-dev's convention is the
+    latter). Skips blank lines and ruler-style separators (e.g.
+    `# ─────────`). Used by `cutip projects` to surface a short
+    description for each discovered project.
+    """
+    for i, line in enumerate(text.splitlines()):
+        if i >= 30:
+            break
+        stripped = line.strip()
+        if not stripped.startswith("#"):
+            continue
+        body = stripped.lstrip("#").strip()
+        if not body:
+            continue
+        # Ruler-style separator (e.g. "─────" or "====="), skip.
+        if all(c in "─-=*#~_" for c in body):
+            continue
+        return body
+    return ""
 
 
 def cmd_tree(args):
@@ -2067,6 +2195,7 @@ COMMANDS = {
     "run": cmd_run,
     "cmd": cmd_cmd,
     "tree": cmd_tree,
+    "projects": cmd_projects,
     "vars": cmd_vars,
     "secrets": cmd_secrets,
     "hosts": cmd_hosts,
@@ -2107,6 +2236,7 @@ def main():
                 "  run        Execute workflow\n"
                 "  cmd        Run a project-defined command\n"
                 "  tree       Print config structure\n"
+                "  projects   Discover all cutip projects under cwd\n"
                 "  vars       Manage project variables (list/get/set)\n"
                 "  secrets    Manage project secrets (list/get/set)\n"
                 "  hosts      Manage connection credentials (list/get/set)\n"

--- a/cutip/cli.py
+++ b/cutip/cli.py
@@ -715,7 +715,7 @@ def cmd_run(args):
     #   2. cli_args defaults           — only applied where yaml vars is absent
     #   3. --vars k=v                  — explicit user runtime override
     #   4. cli_args explicit values    — explicit user runtime override (typed)
-    yaml_vars = (raw_config.get("vars") or {})
+    yaml_vars = raw_config.get("vars") or {}
     var_overrides: dict = {}
     for k, v in cli_arg_defaults.items():
         if k not in yaml_vars or yaml_vars[k] in (None, ""):

--- a/cutip/workflow/cli_args.py
+++ b/cutip/workflow/cli_args.py
@@ -32,16 +32,19 @@ VALID_TYPES = ("str", "int", "float", "bool", "path")
 
 # CLI flag names cutip reserves for itself; declared cli_args may not
 # claim these. Keeps the parser unambiguous.
-RESERVED_FLAGS = frozenset({
-    "-h", "--help",
-    "--bg",
-    "--vars",
-    "--hosts",
-    "--path",
-    "--json",
-    "--all",
-    "--version",
-})
+RESERVED_FLAGS = frozenset(
+    {
+        "-h",
+        "--help",
+        "--bg",
+        "--vars",
+        "--hosts",
+        "--path",
+        "--json",
+        "--all",
+        "--version",
+    }
+)
 
 
 class CliArgsError(ValueError):
@@ -73,7 +76,9 @@ def _coerce(value: str, type_: str, *, key: str, flag: str) -> Any:
             return True
         if v in ("false", "no", "n", "0"):
             return False
-        raise CliArgsError(f"{flag} (vars.{key}): expected bool (true/false), got {value!r}")
+        raise CliArgsError(
+            f"{flag} (vars.{key}): expected bool (true/false), got {value!r}"
+        )
     if type_ == "path":
         return str(Path(value).expanduser())
     raise CliArgsError(f"unknown cli_args type {type_!r} for {key}")
@@ -100,7 +105,9 @@ def normalize_specs(cli_args_block: Any) -> dict[str, dict]:
     for key, raw in cli_args_block.items():
         spec = raw or {}
         if not isinstance(spec, dict):
-            raise CliArgsError(f"cli_args.{key}: spec must be a mapping, got {type(spec).__name__}")
+            raise CliArgsError(
+                f"cli_args.{key}: spec must be a mapping, got {type(spec).__name__}"
+            )
 
         short = spec.get("short")
         long_ = spec.get("long") or f"--{_kebab(key)}"
@@ -117,18 +124,27 @@ def normalize_specs(cli_args_block: Any) -> dict[str, dict]:
 
         # Validate flag shapes
         if short is not None:
-            if not (isinstance(short, str) and len(short) == 2 and short.startswith("-") and short[1] != "-"):
+            if not (
+                isinstance(short, str)
+                and len(short) == 2
+                and short.startswith("-")
+                and short[1] != "-"
+            ):
                 raise CliArgsError(
                     f"cli_args.{key}.short: must be a single-dash 2-char flag like '-f', got {short!r}"
                 )
             if short in RESERVED_FLAGS:
-                raise CliArgsError(f"cli_args.{key}.short={short!r} clashes with reserved cutip flag")
+                raise CliArgsError(
+                    f"cli_args.{key}.short={short!r} clashes with reserved cutip flag"
+                )
         if not (isinstance(long_, str) and long_.startswith("--") and len(long_) > 2):
             raise CliArgsError(
                 f"cli_args.{key}.long: must look like '--name', got {long_!r}"
             )
         if long_ in RESERVED_FLAGS:
-            raise CliArgsError(f"cli_args.{key}.long={long_!r} clashes with reserved cutip flag")
+            raise CliArgsError(
+                f"cli_args.{key}.long={long_!r} clashes with reserved cutip flag"
+            )
 
         # Detect duplicate flags across declared args
         for flag in (short, long_):
@@ -190,14 +206,18 @@ def parse_runtime(
 
         if tok in by_flag:
             key, spec = by_flag[tok]
-            if spec["type"] == "bool" and (i + 1 >= len(tokens) or tokens[i + 1].startswith("-")):
+            if spec["type"] == "bool" and (
+                i + 1 >= len(tokens) or tokens[i + 1].startswith("-")
+            ):
                 # bare bool flag (without explicit value) → True
                 user_values[key] = True
                 i += 1
             else:
                 if i + 1 >= len(tokens):
                     raise CliArgsError(f"{tok}: missing value")
-                user_values[key] = _coerce(tokens[i + 1], spec["type"], key=key, flag=tok)
+                user_values[key] = _coerce(
+                    tokens[i + 1], spec["type"], key=key, flag=tok
+                )
                 i += 2
             continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cutip"
-version = "2.18.0"
+version = "2.19.0"
 description = "Workflow automation framework — define infrastructure as YAML, automate with Python, execute in containers"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,73 @@ class TestCLITree:
         assert data["project"] == "test-project"
 
 
+class TestCLIProjects:
+    def _make_project(self, dirpath, name, host="local", description=None):
+        dirpath.mkdir(parents=True, exist_ok=True)
+        yaml_path = dirpath / f"{name}.yaml"
+        body = ""
+        if description:
+            body += f"# {description}\n"
+        body += f"project: {name}\nhost: {host}\nworkflow: {name}.workflow.py\n"
+        yaml_path.write_text(body)
+        return yaml_path
+
+    def test_projects_discovers_single(self, tmp_path):
+        self._make_project(tmp_path / "alpha", "alpha", description="Alpha project")
+        r = _run_cutip("projects", cwd=str(tmp_path))
+        assert r.returncode == 0
+        assert "alpha" in r.stdout
+        assert "Alpha project" in r.stdout
+
+    def test_projects_discovers_nested(self, tmp_path):
+        self._make_project(tmp_path / "workspaces" / "a", "a-proj", host="local")
+        self._make_project(tmp_path / "workspaces" / "b", "b-proj", host="container")
+        self._make_project(tmp_path / "misc" / "c", "c-proj", host="remote")
+        r = _run_cutip("projects", cwd=str(tmp_path))
+        assert r.returncode == 0
+        assert "a-proj" in r.stdout
+        assert "b-proj" in r.stdout
+        assert "c-proj" in r.stdout
+
+    def test_projects_skips_non_project_yamls(self, tmp_path):
+        self._make_project(tmp_path, "real-proj")
+        # hosts.yaml shape — no project key
+        (tmp_path / "hosts.yaml").write_text("vm:\n  host: 1.2.3.4\n  username: root\n")
+        # arbitrary non-project yaml
+        (tmp_path / "data.yaml").write_text("some_key: some_value\n")
+        r = _run_cutip("projects", cwd=str(tmp_path))
+        assert r.returncode == 0
+        assert "real-proj" in r.stdout
+        assert "hosts.yaml" not in r.stdout
+        assert "data.yaml" not in r.stdout
+
+    def test_projects_empty_dir(self, tmp_path):
+        r = _run_cutip("projects", cwd=str(tmp_path))
+        assert r.returncode == 0
+        assert "No cutip projects" in r.stdout
+
+    def test_projects_json(self, tmp_path):
+        self._make_project(tmp_path / "x", "xproj", host="remote", description="X desc")
+        r = _run_cutip("projects", "--json", cwd=str(tmp_path))
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert len(data) == 1
+        assert data[0]["project"] == "xproj"
+        assert data[0]["host"] == "remote"
+        assert data[0]["description"] == "X desc"
+
+    def test_projects_skips_build_dirs(self, tmp_path):
+        # Hidden / build dirs should be skipped even with valid project yaml.
+        self._make_project(tmp_path / ".venv" / "foo", "venv-proj")
+        self._make_project(tmp_path / "node_modules" / "bar", "node-proj")
+        self._make_project(tmp_path / "real", "real-proj")
+        r = _run_cutip("projects", cwd=str(tmp_path))
+        assert r.returncode == 0
+        assert "real-proj" in r.stdout
+        assert "venv-proj" not in r.stdout
+        assert "node-proj" not in r.stdout
+
+
 class TestCLIShow:
     def test_show_summary(self, simple_project):
         project_file, _ = simple_project

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ toml = [
 
 [[package]]
 name = "cutip"
-version = "2.18.0"
+version = "2.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- New CLI verb: `cutip projects` walks cwd recursively, finds every YAML with `project:` + `host:` keys, prints a table of (path, project name, host, description).
- Designed for monorepos like snf-dev that host many cutip projects scattered across `workspaces/`, `sfm/`, `misc/`, `snf-build/`. Today: 13 projects, requires grep to find them all.
- `--json` for machine consumption. Host column color-codes local/container/remote. Description column pulls the first prose comment line (skipping rulers like `─────`).

## Behavior

```
$ cd snf-dev/
$ cutip projects
                cutip projects under snf-dev/
╭─────────────────────┬─────────────────┬─────────┬──────────────────╮
│ path                │ project         │ host    │ description      │
├─────────────────────┼─────────────────┼─────────┼──────────────────┤
│ misc/wsl/dns.yaml   │ wsl-dns         │ local   │ Restore WSL's... │
│ sfm/gui/first-...   │ sfm-first-login │ local   │ Run ONCE per...  │
│ ...                 │ ...             │ ...     │ ...              │
╰─────────────────────┴─────────────────┴─────────┴──────────────────╯
13 projects
```

## Implementation

- Skips standard build/hidden dirs (`.git`, `node_modules`, `.venv`, `__pycache__`, `target`, `dist`, `site`, `.cutip`, `.tox`, `.mypy_cache`, `.pytest_cache`)
- Skips cutip artifact YAMLs (`apiVersion: cutip/v1`) — different schema, not project files
- Description scan covers first 30 lines (snf-dev convention is comment-block-after-keys, not at top)
- Added to `COMMANDS` dict + the `--help` panel
- `VERSION` bumped 2.18.0 → 2.19.0 in `cutip/cli.py` + `pyproject.toml`

## Test plan

- [x] 6 new tests in `TestCLIProjects` — single, nested, empty dir, json output, non-project yamls skipped, build dirs skipped
- [x] Full suite: 231/231 passing locally
- [x] Smoke-tested against snf-dev (13 projects discovered correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)